### PR TITLE
re-use gridline

### DIFF
--- a/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
@@ -385,7 +385,7 @@ void AstWcsGridRenderService::setAxisDisplayInfo( std::vector<Carta::Lib::AxisDi
         for ( int i = 0; i < infoCount; i++ ){
             if ( displayInfos[i] != m_axisDisplayInfos[i] ){
                 m_axisDisplayInfos[i] = displayInfos[i];
-                m_vgValid = false;
+                //m_vgValid = false;
             }
         }
     }


### PR DESCRIPTION
don't calculate grid again when switching between different  channels. 