### PR TITLE
fixed memory leaking when image is permuted

### DIFF
--- a/carta/cpp/plugins/CasaImageLoader/CCImage.h
+++ b/carta/cpp/plugins/CasaImageLoader/CCImage.h
@@ -227,13 +227,22 @@ public:
 
     virtual
     ~CCImage() {
+        if(m_casaII != nullptr)
+        {
+            delete m_casaII;
+            m_casaII = nullptr;
+        }
+
         //qDebug() << "~CCImage is getting called";
     }
 
     /// do not use this!
     /// \todo constructor should be protected... but I don't have time to fix the
     /// compiler errors (Pavol)
-    CCImage() { }
+    CCImage()
+    {
+        m_casaII = nullptr;
+    }
 
 protected:
     /// type of the image data


### PR DESCRIPTION
1. fixed memory leaking in class CCImageBase

But storing a copy of permutation of image is not an elegant method which wastes a lot of memory space when raw data is large.
My suggest is that accessing raw data by the iterator which keep the information about the permutation of image.
