### PR TITLE
Ecchen/changed default - The default value for Clipping is 100% + resetPan when displayAxes changed

### DIFF
--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -899,7 +899,7 @@ void Controller::_initializeCallbacks(){
 void Controller::_initializeState(){
 
     //First the preference state.
-    m_state.insertValue<bool>( AUTO_CLIP, true );
+    m_state.insertValue<bool>( AUTO_CLIP, false );
     m_state.insertValue<bool>(PAN_ZOOM_ALL, true );
     m_state.insertValue<bool>( STACK_SELECT_AUTO, true );
     m_state.insertValue<double>( CLIP_VALUE_MIN, 0.0 );

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -902,8 +902,8 @@ void Controller::_initializeState(){
     m_state.insertValue<bool>( AUTO_CLIP, true );
     m_state.insertValue<bool>(PAN_ZOOM_ALL, true );
     m_state.insertValue<bool>( STACK_SELECT_AUTO, true );
-    m_state.insertValue<double>( CLIP_VALUE_MIN, 0.025 );
-    m_state.insertValue<double>( CLIP_VALUE_MAX, 0.975 );
+    m_state.insertValue<double>( CLIP_VALUE_MIN, 0.0 );
+    m_state.insertValue<double>( CLIP_VALUE_MAX, 1.0 );
 
     //Default Tab
     m_state.insertValue<int>( Util::TAB_INDEX, 0 );

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -109,6 +109,8 @@ void LayerData::_displayAxesChanged(std::vector<AxisInfo::KnownType> displayAxis
         const std::vector<int>& frames ){
     if ( m_dataSource ){
         m_dataSource->_setDisplayAxes( displayAxisTypes, frames );
+        _resetPan();
+
     }
 }
 

--- a/carta/cpp/core/Data/Image/Render/RenderRequest.cpp
+++ b/carta/cpp/core/Data/Image/Render/RenderRequest.cpp
@@ -18,8 +18,8 @@ RenderRequest::RenderRequest( const std::vector<int>& frames,
     m_requestMain = false;
     m_requestContext = false;
     m_requestZoom = false;
-    m_minClipPercent = 0.025;
-    m_maxClipPercent = 0.975;
+    m_minClipPercent = 0.0;
+    m_maxClipPercent = 1.0;
     m_recomputeClips = true;
     m_pan = QPointF( nan(""), nan(""));
 }

--- a/carta/cpp/core/Hacks/ImageViewController.cpp
+++ b/carta/cpp/core/Hacks/ImageViewController.cpp
@@ -489,12 +489,12 @@ ImageViewController::loadFrame( int frame )
     // get a view of the data using the slice description and make a shared pointer out of it
     Carta::Lib::NdArray::RawViewInterface::SharedPtr view( m_astroImage-> getDataSlice( frameSlice ) );
 
-    // compute 95% clip values, unless we already have them in the cache
+    // compute 100% clip values, unless we already have them in the cache
     std::vector < double > clips = m_quantileCache[m_currentFrame];
     if ( clips.size() < 2 ) {
         Carta::Lib::NdArray::Double doubleView( view.get(), false );
         clips = Carta::Core::Algorithms::quantiles2pixels(
-            doubleView, { 0.025, 0.975 }
+            doubleView, { 0.0, 1.0 }
             );
         qDebug() << "recomputed clips" << clips;
         m_quantileCache[m_currentFrame] = clips;


### PR DESCRIPTION
1. resetPan when displayAxes changed
when permuting axes, resetPan should be issued automatically, otherwise user will get confused where the image is.


2. The default value for Clipping is 100%