### PR TITLE
fix 1. z-axis is not channel 2. crash due to {nan, nan} in quantile 3. bad_alloc problem

### DIFF
--- a/carta/cpp/CartaLib/PixelPipeline/IPixelPipeline.h
+++ b/carta/cpp/CartaLib/PixelPipeline/IPixelPipeline.h
@@ -228,10 +228,7 @@ public:
     virtual void
     convert( double p_val, NormRgb & result ) override
     {
-        // this is a workaround solution
-        // we should think carefully about how to deal with
-        // when the upper bound and the lower bound are nan value
-        // CARTA_ASSERT( ! std::isnan( p_val ) );
+        CARTA_ASSERT( ! std::isnan( p_val ) );
         CARTA_ASSERT( m_stage3 );
 
         // stage 0: clamp

--- a/carta/cpp/CartaLib/PixelPipeline/IPixelPipeline.h
+++ b/carta/cpp/CartaLib/PixelPipeline/IPixelPipeline.h
@@ -228,7 +228,10 @@ public:
     virtual void
     convert( double p_val, NormRgb & result ) override
     {
-        CARTA_ASSERT( ! std::isnan( p_val ) );
+        // this is a workaround solution
+        // we should think carefully about how to deal with
+        // when the upper bound and the lower bound are nan value
+        // CARTA_ASSERT( ! std::isnan( p_val ) );
         CARTA_ASSERT( m_stage3 );
 
         // stage 0: clamp

--- a/carta/cpp/core/Algorithms/quantileAlgorithms.h
+++ b/carta/cpp/core/Algorithms/quantileAlgorithms.h
@@ -63,7 +63,7 @@ quantiles2pixels(
 
     // indicate bad clip if no finite numbers were found
     if ( allValues.size() == 0 ) {
-        return std::vector < Scalar > ( std::numeric_limits < Scalar >::quiet_NaN(), quant.size() );
+        return std::vector < Scalar > ( quant.size(), std::numeric_limits < Scalar >::quiet_NaN());
     }
 
     // for every input quantile, do quickselect and store the result

--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -595,6 +595,19 @@ Carta::Lib::NdArray::RawViewInterface* DataSource::_getRawData( const std::vecto
     std::vector<int> mFrames = _fitFramesToImage( frames );
     if ( m_permuteImage ){
         int imageDim =m_permuteImage->dims().size();
+
+	//Build a vector showing the permute order.
+	std::vector<int> indices( imageDim );
+        indices[0] = m_axisIndexX;
+        indices[1] = m_axisIndexY;
+        int vectorIndex = 2;
+        for ( int i = 0; i < imageDim; i++ ){
+            if ( i != m_axisIndexX && i != m_axisIndexY ){
+                indices[vectorIndex] = i;
+                vectorIndex++;
+            }
+        }
+
         SliceND nextSlice = SliceND();
         SliceND& slice = nextSlice;
         for ( int i = 0; i < imageDim; i++ ){
@@ -603,7 +616,8 @@ Carta::Lib::NdArray::RawViewInterface* DataSource::_getRawData( const std::vecto
             if ( i != 0 && i != 1 ){
                 //Take a slice at the indicated frame.
                 int frameIndex = 0;
-                AxisInfo::KnownType type = _getAxisType( i );
+		int thisAxis = indices[i];
+                AxisInfo::KnownType type = _getAxisType( thisAxis );
                 if ( AxisInfo::KnownType::OTHER != type ){
                     int axisIndex = static_cast<int>( type );
                     frameIndex = mFrames[axisIndex];

--- a/carta/cpp/core/ImageRenderService.cpp
+++ b/carta/cpp/core/ImageRenderService.cpp
@@ -299,6 +299,9 @@ Service::internalRenderSlot()
 
     QRgb nanColor = m_nanColor.rgb();
     if ( m_defaultNan ){
+        // when function quantiles2pixels in quantileAlgorithms.h return {nan, nan}
+        // it may cause CARTA to crash
+        // because of function convert in IPixelPipeline.h
         m_pixelPipelineRaw->convertq( clipMin, nanColor );
     }
 


### PR DESCRIPTION
1. Animator can work when z-axis is not channel
2. fixed bad_alloc problem because of syntax error


N.B. we should think carefully about when function "quantiles2pixels" in quantileAlgorithms.h return {nan, nan}.
it may cause CARTA to crash because of function "convert" in IPixelPipeline.h)
