### PR TITLE
re-use gridline

### DIFF
--- a/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
@@ -385,7 +385,7 @@ void AstWcsGridRenderService::setAxisDisplayInfo( std::vector<Carta::Lib::AxisDi
         for ( int i = 0; i < infoCount; i++ ){
             if ( displayInfos[i] != m_axisDisplayInfos[i] ){
                 m_axisDisplayInfos[i] = displayInfos[i];
-                m_vgValid = false;
+                //m_vgValid = false;
             }
         }
     }


### PR DESCRIPTION
Don't calculate grid again when switching between different channels.

@kswang1029 , @CNOCycle From Susan: I guess with the re-use gridline issue (6), I would worry that the display axes would get permuted and the grid would not get redrawn, but I assume you have checked and that does not happen.

make the pull request again. https://github.com/CARTAvis/carta/pull/6 seems disappeared. 