### PR TITLE
Remove 'location'(or 'index') in the percentile function in DataSouce.cpp

### DIFF
--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -383,10 +383,7 @@ std::vector<std::pair<int,double> > DataSource::_getIntensityCache( int frameLow
 
         if ( allValues.size() > 0 ){
 
-            int divisor = total_size;
-            if (spectralIndex != -1) {
-                divisor /= dims[spectralIndex];
-            }
+            int divisor = 1;
 
             // only compare the intensity values; ignore the indices
             auto compareIntensityTuples = [] (const std::pair<int,double>& lhs, const std::pair<int,double>& rhs) { return lhs.second < rhs.second; };


### PR DESCRIPTION
1. Remove 'location'(or 'index') in the percentile function in DataSouce.cpp

  The first element in the `intensities` pair is the location of pixel, but this value has no physical meaning and affects the performance.

2.  Remove `divisor`

  `m_cachePercentiles` fails if 'location' is divided by 'divisor' when data is a single 2D image.

3. We should aware that `percentiles` value is stored in double type and it has limited significant digits.

  I am not sure how many significant digits are required for a cache hit in Andianna's new cache ( `percentiles` in this commit has 6 significant digits) but it should be fine if users only uses pre-defined clipping value.
