### PR TITLE
a filter to reduce the number of colormaps from matlplotlib

### DIFF
--- a/carta/cpp/plugins/ColormapsPy/ColormapsPy.py
+++ b/carta/cpp/plugins/ColormapsPy/ColormapsPy.py
@@ -41,8 +41,21 @@ class CMap(object):
 def colormapScalarHook():
     print("colormapScalarHook");
     maps=[m for m in cm.datad if not m.endswith("_r")]
+    print "available colormaps from matplotlib: ",maps
+
+    # filter out unwanted colormaps borrowed from matplotlib
+    maps_whiteList = ['Spectral','coolwarm','Set1','gnuplot2',
+                      'jet','Reds','gist_stern','Blues',
+                      'terrain','gnuplot','hot','Greens',
+                      'nipy_spectral']
+    print "including the following colormaps only: ",maps_whiteList
+    maps_filtered = []
+    for x in maps:
+        if x in maps_whiteList:
+            maps_filtered.append(x)
+
     result = []
-    for i, m in enumerate(maps):
+    for i, m in enumerate(maps_filtered):
         result.append( CMap(m))
     return result
 

--- a/carta/cpp/plugins/ColormapsPy/ColormapsPy.py
+++ b/carta/cpp/plugins/ColormapsPy/ColormapsPy.py
@@ -41,14 +41,14 @@ class CMap(object):
 def colormapScalarHook():
     print("colormapScalarHook");
     maps=[m for m in cm.datad if not m.endswith("_r")]
-    print "available colormaps from matplotlib: ",maps
+    print("available colormaps from matplotlib: ", maps)
 
     # filter out unwanted colormaps borrowed from matplotlib
     maps_whiteList = ['Spectral','coolwarm','Set1','gnuplot2',
                       'jet','Reds','gist_stern','Blues',
                       'terrain','gnuplot','hot','Greens',
                       'nipy_spectral']
-    print "including the following colormaps only: ",maps_whiteList
+    print("including the following colormaps only: ", maps_whiteList)
     maps_filtered = []
     for x in maps:
         if x in maps_whiteList:
@@ -56,6 +56,6 @@ def colormapScalarHook():
 
     result = []
     for i, m in enumerate(maps_filtered):
-        result.append( CMap(m))
+        result.append(CMap(m))
     return result
 


### PR DESCRIPTION
This pull request is to reduce the total number of colormaps from matplotlib. Currently including:
['Spectral','coolwarm','Set1','gnuplot2','jet','Reds','gist_stern','Blues','terrain','gnuplot','hot','Greens','nipy_spectral']
Feel free to let me know if you want to add more useful ones from matplotlib.