### PR TITLE
Known issue:  encoding format for FITS header

### DIFF
--- a/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
@@ -171,6 +171,10 @@ QString AstWcsGridRenderService::_getFitsHeaderforAst(QStringList &fitsHeader)
     lambdareplace1D("PV%1_3" );
     lambdareplace1D("PV%1_4" );
 
+    // Known issue: CASAImage does not follow FIT-WCS standard
+    IndexSearchBegin = 0;
+    lambdareplace2D("PC0%1_0%2");
+
 #if CARTA_RUNTIME_CHECKS > 0
     for(int ii = 0; ii < AstFitsHeader.length(); ii = ii + 1)
     {


### PR DESCRIPTION
1. There are many encoding format for FITS header
ref: http://www.starlink.rl.ac.uk/docs/sun210.htx/sun210se17.html

2. Here is the FITS standard v4.0
ref: https://fits.gsfc.nasa.gov/standard40/fits_standard40draft1.pdf

3. CasaImage does not follow FITS-WCS standard, so I'm trying to fix it
CasaImage format    -> PC%2d_%2d
but,
FITS-WCS standard -> PC%1d_%1d