### PR TITLE
refine displayed cursor info and add more precision to displayed coordinates

### DIFF
--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -194,11 +194,11 @@ QString DataSource::_getCursorText( int mouseX, int mouseY,
 
         QString pixelValue = _getPixelValue( round(imgX), round(imgY), frames );
         QString pixelUnits = _getPixelUnits();
-        out << pixelValue << " " << pixelUnits;
-        out <<"Pixel:" << imgX << "," << imgY << "\n";
+        out << "Pixel value:" << pixelValue << " " << pixelUnits << "at ";
+        out <<"pixel:" << imgX << ", " << imgY << "\n";
 
         cf-> setSkyCS( cs );
-        out << m_coords->getName( cs ) << ": ";
+        out << "[" << m_coords->getName( cs ) << "] ";
         std::vector <AxisInfo> ais;
         for ( int axis = 0 ; axis < cf->nAxes() ; axis++ ) {
             const AxisInfo & ai = cf-> axisInfo( axis );

--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -194,8 +194,8 @@ QString DataSource::_getCursorText( int mouseX, int mouseY,
 
         QString pixelValue = _getPixelValue( round(imgX), round(imgY), frames );
         QString pixelUnits = _getPixelUnits();
-        out << "Pixel value:" << pixelValue << " " << pixelUnits << "at ";
-        out <<"pixel:" << imgX << ", " << imgY << "\n";
+        out << "Pixel value:" << pixelValue << " " << pixelUnits << " at ";
+        out <<"pixel:" << imgX << "," << imgY << "\n";
 
         cf-> setSkyCS( cs );
         out << "[" << m_coords->getName( cs ) << "] ";

--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -198,7 +198,7 @@ QString DataSource::_getCursorText( int mouseX, int mouseY,
         out <<"pixel:" << imgX << "," << imgY << "\n";
 
         cf-> setSkyCS( cs );
-        out << "[" << m_coords->getName( cs ) << "] ";
+        out << "[ " << m_coords->getName( cs ) << " ] ";
         std::vector <AxisInfo> ais;
         for ( int axis = 0 ; axis < cf->nAxes() ; axis++ ) {
             const AxisInfo & ai = cf-> axisInfo( axis );

--- a/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
@@ -466,13 +466,13 @@ CCCoordinateFormatter::parseCasaCSi( int pixelAxis )
                     CARTA_ASSERT( false );
                 }
             }
-            m_precisions[pixelAxis] = 3;
+            m_precisions[pixelAxis] = 6;
         }
         else if ( cc.type() == casa::Coordinate::SPECTRAL ) {
             aInfo.setKnownType( AxisInfo::KnownType::SPECTRAL )
                 .setLongLabel( HtmlString::fromPlain( "Frequency" ) )
                 .setShortLabel( HtmlString( "Freq", "Freq" ) );
-            m_precisions[pixelAxis] = 6;
+            m_precisions[pixelAxis] = 9;
         }
         else if ( cc.type() == casa::Coordinate::STOKES ) {
             aInfo.setKnownType( AxisInfo::KnownType::STOKES )

--- a/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
@@ -94,7 +94,7 @@ protected:
 
     bool m_showPlus = false;
     bool m_sexagesimal = false;
-    int m_precision = 3;
+    int m_precision = 4;
     QString m_separator = ":";
 };
 
@@ -363,8 +363,8 @@ CCCoordinateFormatter::parseCasaCS()
         qDebug() << "all names:" << u.c_str();
     }*/
 
-    // default precision is 6
-    m_precisions.resize( nAxes(), 6 );
+    // default precision is 4
+    m_precisions.resize( nAxes(), 4 );
     m_axisInfos.resize( nAxes() );
 
     for ( int i = 0 ; i < nAxes() ; i++ ) {
@@ -466,7 +466,7 @@ CCCoordinateFormatter::parseCasaCSi( int pixelAxis )
                     CARTA_ASSERT( false );
                 }
             }
-            m_precisions[pixelAxis] = 6;
+            m_precisions[pixelAxis] = 4;
         }
         else if ( cc.type() == casa::Coordinate::SPECTRAL ) {
             aInfo.setKnownType( AxisInfo::KnownType::SPECTRAL )

--- a/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
@@ -363,8 +363,8 @@ CCCoordinateFormatter::parseCasaCS()
         qDebug() << "all names:" << u.c_str();
     }*/
 
-    // default precision is 3
-    m_precisions.resize( nAxes(), 3 );
+    // default precision is 6
+    m_precisions.resize( nAxes(), 6 );
     m_axisInfos.resize( nAxes() );
 
     for ( int i = 0 ; i < nAxes() ; i++ ) {


### PR DESCRIPTION
1) refine the displayed cursor information for better readability 

2) add more precision to the displayed coordinates, including frequency axis. This is needed for high-resolution observations like HLtau.

Attached image is
<img width="706" alt="screen shot 2017-03-05 at 6 41 39 pm" src="https://cloud.githubusercontent.com/assets/20819712/23586607/80236890-01d3-11e7-9c14-fcfc5d793809.png">
 before and after comparison.


