### PR TITLE
show beam size with dynamical precision

### DIFF
--- a/carta/cpp/plugins/ImageStatistics/StatisticsCASAImage.cpp
+++ b/carta/cpp/plugins/ImageStatistics/StatisticsCASAImage.cpp
@@ -16,6 +16,7 @@ StatisticsCASAImage::StatisticsCASAImage() {
 std::vector<QString> StatisticsCASAImage::_beamAsStringVector( const casa::GaussianBeam &beam ){
     std::vector<QString> result;
     if (! beam.isNull()) {
+        char buf[512];
         //determine the precision of beam size dynamically 
         if (beam.getMinor("arcsec") > 0.1 && beam.getMinor("arcsec") < 60.0){
             sprintf( buf,"%.2f\"", beam.getMajor("arcsec") );

--- a/carta/cpp/plugins/ImageStatistics/StatisticsCASAImage.cpp
+++ b/carta/cpp/plugins/ImageStatistics/StatisticsCASAImage.cpp
@@ -16,13 +16,47 @@ StatisticsCASAImage::StatisticsCASAImage() {
 std::vector<QString> StatisticsCASAImage::_beamAsStringVector( const casa::GaussianBeam &beam ){
     std::vector<QString> result;
     if (! beam.isNull()) {
-        char buf[512];
-        sprintf( buf,"%.2f\"", beam.getMajor("arcsec"));
-        result.push_back(QString(buf));
-        sprintf( buf,"%.2f\"", beam.getMinor("arcsec") );
-        result.push_back(QString(buf));
-        sprintf( buf,"%.2f%c", beam.getPA("deg", casa::True), 0x00B0 );
-        result.push_back(QString(buf));
+        //determine the precision of beam size dynamically 
+        if (beam.getMinor("arcsec") > 0.1 && beam.getMinor("arcsec") < 60.0){
+            sprintf( buf,"%.2f\"", beam.getMajor("arcsec") );
+            result.push_back(QString(buf));
+            sprintf( buf,"%.2f\"", beam.getMinor("arcsec") );
+            result.push_back(QString(buf));
+            //sprintf( buf,"%.2f%s", beam.getPA("deg", casa::True), "\u00B0" );
+            //temporary solution to correctly display 'degree' char
+            sprintf( buf,"%.2fdeg", beam.getPA("deg", casa::True) );
+            result.push_back(QString(buf));
+        }
+        if (beam.getMinor("arcsec") <= 0.1){
+            sprintf( buf,"%.3f\"", beam.getMajor("arcsec") );
+            result.push_back(QString(buf));
+            sprintf( buf,"%.3f\"", beam.getMinor("arcsec") );
+            result.push_back(QString(buf));
+            //sprintf( buf,"%.2f%s", beam.getPA("deg", casa::True), "\u00B0" );
+            //temporary solution to correctly display 'degree' char
+            sprintf( buf,"%.2fdeg", beam.getPA("deg", casa::True) );
+            result.push_back(QString(buf));
+        }
+        if (beam.getMinor("arcsec") <= 0.01){
+            sprintf( buf,"%.4f\"", beam.getMajor("arcsec") );
+            result.push_back(QString(buf));
+            sprintf( buf,"%.4f\"", beam.getMinor("arcsec") );
+            result.push_back(QString(buf));
+            //sprintf( buf,"%.2f%s", beam.getPA("deg", casa::True), "\u00B0" );
+            //temporary solution to correctly display 'degree' char
+            sprintf( buf,"%.2fdeg", beam.getPA("deg", casa::True) );
+            result.push_back(QString(buf));
+        }
+        if (beam.getMinor("arcsec") >= 60.0){
+            sprintf( buf,"%.2f\'", beam.getMajor("arcmin") );
+            result.push_back(QString(buf));
+            sprintf( buf,"%.2f\'", beam.getMinor("arcmin") );
+            result.push_back(QString(buf));
+            //sprintf( buf,"%.2f%s", beam.getPA("deg", casa::True), "\u00B0" );
+            //temporary solution to correctly display 'degree' char
+            sprintf( buf,"%.2fdeg", beam.getPA("deg", casa::True) );
+            result.push_back(QString(buf));
+        }
     }
     return result;
 }


### PR DESCRIPTION
modified the displayed formats of beam size in statistics plugin.

Now the precision is dynamically determined by the header beam info. Proper unit (arcsec or arcmin) is dynamically displayed too.

N.B. the degree symbol needs to be worked out still, likely due to encoding issue. I can correctly display the degree symbol (check my comment-out code) but extra character is also shown...

<img width="723" alt="screen shot 2017-03-06 at 5 40 50 pm" src="https://cloud.githubusercontent.com/assets/20819712/23604639/8420c156-0294-11e7-95d3-9013590dc82e.png">