### PR TITLE
Mark/addhelp

### DIFF
--- a/carta/cpp/desktop/MainWindow.cpp
+++ b/carta/cpp/desktop/MainWindow.cpp
@@ -39,6 +39,13 @@ MainWindow::MainWindow( )
     QMenu *toolsMenu = menuBar()->addMenu(tr("&Tools"));
     toolsMenu->addAction(tr("Show JS Console"), this, SLOT(showJsConsole()));
 
+    // add Help option
+    QMenu *helpMenu = menuBar()->addMenu(tr("&Help"));
+    helpMenu->addAction(tr("GitHub Home"), this, SLOT(helpUrlGitHubHome()));
+    helpMenu->addAction(tr("GitHub Wiki"), this, SLOT(helpUrlGitHubWiki()));
+    helpMenu->addAction(tr("GitHub Issues"), this, SLOT(helpUrlGitHubIssues()));
+    helpMenu->addAction(tr("Copy Right and License"), this, SLOT(helpLicense()));
+
     setCentralWidget(m_view);
     setUnifiedTitleAndToolBarOnMac(true);
 
@@ -46,11 +53,16 @@ MainWindow::MainWindow( )
              & QWebFrame::javaScriptWindowObjectCleared,
              this,
              & MainWindow::addToJavaScript );
+
     bool qtDecorationsEnabled = Globals::instance()->mainConfig()->isDeveloperDecorations();
     if( !qtDecorationsEnabled ) {
-        menuBar()->setVisible( false);
+        menuBar()->setVisible( true);
         toolBar->setVisible( false);
-        statusBar()->setVisible( false);
+        statusBar()->setVisible( true);
+    } else {
+        menuBar()->setVisible( true);
+        toolBar->setVisible( false);
+        statusBar()->setVisible( true);
     }
 
     // install 'fileq' protocol handler
@@ -116,4 +128,35 @@ void MainWindow::addToJavaScript()
         m_view->page()->mainFrame()->addToJavaScriptWindowObject(
                     entry.first, entry.second);
     }
+}
+
+void MainWindow::helpUrlGitHubHome()
+{
+    QDesktopServices::openUrl(QUrl("https://github.com/CARTAvis/carta", QUrl::TolerantMode));
+}
+
+void MainWindow::helpUrlGitHubWiki()
+{
+    QDesktopServices::openUrl(QUrl("https://github.com/CARTAvis/carta/wiki", QUrl::TolerantMode));
+}
+
+void MainWindow::helpUrlGitHubIssues()
+{
+    QDesktopServices::openUrl(QUrl("https://github.com/CARTAvis/carta/issues", QUrl::TolerantMode));
+}
+
+void MainWindow::helpLicense()
+{
+    QMessageBox::about(this, tr("Copy Right and License"),
+                 tr("<p>This program is free software: you can redistribute it and/or modify \
+                    it under the terms of the GNU General Public License as published by \
+                    the Free Software Foundation, either version 3 of the License, or \
+                    (at your option) any later version.</p>\
+                    <p>This program is distributed in the hope that it will be useful, \
+                    but WITHOUT ANY WARRANTY; without even the implied warranty of \
+                    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the \
+                    GNU General Public License for more details.</p>\
+                    <p>You should have received a copy of the GNU General Public License \
+                    along with this program.  If not, see \
+                    <a href='http://www.gnu.org/licenses/'>http://www.gnu.org/licenses/<a>.</p>"));
 }

--- a/carta/cpp/desktop/MainWindow.h
+++ b/carta/cpp/desktop/MainWindow.h
@@ -39,6 +39,10 @@ protected slots:
     void finishLoading(bool);
     void showJsConsole();
     void addToJavaScript();
+    void helpUrlGitHubHome();
+    void helpUrlGitHubWiki();
+    void helpUrlGitHubIssues();
+    void helpLicense();
 
 private:
     QWebView * m_view = nullptr;


### PR DESCRIPTION
Although, it is closed, just still leave some notes here.  @markccchiang , could you add more description either in the title or first comment?

Other improvements we can do, 
1. add version information later. in Carta/About carta
2. move copyright to "Carta"/About carta, not in help.  Can use Sourcetree/Atom/VS code about as a reference.  
3. put release note link in help. 

@kswang1029 , any others?