### PR TITLE
Prevent possible invalid qimage being inserted into (raster) m_frameCache.

### DIFF
--- a/carta/cpp/core/ImageRenderService.cpp
+++ b/carta/cpp/core/ImageRenderService.cpp
@@ -347,11 +347,11 @@ Service::internalRenderSlot()
         return;
     }
 
-    auto cachedRawImage = m_frameCache.object( cacheId
- );
+    // seems it is copying, so no need to copy again for more safe usage
+    auto cachedRawImage = m_frameCache.object(cacheId);
 
     // render the frame if needed
-    if ( !cachedRawImage ) {
+    if (!cachedRawImage) {
         // cacheRaw miss
 
         // disable pixelPipelineCache in case [clipMin, clipMax] = nan
@@ -380,7 +380,6 @@ Service::internalRenderSlot()
     else
     {
         // cacheRaw hit
-
         m_frameImage = *cachedRawImage;
     }
 
@@ -444,11 +443,17 @@ Service::internalRenderSlot()
         }
     }
 
+    if (!cachedRawImage) {
+        // insert this image into frame cache, they may be alterd by emit done, so change to insert first.
+        if (m_frameImage.byteCount() >0 && img.byteCount()>0) {
+            m_frameCache.insert( cacheId, new QImage( m_frameImage ), img.byteCount() );
+        } else {
+            qDebug() << "m_frameCache is empty, will not be inserted";
+        }
+    }
+
     // report result
     emit done( img, m_lastSubmittedJobId );
-
-    // insert this image into frame cache
-    m_frameCache.insert( cacheId, new QImage( m_frameImage ), img.byteCount() );
 
 } // internalRenderSlot
 


### PR DESCRIPTION
Here is the solved bug, raster image is gone in some cases but gridline is still there. 
How to replicate:
open the 502 image first, then aJ, then use animator to switch over.

Root cause:
1. https://github.com/CARTAvis/carta/pull/9/commits/839dcd22f3d11b3976f59e027209253a17fd10fa in #9 tries to use original m_frameImage as cache but did not check if the original image is ok before inserting into cache. 

2. https://github.com/CARTAvis/carta/pull/15/commits/9da880b911066b0c2c1b207588f84d29cf7a632c in #15  fixed that some rendering images/request were be dropped by the bug about flag. 

3. In some cases (e.g. the `How to replicate` case), the rendering request/images are duplicated and redundant, and these images are broken or duplicated for the same image request (e.g. specific channel, zoom in level etc). Originally these bad duplicated images may be dropped by the bug introduced in the above `2nd` item but now they will be rendered after the bug fix. It can be improved to reduce these kinds of duplicated/bad images/request. Besides this, any code trying to use any images, for example storing them into cache, should be very carefully. 

So just add more check when using images in cache in `ImageRenderService`.
