### PR TITLE
Mark/center main window

### DIFF
--- a/carta/cpp/desktop/DesktopPlatform.cpp
+++ b/carta/cpp/desktop/DesktopPlatform.cpp
@@ -99,7 +99,7 @@ DesktopPlatform::DesktopPlatform()
 
     // create main window
     m_mainWindow = new MainWindow();
-    m_mainWindow-> resize( 1000, 700);
+    m_mainWindow-> resize( 1280, 800);
 
     // center the main window on the screen
     QDesktopWidget wid;

--- a/carta/cpp/desktop/DesktopPlatform.cpp
+++ b/carta/cpp/desktop/DesktopPlatform.cpp
@@ -10,7 +10,7 @@
 
 #include <QtWidgets>
 #include <QWebSettings>
-
+#include <QDesktopWidget>
 #include <unistd.h>
 
 std::string warningColor, criticalColor, fatalColor, resetColor;
@@ -69,7 +69,7 @@ DesktopPlatform::DesktopPlatform()
 {
     // install a custom message handler
     qInstallMessageHandler( qtMessageHandler);
-
+    
     // figure out which url to use to load the html5 component
     // by default it's the locally compiled filesystem, but we let the developer
     // override it for debugging purposes
@@ -99,7 +99,15 @@ DesktopPlatform::DesktopPlatform()
 
     // create main window
     m_mainWindow = new MainWindow();
-    m_mainWindow-> resize( 1280, 800);
+    m_mainWindow-> resize( 1000, 700);
+
+    // center the main window on the screen
+    QDesktopWidget wid;
+    int screenWidth = wid.screen()->width();
+    int screenHeight = wid.screen()->height();
+    int panelWidth = m_mainWindow->frameGeometry().width();
+    int panelHeight = m_mainWindow->frameGeometry().height();
+    m_mainWindow->setGeometry( (screenWidth/2)-(panelWidth/2), (screenHeight/2)-(panelHeight/2), panelWidth, panelHeight);
 
     // add platform and connector to JS exports
     m_mainWindow->addJSExport( "QtPlatform", this);

--- a/carta/cpp/desktop/MainWindow.cpp
+++ b/carta/cpp/desktop/MainWindow.cpp
@@ -8,6 +8,7 @@
 #include <QtWebKitWidgets>
 #include <iostream>
 #include <QWebInspector>
+#include <qglobal.h>
 
 MainWindow::MainWindow( )
 {
@@ -36,6 +37,12 @@ MainWindow::MainWindow( )
     m_inspector-> setPage( m_view-> page());
     m_inspector-> resize( 800, 600);
 
+#ifdef Q_OS_LINUX
+    // add Carta option
+    QMenu *cartaMenu = menuBar()->addMenu(tr("&Carta"));
+    cartaMenu->addAction(tr("Copyright and License"), this, SLOT(cartaLicense()));
+    cartaMenu->addAction(tr("Version 0.9"));
+
     QMenu *toolsMenu = menuBar()->addMenu(tr("&Tools"));
     toolsMenu->addAction(tr("Show JS Console"), this, SLOT(showJsConsole()));
 
@@ -44,7 +51,21 @@ MainWindow::MainWindow( )
     helpMenu->addAction(tr("GitHub Home"), this, SLOT(helpUrlGitHubHome()));
     helpMenu->addAction(tr("GitHub Wiki"), this, SLOT(helpUrlGitHubWiki()));
     helpMenu->addAction(tr("GitHub Issues"), this, SLOT(helpUrlGitHubIssues()));
-    helpMenu->addAction(tr("Copy Right and License"), this, SLOT(helpLicense()));
+#else
+    QMenu *toolsMenu = menuBar()->addMenu(tr("&Tools"));
+    toolsMenu->addAction(tr("Show JS Console"), this, SLOT(showJsConsole()));
+
+    // add Help option
+    QMenu *helpMenu = menuBar()->addMenu(tr("&Help"));
+    helpMenu->addAction(tr("GitHub Home"), this, SLOT(helpUrlGitHubHome()));
+    helpMenu->addAction(tr("GitHub Wiki"), this, SLOT(helpUrlGitHubWiki()));
+    helpMenu->addAction(tr("GitHub Issues"), this, SLOT(helpUrlGitHubIssues()));
+
+    // add About option
+    QMenu *cartaMenu = menuBar()->addMenu(tr("&About"));
+    cartaMenu->addAction(tr("Copyright and License"), this, SLOT(cartaLicense()));
+    cartaMenu->addAction(tr("Version 0.9"));
+#endif
 
     setCentralWidget(m_view);
     setUnifiedTitleAndToolBarOnMac(true);
@@ -145,9 +166,9 @@ void MainWindow::helpUrlGitHubIssues()
     QDesktopServices::openUrl(QUrl("https://github.com/CARTAvis/carta/issues", QUrl::TolerantMode));
 }
 
-void MainWindow::helpLicense()
+void MainWindow::cartaLicense()
 {
-    QMessageBox::about(this, tr("Copy Right and License"),
+    QMessageBox::about(this, tr("Copyright and License"),
                  tr("<p>This program is free software: you can redistribute it and/or modify \
                     it under the terms of the GNU General Public License as published by \
                     the Free Software Foundation, either version 3 of the License, or \

--- a/carta/cpp/desktop/MainWindow.h
+++ b/carta/cpp/desktop/MainWindow.h
@@ -42,7 +42,7 @@ protected slots:
     void helpUrlGitHubHome();
     void helpUrlGitHubWiki();
     void helpUrlGitHubIssues();
-    void helpLicense();
+    void cartaLicense();
 
 private:
     QWebView * m_view = nullptr;


### PR DESCRIPTION
1. CAS-9802 modify the "help" option and add "copyright and version" in another option: "Carta" for Linux / "About" for Mac.

2. center the main window on the screen.

