### PR TITLE
Solve Animator crash.  

### DIFF
--- a/carta/cpp/core/Data/Image/Draw/DrawStackSynchronizer.cpp
+++ b/carta/cpp/core/Data/Image/Draw/DrawStackSynchronizer.cpp
@@ -137,12 +137,15 @@ void DrawStackSynchronizer::_scheduleFrameRepaint( const std::shared_ptr<RenderR
 
     m_repaintFrameQueued = false;
 
+    // create a copy, since "emit done" will invoke "DrawStackSynchronizer::_render"
+    // which will call "m_layers = datas;"
+    QList< std::shared_ptr<Layer> > m_layers_copy = m_layers;
+
     emit done( true );
 
     // QMetaObject::invokeMethod( this, "_repaintFrameNow", Qt::QueuedConnection );
     for ( int i = 0; i < dataCount; i++ ){
-
-        m_layers[i]->_renderDone();
+        m_layers_copy[i]->_renderDone();
     }
 
     m_view->scheduleRepaint();


### PR DESCRIPTION
This crash bug is the side effect of the commit "9da880b911066b0c2c1b207588f84d29cf7a632c" (Fix animator drop frame). It would let animator happen crash when opening two datasets.