### PR TITLE
WCSPlotter/sharpenLine (grid line)

### DIFF
--- a/carta/cpp/plugins/WcsPlotter/AstGridPlotter.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstGridPlotter.cpp
@@ -307,7 +307,7 @@ AstGridPlotter::plot()
 //        grfGlobals()->pens.push_back( QPen( QColor( "green"), 1));
 //    }
     // setup shadow pen
-    grfGlobals()-> lineShadowPenIndex = m_shadowPenIndex;
+    grfGlobals()-> lineShadowPenIndex = -1;//m_shadowPenIndex;
     // assign VG composer
     grfGlobals()-> vgComposer = m_vgc;
     // pre-cache some things


### PR DESCRIPTION
I temporarily overwrote `lineShadowPenIndex=-1`. 

It means that shadow-pen is disable and the gridline and label are more clear than before. 

We need to investigate why this feature is needed or can we safely remove this feature?

Do anyone have any suggestions?

Known issue:
1. It dose not work on server version.