### PR TITLE
Mark/remove grid lines

### DIFF
--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -260,7 +260,7 @@ void DataGrid::_initializeDefaultState(){
     //Spacing goes from 0.250 to 3
 
     m_state.insertValue<bool>( SHOW_AXIS, true );
-    m_state.insertValue<bool>( SHOW_GRID_LINES, true );
+    m_state.insertValue<bool>( SHOW_GRID_LINES, false );
     m_state.insertValue<bool>( SHOW_TICKS, true );
     m_state.insertValue<bool>( SHOW_INTERNAL_LABELS, false );
     m_state.insertValue<bool>( SHOW_COORDS, true );


### PR DESCRIPTION
This branch is merged with previous pull requested branches: "mark/reLocateConfigJson", "grimmer/fixIncompatibleAxesCrash" and "grimmer/fixAnimatorCrash". There is only one file changed compared to my last pull request, which is 

$CARTAWORKHOME/CARTAvis/carta/cpp/core/Data/Image/Grid/DataGrid.cpp.

It removes the grid lines as the default setting for Carta image viewer. The grid lines can be called back by clipping the "Image Settings" -> "Grid" -> "Grid Lines (checkbox)."

