### PR TITLE
Mark / Add Grid Lines Default Option in config.json

### DIFF
--- a/carta/config.json
+++ b/carta/config.json
@@ -1,0 +1,15 @@
+{
+    "_comment" : "List of plugin directories",
+    "pluginDirs": [
+        "$(APPDIR)/../plugins",
+        "$(APPDIR)/../../../../plugins"
+    ],
+    "disabledPlugins" : ["casaCore-2.0.1"],
+    "plugins": {
+        "PCacheSqlite3" : {
+            "dbPath": "/tmp/pcache.sqlite"
+        }
+    },
+    "qtDecorations" : "true",
+    "defaultGridLines" : "false"
+}

--- a/carta/cpp/core/CmdLine.cpp
+++ b/carta/cpp/core/CmdLine.cpp
@@ -5,7 +5,7 @@
 #include "CmdLine.h"
 #include <QDebug>
 #include <QCommandLineParser>
-#include <QDir>
+#include <QCoreApplication>
 #include <qglobal.h>
 
 static QString cartaGetEnv( const QString & name)
@@ -48,9 +48,9 @@ ParsedInfo parse(const QStringList & argv)
     // assign a default value
     if( info.m_configFilePath.isEmpty()) {
 #ifdef Q_OS_LINUX
-        info.m_configFilePath = QDir::currentPath() + "/../../../carta/config.json";
+        info.m_configFilePath = QCoreApplication::applicationDirPath() + "/../../../carta/config.json";
 #else
-        info.m_configFilePath = QDir::currentPath() + "/../../../../../../carta/config.json";
+        info.m_configFilePath = QCoreApplication::applicationDirPath() + "/../../../../../../carta/config.json";
 #endif
     }
 

--- a/carta/cpp/core/CmdLine.cpp
+++ b/carta/cpp/core/CmdLine.cpp
@@ -2,11 +2,11 @@
  *
  **/
 
-
 #include "CmdLine.h"
 #include <QDebug>
 #include <QCommandLineParser>
 #include <QDir>
+#include <qglobal.h>
 
 static QString cartaGetEnv( const QString & name)
 {
@@ -47,7 +47,11 @@ ParsedInfo parse(const QStringList & argv)
     // if the config file was not specified neither through command line or environment
     // assign a default value
     if( info.m_configFilePath.isEmpty()) {
-        info.m_configFilePath = QDir::homePath() + "/.cartavis/config.json";
+#ifdef Q_OS_LINUX
+        info.m_configFilePath = QDir::currentPath() + "/../../../carta/config.json";
+#else
+        info.m_configFilePath = QDir::currentPath() + "/../../../../../../carta/config.json";
+#endif
     }
 
 

--- a/carta/cpp/core/CmdLine.h
+++ b/carta/cpp/core/CmdLine.h
@@ -17,7 +17,7 @@ public:
     /// returns the path to the configuaration file
     /// set either through '--cfg file' option or $CARTAVIS_CONFIG environment
     /// if config file was not provided, the default is used, which is:
-    /// $HOME/.cartavis/config.json
+    /// $CARTAWORKHOME/CARTAvis/carta/config.json
     QString configFilePath() const;
 
     /// returns the path to the html file, only used by the desktop version

--- a/carta/cpp/core/Data/Image/Draw/DrawStackSynchronizer.cpp
+++ b/carta/cpp/core/Data/Image/Draw/DrawStackSynchronizer.cpp
@@ -137,12 +137,15 @@ void DrawStackSynchronizer::_scheduleFrameRepaint( const std::shared_ptr<RenderR
 
     m_repaintFrameQueued = false;
 
+    // create a copy, since "emit done" will invoke "DrawStackSynchronizer::_render"
+    // which will call "m_layers = datas;"
+    QList< std::shared_ptr<Layer> > m_layers_copy = m_layers;
+
     emit done( true );
 
     // QMetaObject::invokeMethod( this, "_repaintFrameNow", Qt::QueuedConnection );
     for ( int i = 0; i < dataCount; i++ ){
-
-        m_layers[i]->_renderDone();
+        m_layers_copy[i]->_renderDone();
     }
 
     m_view->scheduleRepaint();

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -260,7 +260,7 @@ void DataGrid::_initializeDefaultState(){
     //Spacing goes from 0.250 to 3
 
     m_state.insertValue<bool>( SHOW_AXIS, true );
-    m_state.insertValue<bool>( SHOW_GRID_LINES, true );
+    m_state.insertValue<bool>( SHOW_GRID_LINES, false );
     m_state.insertValue<bool>( SHOW_TICKS, true );
     m_state.insertValue<bool>( SHOW_INTERNAL_LABELS, false );
     m_state.insertValue<bool>( SHOW_COORDS, true );

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -4,6 +4,7 @@
 #include "Fonts.h"
 #include "Themes.h"
 #include "Globals.h"
+#include "MainConfig.h"
 #include "DummyGridRenderer.h"
 #include "CartaLib/AxisInfo.h"
 #include "Data/Image/CoordinateSystems.h"
@@ -260,7 +261,11 @@ void DataGrid::_initializeDefaultState(){
     //Spacing goes from 0.250 to 3
 
     m_state.insertValue<bool>( SHOW_AXIS, true );
-    m_state.insertValue<bool>( SHOW_GRID_LINES, false );
+
+    // load the default setting of grid lines (true/false --> on/off) from the file "config.json"
+    bool setDefaultGridLines = Globals::instance()->mainConfig()->isDefaultGridLines();
+    m_state.insertValue<bool>( SHOW_GRID_LINES, setDefaultGridLines );
+
     m_state.insertValue<bool>( SHOW_TICKS, true );
     m_state.insertValue<bool>( SHOW_INTERNAL_LABELS, false );
     m_state.insertValue<bool>( SHOW_COORDS, true );

--- a/carta/cpp/core/MainConfig.cpp
+++ b/carta/cpp/core/MainConfig.cpp
@@ -87,6 +87,7 @@ ParsedInfo parse(const QString & filePath)
     _storeBool( json["hacksEnabled"], &info.m_hacksEnabled, "hacks enabled");
     _storeBool( json["developerLayout"], &info.m_developerLayout, "developer layout");
     _storeBool( json["qtDecorations"], &info.m_developerDecorations, "developer decorations");
+    _storeBool( json["defaultGridLines"], &info.m_defaultGridLines, "set default grid lines");
 
     _storePositiveInt( json["histogramBinCountMax"], &info.m_histogramBinCountMax, "histogram bin count max");
     _storePositiveInt( json["contourLevelCountMax"], &info.m_contourLevelCountMax, "contour level count max");
@@ -109,6 +110,9 @@ bool ParsedInfo::isDeveloperDecorations() const {
     return m_developerDecorations;
 }
 
+bool ParsedInfo::isDefaultGridLines() const {
+    return m_defaultGridLines;
+}
 
 bool ParsedInfo::isDeveloperLayout() const {
     return m_developerLayout;

--- a/carta/cpp/core/MainConfig.h
+++ b/carta/cpp/core/MainConfig.h
@@ -56,6 +56,12 @@ public:
      */
     bool isDeveloperDecorations() const;
 
+    /**
+     * Returns whether CARTA should come up with grid lines.
+     * @return true - show grid lines in the image viewer as the default; false otherwise.
+     */
+    bool isDefaultGridLines() const;
+
     /// the whole config file as json
     const QJsonObject & json() const;
 
@@ -90,6 +96,7 @@ protected:
     QStringList m_pluginDirectories;
     bool m_hacksEnabled = false;
     bool m_developerDecorations = false;
+    bool m_defaultGridLines = false;
     bool m_developerLayout = false;
     int m_histogramBinCountMax = -1;
     int m_contourLevelCountMax = -1;


### PR DESCRIPTION
This branch is merged with previous pull requested branches: "mark/removeGridLines", "mark/reLocateConfigJson", "grimmer/fixIncompatibleAxesCrash" and "grimmer/fixAnimatorCrash".
There are four files changed compared to my last pull request, these are 

$CARTAWORKHOME/CARTAvis/carta/config.json
$CARTAWORKHOME/CARTAvis/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
$CARTAWORKHOME/CARTAvis/carta/cpp/core/MainConfig.cpp
$CARTAWORKHOME/CARTAvis/carta/cpp/core/MainConfig.h

Users can set the default of grid lines on/off in the "config.json" file: 

"defaultGridLines" : "false"  -->  turn off grid lines as the default in Carta image viewer
"defaultGridLines" : "true"  -->  turn on grid lines as the default in Carta image viewer
