### PR TITLE
Fix the problem of CachePercentile

### DIFF
--- a/carta/cpp/core/Data/Image/LeastRecentlyUsedCacheEntry.cpp
+++ b/carta/cpp/core/Data/Image/LeastRecentlyUsedCacheEntry.cpp
@@ -35,12 +35,12 @@ double LeastRecentlyUsedCacheEntry::getIntensity() const {
 
 bool LeastRecentlyUsedCacheEntry::operator==( const LeastRecentlyUsedCacheEntry& other ) const {
     bool equalEntries = false;
-    if ( m_frameLow == other.m_frameLow ){
-        if ( m_frameHigh == other.m_frameHigh ){
-            if ( m_location == other.m_location ){
-                equalEntries = true;
-            }
-        }
+    if (m_frameLow == other.m_frameLow &&
+        m_frameHigh == other.m_frameHigh &&
+        m_location == other.m_location &&
+        m_percentile == other.m_percentile &&
+        m_intensity == other.m_intensity ){
+        equalEntries = true;
     }
     return equalEntries;
 }

--- a/carta/cpp/core/Data/Image/LeastRecentlyUsedCacheEntry.cpp
+++ b/carta/cpp/core/Data/Image/LeastRecentlyUsedCacheEntry.cpp
@@ -38,8 +38,7 @@ bool LeastRecentlyUsedCacheEntry::operator==( const LeastRecentlyUsedCacheEntry&
     if (m_frameLow == other.m_frameLow &&
         m_frameHigh == other.m_frameHigh &&
         m_location == other.m_location &&
-        m_percentile == other.m_percentile &&
-        m_intensity == other.m_intensity ){
+        m_percentile == other.m_percentile ){
         equalEntries = true;
     }
     return equalEntries;


### PR DESCRIPTION
The judgment of LeastRecentlyUsedCacheEntry is not complete so that carta can't distinguish the difference between the entries of maximum and minimum. This causes the entry of maximum won't be saved and read later. After adding these conditions, I think the entries can be saved correctly now.