### PR TITLE
Setup no default enabled Canvas -> All images.

### DIFF
--- a/carta/cpp/core/Data/Image/Grid/GridControls.cpp
+++ b/carta/cpp/core/Data/Image/Grid/GridControls.cpp
@@ -46,7 +46,7 @@ GridControls::GridControls( const QString& path, const QString& id):
 
 
 void GridControls::_initializeDefaultState(){
-    m_state.insertValue<bool>( ALL, true  );
+    m_state.insertValue<bool>( ALL, false  );
     m_state.insertObject( DataGrid::GRID, m_dataGrid->_getState().toString());
     m_state.flushState();
 }


### PR DESCRIPTION
Setup default setting of Image Setting -> Canvas -> All images to unchecked. So the default status is, changing coordinate system and axes is only for the current image (dataset file).