### PR TITLE
Grimmer/aspect raio

### DIFF
--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -711,10 +711,9 @@ void Controller::_initializeCallbacks(){
         if ( vals.size() > 2 ) {
             double centerX = vals[0];
             double centerY = vals[1];
-            double z = vals[2];
+            double level = vals[2];
             double layerId = vals[3];
-            //updateZoom( centerX, centerY, z );
-            updatePanZoomLevel( centerX, centerY, z, layerId );
+            updatePanZoomLevel( centerX, centerY, level, layerId );
         }
         return "";
     });
@@ -724,12 +723,8 @@ void Controller::_initializeCallbacks(){
         bool error = false;
         auto vals = Util::string2VectorDouble( params, &error );
         if ( vals.size() > 0 ) {
-            // double centerX = vals[0];
-            // double centerY = vals[1];
             double z = vals[0];
             double layerId = vals[1];
-
-            // updateZoom( centerX, centerY, z );
             setZoomLevelJS(z, layerId);
         }
         return "";
@@ -785,7 +780,6 @@ void Controller::_initializeCallbacks(){
 
     addCommandCallback( "resetZoom", [=] (const QString & /*cmd*/,
                         const QString & /*params*/, const QString & /*sessionId*/) -> QString {
-        qDebug() << "grimmer resetZoom !!";
         QString result;
         resetZoom();
         return result;
@@ -1312,14 +1306,13 @@ void Controller::_setViewDrawZoom( std::shared_ptr<DrawStackSynchronizer> drawZo
     m_stack->_setViewDrawZoom( drawZoom );
 }
 
-// for Python
+// used by Python Client
 void Controller::setZoomLevel( double zoomFactor ){
     bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
     m_stack->_setZoomLevel( zoomFactor, zoomPanAll );
 }
 
 void Controller::setZoomLevelJS( double zoomFactor, double layerId ){
-//    bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
     m_stack->_setZoomLevelForLayerId( zoomFactor, layerId );
 }
 
@@ -1371,7 +1364,6 @@ void Controller::_updateDisplayAxes(){
 
 
 void Controller::updatePanZoomLevel( double centerX, double centerY, double zoomLevel, double layerId ){
-//    bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
     m_stack->_updatePanZoom( centerX, centerY, -1, false, zoomLevel, layerId);
     emit contextChanged();
     emit zoomChanged();

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -712,8 +712,9 @@ void Controller::_initializeCallbacks(){
             double centerX = vals[0];
             double centerY = vals[1];
             double z = vals[2];
+            double layerId = vals[3];
             //updateZoom( centerX, centerY, z );
-            updatePanZoomLevel( centerX, centerY, z );
+            updatePanZoomLevel( centerX, centerY, z, layerId );
         }
         return "";
     });
@@ -726,8 +727,10 @@ void Controller::_initializeCallbacks(){
             // double centerX = vals[0];
             // double centerY = vals[1];
             double z = vals[0];
+            double layerId = vals[1];
+
             // updateZoom( centerX, centerY, z );
-            setZoomLevelJS(z);
+            setZoomLevelJS(z, layerId);
         }
         return "";
     });
@@ -1315,9 +1318,9 @@ void Controller::setZoomLevel( double zoomFactor ){
     m_stack->_setZoomLevel( zoomFactor, zoomPanAll );
 }
 
-void Controller::setZoomLevelJS( double zoomFactor ){
+void Controller::setZoomLevelJS( double zoomFactor, double layerId ){
 //    bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
-    m_stack->_setZoomLevel( zoomFactor, false );
+    m_stack->_setZoomLevelForLayerId( zoomFactor, layerId );
 }
 
 void Controller::_updateCursor( int mouseX, int mouseY ){
@@ -1367,16 +1370,16 @@ void Controller::_updateDisplayAxes(){
 
 
 
-void Controller::updatePanZoomLevel( double centerX, double centerY, double zoomLevel ){
-    bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
-    m_stack->_updatePanZoom( centerX, centerY, -1, zoomPanAll, zoomLevel);
+void Controller::updatePanZoomLevel( double centerX, double centerY, double zoomLevel, double layerId ){
+//    bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
+    m_stack->_updatePanZoom( centerX, centerY, -1, false, zoomLevel, layerId);
     emit contextChanged();
     emit zoomChanged();
 }
 
 void Controller::updateZoom( double centerX, double centerY, double zoomFactor ){
     bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
-    m_stack->_updatePanZoom( centerX, centerY, zoomFactor, zoomPanAll, -1);
+    m_stack->_updatePanZoom( centerX, centerY, zoomFactor, zoomPanAll, -1, -1);
     emit contextChanged();
     emit zoomChanged();
 }

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -704,6 +704,20 @@ void Controller::_initializeCallbacks(){
         return "";
     });
 
+    addCommandCallback( "setPanAndZoomLevel", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) ->QString {
+        bool error = false;
+        auto vals = Util::string2VectorDouble( params, &error );
+        if ( vals.size() > 2 ) {
+            double centerX = vals[0];
+            double centerY = vals[1];
+            double z = vals[2];
+            //updateZoom( centerX, centerY, z );
+            updatePanZoomLevel( centerX, centerY, z );
+        }
+        return "";
+    });
+
     addCommandCallback( "setZoomLevel", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) ->QString {
         bool error = false;
@@ -713,7 +727,7 @@ void Controller::_initializeCallbacks(){
             // double centerY = vals[1];
             double z = vals[0];
             // updateZoom( centerX, centerY, z );
-						setZoomLevelJS(z);
+            setZoomLevelJS(z);
         }
         return "";
     });
@@ -1295,6 +1309,7 @@ void Controller::_setViewDrawZoom( std::shared_ptr<DrawStackSynchronizer> drawZo
     m_stack->_setViewDrawZoom( drawZoom );
 }
 
+// for Python
 void Controller::setZoomLevel( double zoomFactor ){
     bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
     m_stack->_setZoomLevel( zoomFactor, zoomPanAll );
@@ -1351,9 +1366,17 @@ void Controller::_updateDisplayAxes(){
 }
 
 
+
+void Controller::updatePanZoomLevel( double centerX, double centerY, double zoomLevel ){
+    bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
+    m_stack->_updatePanZoom( centerX, centerY, -1, zoomPanAll, zoomLevel);
+    emit contextChanged();
+    emit zoomChanged();
+}
+
 void Controller::updateZoom( double centerX, double centerY, double zoomFactor ){
     bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
-    m_stack->_updateZoom( centerX, centerY, zoomFactor, zoomPanAll);
+    m_stack->_updatePanZoom( centerX, centerY, zoomFactor, zoomPanAll, -1);
     emit contextChanged();
     emit zoomChanged();
 }

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -704,6 +704,20 @@ void Controller::_initializeCallbacks(){
         return "";
     });
 
+    addCommandCallback( "setZoomLevel", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) ->QString {
+        bool error = false;
+        auto vals = Util::string2VectorDouble( params, &error );
+        if ( vals.size() > 0 ) {
+            // double centerX = vals[0];
+            // double centerY = vals[1];
+            double z = vals[0];
+            // updateZoom( centerX, centerY, z );
+						setZoomLevelJS(z);
+        }
+        return "";
+    });
+
     addCommandCallback( "registerContourControls", [=] (const QString & /*cmd*/,
                             const QString & /*params*/, const QString & /*sessionId*/) -> QString {
         QString result;
@@ -754,6 +768,7 @@ void Controller::_initializeCallbacks(){
 
     addCommandCallback( "resetZoom", [=] (const QString & /*cmd*/,
                         const QString & /*params*/, const QString & /*sessionId*/) -> QString {
+        qDebug() << "grimmer resetZoom !!";
         QString result;
         resetZoom();
         return result;
@@ -1285,6 +1300,10 @@ void Controller::setZoomLevel( double zoomFactor ){
     m_stack->_setZoomLevel( zoomFactor, zoomPanAll );
 }
 
+void Controller::setZoomLevelJS( double zoomFactor ){
+//    bool zoomPanAll = m_state.getValue<bool>(PAN_ZOOM_ALL);
+    m_stack->_setZoomLevel( zoomFactor, false );
+}
 
 void Controller::_updateCursor( int mouseX, int mouseY ){
     if ( m_stack->_getStackSize() == 0 ){

--- a/carta/cpp/core/Data/Image/Controller.h
+++ b/carta/cpp/core/Data/Image/Controller.h
@@ -422,7 +422,7 @@ public:
      */
     void setFrameRegion( int regionIndex );
 
-    void setZoomLevelJS(double zoomFactor);
+    void setZoomLevelJS(double zoomFactor, double layerId);
 
     /**
      * Set the zoom level
@@ -534,7 +534,7 @@ public:
      * @param centerY the screen y-coordinate where the zoom was centered.
      * @param z either positive or negative depending on the desired zoom direction.
      */
-    void updatePanZoomLevel( double centerX, double centerY, double zoomLevel );
+    void updatePanZoomLevel( double centerX, double centerY, double zoomLevel, double layerId );
 
     /**
      * Update the zoom settings.

--- a/carta/cpp/core/Data/Image/Controller.h
+++ b/carta/cpp/core/Data/Image/Controller.h
@@ -59,7 +59,7 @@ class Controller: public QObject, public Carta::State::CartaObject,
     Q_OBJECT
 
 public:
-    
+
     /**
      * Clear the view.
      */
@@ -532,7 +532,8 @@ public:
      * Update the pan and zoom level settings.
      * @param centerX the screen x-coordinate where the zoom was centered.
      * @param centerY the screen y-coordinate where the zoom was centered.
-     * @param z either positive or negative depending on the desired zoom direction.
+     * @param zoomLevel zoom level 
+     * @param layerId specify the id of a layerData to update its Pan and Zoom level
      */
     void updatePanZoomLevel( double centerX, double centerY, double zoomLevel, double layerId );
 

--- a/carta/cpp/core/Data/Image/Controller.h
+++ b/carta/cpp/core/Data/Image/Controller.h
@@ -528,6 +528,13 @@ public:
      */
     void updatePan( double imgX , double imgY);
 
+    /**
+     * Update the pan and zoom level settings.
+     * @param centerX the screen x-coordinate where the zoom was centered.
+     * @param centerY the screen y-coordinate where the zoom was centered.
+     * @param z either positive or negative depending on the desired zoom direction.
+     */
+    void updatePanZoomLevel( double centerX, double centerY, double zoomLevel );
 
     /**
      * Update the zoom settings.

--- a/carta/cpp/core/Data/Image/Controller.h
+++ b/carta/cpp/core/Data/Image/Controller.h
@@ -422,6 +422,8 @@ public:
      */
     void setFrameRegion( int regionIndex );
 
+    void setZoomLevelJS(double zoomFactor);
+
     /**
      * Set the zoom level
      * @param zoomLevel either positive or negative depending on the desired zoom direction.

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -109,7 +109,7 @@ void LayerData::_displayAxesChanged(std::vector<AxisInfo::KnownType> displayAxis
         const std::vector<int>& frames ){
     if ( m_dataSource ){
         m_dataSource->_setDisplayAxes( displayAxisTypes, frames );
-        // _resetPan();
+        _resetPan();
 
     }
 }
@@ -541,65 +541,13 @@ QSize LayerData::_getSaveSize( const QSize& outputSize,  Qt::AspectRatioMode asp
     return saveSize;
 }
 
-QString LayerData::_getImageString( ) const {
-    std::shared_ptr<Carta::Lib::Image::ImageInterface> image;
-    if ( m_dataSource ){
-        image = m_dataSource->_getImage();
-    }
-
-
-    qDebug() <<"grimmer aspect getImages";
-
-//    std::pair<int,int> DataSource::_getDisplayDims() const {
-//        displayDims.first = m_image->dims()[m_axisIndexX];
-//  //    image->dims()
-
-    //QPointF result = _getPixelCoordinates()?
-
-    // 成對的:
-    //QPointF LayerData::_getPixelCoordinates( double ra, double dec, bool* valid ) const{
-//    QPointF LayerData::_getWorldCoordinates( double pixelX, double pixelY,
-//            Carta::Lib::KnownSkyCS coordSys, bool* valid ) const{
-
-    // 2, aj.fits
-    int dimes = _getDimension();
-    //    int LayerData::_getDimension() const {
-
-    // 512, 1024
-    std::vector<int> result2 = _getImageDimensions();
-//    std::vector<int> LayerData::_getImageDimensions( ) const {
-
-    // 512,1024, may be image or possible others: Frequency x DEC plot
-    QSize imageSize = _getDisplaySize(); //<-這較好
-//    QSize LayerData::_getDisplaySize() const {
-
-    std::vector<AxisInfo::KnownType> axisTypes= _getAxisTypes(); // if Ztype, 0
-    // DIRECTION_LON, DIRECTION_LAT
-
-    Carta::Lib::KnownSkyCS cs = _getCoordinateSystem(); //J2000
-
-    QString aa = "";
-    return aa;
-}
-
 QString LayerData::_getStateString( bool truncatePaths ) const{
 
-    qDebug()<<"grimmer layerdata-1";
-
-    // 一般stack會直接取layerdata的m_state, 但統計那邊需要 此layerdata的
-    // m_dataSource的 image (Carta::Lib::Image::ImageInterface)
     Carta::State::StateInterface copyState( m_state );
 
-    qDebug() <<"grimmer getStateString0:"<<copyState.toString();
     if ( !truncatePaths ){
-        qDebug() <<"grimmer getStateString1:"<<copyState.toString();
-
         copyState.setValue<QString>(Util::NAME, m_dataSource->_getFileName());
-        qDebug() <<"grimmer getStateString2:"<<copyState.toString();
-
         copyState.insertObject( DataGrid::GRID, m_dataGrid->_getState().toString() );
-        qDebug() <<"grimmer getStateString3:"<<copyState.toString();
-
         int contourCount = m_dataContours.size();
         copyState.insertArray( DataContours::CONTOURS, contourCount );
         int i = 0;
@@ -607,7 +555,6 @@ QString LayerData::_getStateString( bool truncatePaths ) const{
             iter != m_dataContours.end(); iter++ ){
             QString lookup = Carta::State::UtilState::getLookup( DataContours::CONTOURS, i );
             copyState.setObject( lookup, (*iter)->_getState().toString() );
-            qDebug()<<"grimmer try to set layer-countour key:"<<lookup;
             i++;
         }
         QString colorState( "");
@@ -617,14 +564,11 @@ QString LayerData::_getStateString( bool truncatePaths ) const{
         copyState.insertObject( ColorState::CLASS_NAME, colorState );
     }
 
-    qDebug()<<"grimmer layerdata-2";
-
-    // _getImageString();
     std::shared_ptr<Carta::Lib::Image::ImageInterface> image;
     if ( m_dataSource ){
         image = m_dataSource->_getImage();
     }
-    QSize imageSize = _getDisplaySize(); //<-這較好
+    QSize imageSize = _getDisplaySize();
     int pixelX = imageSize.width();
     int pixelY = imageSize.height();
 
@@ -632,7 +576,6 @@ QString LayerData::_getStateString( bool truncatePaths ) const{
     copyState.insertObject( "pixelY", QString::number(pixelY) );
 
     QString stateStr = copyState.toString();
-    qDebug() <<"grimmer getStateString";
 
     return stateStr;
 }

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -109,7 +109,7 @@ void LayerData::_displayAxesChanged(std::vector<AxisInfo::KnownType> displayAxis
         const std::vector<int>& frames ){
     if ( m_dataSource ){
         m_dataSource->_setDisplayAxes( displayAxisTypes, frames );
-        _resetPan();
+        // _resetPan();
 
     }
 }
@@ -541,12 +541,65 @@ QSize LayerData::_getSaveSize( const QSize& outputSize,  Qt::AspectRatioMode asp
     return saveSize;
 }
 
+QString LayerData::_getImageString( ) const {
+    std::shared_ptr<Carta::Lib::Image::ImageInterface> image;
+    if ( m_dataSource ){
+        image = m_dataSource->_getImage();
+    }
+
+
+    qDebug() <<"grimmer aspect getImages";
+
+//    std::pair<int,int> DataSource::_getDisplayDims() const {
+//        displayDims.first = m_image->dims()[m_axisIndexX];
+//  //    image->dims()
+
+    //QPointF result = _getPixelCoordinates()?
+
+    // 成對的:
+    //QPointF LayerData::_getPixelCoordinates( double ra, double dec, bool* valid ) const{
+//    QPointF LayerData::_getWorldCoordinates( double pixelX, double pixelY,
+//            Carta::Lib::KnownSkyCS coordSys, bool* valid ) const{
+
+    // 2, aj.fits
+    int dimes = _getDimension();
+    //    int LayerData::_getDimension() const {
+
+    // 512, 1024
+    std::vector<int> result2 = _getImageDimensions();
+//    std::vector<int> LayerData::_getImageDimensions( ) const {
+
+    // 512,1024, may be image or possible others: Frequency x DEC plot
+    QSize imageSize = _getDisplaySize(); //<-這較好
+//    QSize LayerData::_getDisplaySize() const {
+
+    std::vector<AxisInfo::KnownType> axisTypes= _getAxisTypes(); // if Ztype, 0
+    // DIRECTION_LON, DIRECTION_LAT
+
+    Carta::Lib::KnownSkyCS cs = _getCoordinateSystem(); //J2000
+
+    QString aa = "";
+    return aa;
+}
 
 QString LayerData::_getStateString( bool truncatePaths ) const{
+
+    qDebug()<<"grimmer layerdata-1";
+
+    // 一般stack會直接取layerdata的m_state, 但統計那邊需要 此layerdata的
+    // m_dataSource的 image (Carta::Lib::Image::ImageInterface)
     Carta::State::StateInterface copyState( m_state );
+
+    qDebug() <<"grimmer getStateString0:"<<copyState.toString();
     if ( !truncatePaths ){
+        qDebug() <<"grimmer getStateString1:"<<copyState.toString();
+
         copyState.setValue<QString>(Util::NAME, m_dataSource->_getFileName());
+        qDebug() <<"grimmer getStateString2:"<<copyState.toString();
+
         copyState.insertObject( DataGrid::GRID, m_dataGrid->_getState().toString() );
+        qDebug() <<"grimmer getStateString3:"<<copyState.toString();
+
         int contourCount = m_dataContours.size();
         copyState.insertArray( DataContours::CONTOURS, contourCount );
         int i = 0;
@@ -554,6 +607,7 @@ QString LayerData::_getStateString( bool truncatePaths ) const{
             iter != m_dataContours.end(); iter++ ){
             QString lookup = Carta::State::UtilState::getLookup( DataContours::CONTOURS, i );
             copyState.setObject( lookup, (*iter)->_getState().toString() );
+            qDebug()<<"grimmer try to set layer-countour key:"<<lookup;
             i++;
         }
         QString colorState( "");
@@ -562,7 +616,24 @@ QString LayerData::_getStateString( bool truncatePaths ) const{
         }
         copyState.insertObject( ColorState::CLASS_NAME, colorState );
     }
+
+    qDebug()<<"grimmer layerdata-2";
+
+    // _getImageString();
+    std::shared_ptr<Carta::Lib::Image::ImageInterface> image;
+    if ( m_dataSource ){
+        image = m_dataSource->_getImage();
+    }
+    QSize imageSize = _getDisplaySize(); //<-這較好
+    int pixelX = imageSize.width();
+    int pixelY = imageSize.height();
+
+    copyState.insertObject( "pixelX", QString::number(pixelX) );
+    copyState.insertObject( "pixelY", QString::number(pixelY) );
+
     QString stateStr = copyState.toString();
+    qDebug() <<"grimmer getStateString";
+
     return stateStr;
 }
 

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -274,6 +274,8 @@ protected:
      */
     virtual std::vector< std::shared_ptr<ColorState> >  _getSelectedColorStates( bool global ) Q_DECL_OVERRIDE;
 
+    virtual QString _getImageString( ) const;
+
     /**
      * Return the state of this layer.
      * @param truncatePaths - true if full paths to files should not be given.

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -274,8 +274,6 @@ protected:
      */
     virtual std::vector< std::shared_ptr<ColorState> >  _getSelectedColorStates( bool global ) Q_DECL_OVERRIDE;
 
-    virtual QString _getImageString( ) const;
-
     /**
      * Return the state of this layer.
      * @param truncatePaths - true if full paths to files should not be given.

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -266,7 +266,7 @@ int Stack::_getIndex( const QString& layerId) const {
 int Stack::_getIndexCurrent( ) const {
     int dataIndex = -1;
     if ( m_selectImage ){
-        int index = m_selectImage->getIndex(); //visible裡的第幾個
+        int index = m_selectImage->getIndex();
         int visibleIndex = -1;
         int dataCount = m_children.size();
         for ( int i = 0; i < dataCount; i++ ){
@@ -449,12 +449,6 @@ void Stack::_renderAll(bool recomputeClipsOnNewFrame,
         double minClipPercentile, double maxClipPercentile){
     int gridIndex = 0;
     QList<std::shared_ptr<Layer> > datas = _getDrawChildren();
-    int len = datas.length();
-    if (len >1 ) {
-        qDebug()<<"grimmer animator crash 2";
-    } else {
-        qDebug()<<"grimmer animator crash 1";
-    }
     _render( datas, gridIndex, recomputeClipsOnNewFrame, minClipPercentile, maxClipPercentile );
 }
 
@@ -583,18 +577,16 @@ void Stack::_resetZoom( bool panZoomAll ){
     emit viewLoad( );
 }
 
-// _saveState
+
 void Stack::_saveChildren( Carta::State::StateInterface& state, bool truncate ) const {
     int dataCount = m_children.size();
     int oldDataCount = state.getArraySize( LAYERS );
     if ( oldDataCount != dataCount ){
         state.resizeArray(LAYERS, dataCount, Carta::State::StateInterface::PreserveNone );
     }
-    qDebug() <<"grimmer aspec count:" << dataCount;
     for (int i = 0; i < dataCount; i++) {
         QString layerString = m_children[i]->_getStateString( truncate );
         QString dataKey = Carta::State::UtilState::getLookup( LAYERS, i);
-        qDebug() <<"grimmer aspec dataKey:" <<dataKey <<";layerString:"<<layerString;
         state.setObject( dataKey, layerString);
     }
 }
@@ -789,15 +781,10 @@ bool Stack::_setVisible( const QString& id, bool visible ){
     return layerFound;
 }
 
-// m_stack->_setZoomLevelForLayerId( zoomFactor, false );
-
 void Stack::_setZoomLevelForLayerId(double zoomFactor, double layerId) {
     int dataCount = m_children.size();
     for ( int i = 0; i < dataCount; i++ ){
-        // QString id1 = m_children[i]->getId();
-        // QString id2 = m_children[i]->_getLayerId();
         if (m_children[i]->_getLayerId() == QString::number(layerId)){
-            qDebug() << "grimmer aspect match layerID";
             m_children[i]->_setZoom( zoomFactor );
             break;
         }
@@ -858,21 +845,11 @@ void Stack::_updatePanZoom( double centerX, double centerY, double zoomFactor, b
 
         int dataCount = m_children.size();
         for ( int i = 0; i < dataCount; i++ ){
-            //QString id1 = m_children[i]->getId(); //cxx
-            //QString id2 = m_children[i]->_getLayerId(); //xx
             if (m_children[i]->_getLayerId() == QString::number(layerId)){
-                qDebug() << "grimmer aspect match layerID for panzoom";
                 _updatePanZoom( centerX, centerY, zoomFactor, m_children[i], zoomLevel );
-
-                // m_children[i]->_setZoom( zoomFactor );
                 break;
             }
         }
-
-        // int dataIndex = _getIndexCurrent();
-        // if ( dataIndex >= 0 ){
-        //     _updatePanZoom( centerX, centerY, zoomFactor, m_children[dataIndex], zoomLevel );
-        // }
     }
     emit viewLoad();
 }

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -129,6 +129,7 @@ void Stack::_displayAxesChanged(std::vector<AxisInfo::KnownType> displayAxisType
             }
         }
     }
+     _saveState();
     emit viewLoad( );
 }
 

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -262,7 +262,6 @@ int Stack::_getIndex( const QString& layerId) const {
     return index;
 }
 
-
 int Stack::_getIndexCurrent( ) const {
     int dataIndex = -1;
     if ( m_selectImage ){
@@ -789,6 +788,22 @@ bool Stack::_setVisible( const QString& id, bool visible ){
     return layerFound;
 }
 
+// m_stack->_setZoomLevelForLayerId( zoomFactor, false );
+
+void Stack::_setZoomLevelForLayerId(double zoomFactor, double layerId) {
+    int dataCount = m_children.size();
+    for ( int i = 0; i < dataCount; i++ ){
+        // QString id1 = m_children[i]->getId();
+        // QString id2 = m_children[i]->_getLayerId();
+        if (m_children[i]->_getLayerId() == QString::number(layerId)){
+            qDebug() << "grimmer aspect match layerID";
+            m_children[i]->_setZoom( zoomFactor );
+            break;
+        }
+    }
+    emit viewLoad();
+}
+
 void Stack::_setZoomLevel( double zoomFactor, bool zoomPanAll ){
     if ( zoomPanAll ){
         int dataCount = m_children.size();
@@ -832,17 +847,31 @@ void Stack::_updatePan( double centerX , double centerY,
     }
 }
 
-void Stack::_updatePanZoom( double centerX, double centerY, double zoomFactor, bool zoomPanAll, double zoomLevel){
+void Stack::_updatePanZoom( double centerX, double centerY, double zoomFactor, bool zoomPanAll, double zoomLevel, double layerId){
     if ( zoomPanAll ){
         for (std::shared_ptr<Layer> data : m_children ){
             _updatePanZoom( centerX, centerY, zoomFactor, data, zoomLevel );
         }
     }
     else {
-        int dataIndex = _getIndexCurrent();
-        if ( dataIndex >= 0 ){
-            _updatePanZoom( centerX, centerY, zoomFactor, m_children[dataIndex], zoomLevel );
+
+        int dataCount = m_children.size();
+        for ( int i = 0; i < dataCount; i++ ){
+            //QString id1 = m_children[i]->getId(); //cxx
+            //QString id2 = m_children[i]->_getLayerId(); //xx
+            if (m_children[i]->_getLayerId() == QString::number(layerId)){
+                qDebug() << "grimmer aspect match layerID for panzoom";
+                _updatePanZoom( centerX, centerY, zoomFactor, m_children[i], zoomLevel );
+
+                // m_children[i]->_setZoom( zoomFactor );
+                break;
+            }
         }
+
+        // int dataIndex = _getIndexCurrent();
+        // if ( dataIndex >= 0 ){
+        //     _updatePanZoom( centerX, centerY, zoomFactor, m_children[dataIndex], zoomLevel );
+        // }
     }
     emit viewLoad();
 }

--- a/carta/cpp/core/Data/Image/Stack.h
+++ b/carta/cpp/core/Data/Image/Stack.h
@@ -173,6 +173,7 @@ private:
     void _setViewDrawContext( std::shared_ptr<DrawStackSynchronizer> drawStack );
     void _setViewDrawZoom( std::shared_ptr<DrawStackSynchronizer> drawZoom );
 
+    void _setZoomLevelForLayerId( double zoomFactor, double layerId );
     void _setZoomLevel( double zoomFactor, bool zoomPanAll );
 
 
@@ -180,7 +181,7 @@ private:
     void _updatePan( double centerX , double centerY,
             std::shared_ptr<Layer> data);
 
-    void _updatePanZoom( double centerX, double centerY, double zoomFactor, bool zoomPanAll, double zoomLevel);
+    void _updatePanZoom( double centerX, double centerY, double zoomFactor, bool zoomPanAll, double zoomLevel, double layerId);
     void _updatePanZoom( double centerX, double centerY, double zoomFactor,
             std::shared_ptr<Layer> data, double zoomLevel );
 

--- a/carta/cpp/core/Data/Image/Stack.h
+++ b/carta/cpp/core/Data/Image/Stack.h
@@ -180,9 +180,9 @@ private:
     void _updatePan( double centerX , double centerY,
             std::shared_ptr<Layer> data);
 
-    void _updateZoom( double centerX, double centerY, double zoomFactor, bool zoomPanAll);
-    void _updateZoom( double centerX, double centerY, double zoomFactor,
-            std::shared_ptr<Layer> data );
+    void _updatePanZoom( double centerX, double centerY, double zoomFactor, bool zoomPanAll, double zoomLevel);
+    void _updatePanZoom( double centerX, double centerY, double zoomFactor,
+            std::shared_ptr<Layer> data, double zoomLevel );
 
 
     /**

--- a/carta/html5/common/skel/source/class/skel/Command/Data/CommandZoomReset.js
+++ b/carta/html5/common/skel/source/class/skel/Command/Data/CommandZoomReset.js
@@ -17,7 +17,7 @@ qx.Class.define("skel.Command.Data.CommandZoomReset", {
         this.m_global = false;
         this.setToolTipText( "Reset the zoom level to its original value.");
     },
-    
+
     members : {
         doAction : function( vals, undoCB ){
             var activeWins = skel.Command.Command.m_activeWins;
@@ -26,8 +26,12 @@ qx.Class.define("skel.Command.Data.CommandZoomReset", {
                 for ( var i = 0; i < activeWins.length; i++ ){
                     if ( activeWins[i].isCmdSupported( this ) ){
                         var id = activeWins[i].getIdentifier();
-                        var params = "";
-                        this.sendCommand( id, params, emptyFunc);
+
+                        if (activeWins[i].resetZoomToFitWindow) {
+                            activeWins[i].resetZoomToFitWindow();
+                        }
+                        // var params = "";
+                        // this.sendCommand( id, params, emptyFunc);
                     }
                 }
             }

--- a/carta/html5/common/skel/source/class/skel/Command/Data/CommandZoomReset.js
+++ b/carta/html5/common/skel/source/class/skel/Command/Data/CommandZoomReset.js
@@ -11,7 +11,10 @@ qx.Class.define("skel.Command.Data.CommandZoomReset", {
      */
     construct : function() {
         var path = skel.widgets.Path.getInstance();
+
+        // no use now.  use resetZoomToFitWindow instead 
         var cmd = path.SEP_COMMAND + "resetZoom";
+
         this.base( arguments, "Zoom Reset", cmd);
         this.setEnabled( false );
         this.m_global = false;
@@ -25,11 +28,12 @@ qx.Class.define("skel.Command.Data.CommandZoomReset", {
                 var emptyFunc = function(){};
                 for ( var i = 0; i < activeWins.length; i++ ){
                     if ( activeWins[i].isCmdSupported( this ) ){
-                        var id = activeWins[i].getIdentifier();
 
                         if (activeWins[i].resetZoomToFitWindow) {
                             activeWins[i].resetZoomToFitWindow();
                         }
+
+                        // var id = activeWins[i].getIdentifier();
                         // var params = "";
                         // this.sendCommand( id, params, emptyFunc);
                     }

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/View/PanZoomView.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/View/PanZoomView.js
@@ -23,7 +23,7 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
         this.m_viewWidget.m_updateViewCallback = this.viewSizeHandler.bind(this);
 
         // monitor mouse move
-        this.addListener( "mousewheel", this._mouseWheelCB.bind(this));
+        // this.addListener( "mousewheel", this._mouseWheelCB.bind(this));
 
         this.m_viewId = viewId;
         this.m_connector = mImport( "connector");
@@ -46,6 +46,8 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
         //     this.fireDataEvent( "viewRefreshed");
         // },
 
+
+
         /**
          * Install an input handler.
          * @param handlerType {class}
@@ -65,25 +67,26 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
             this.m_inputHandlers[handlerType] = handler;
         },
 
+        sendPanZoomLevel : function(pt, level) {
+            // var box = this.overlayWidget().getContentLocation( "box" );
+            // var pt = {
+            //     x: ev.getDocumentLeft() - box.left,
+            //     y: ev.getDocumentTop() - box.top
+            // };
+            //console.log( "vwid wheel", pt.x, pt.y, ev.getWheelDelta());
+            var path = skel.widgets.Path.getInstance();
+            var cmd = this.m_viewId + path.SEP_COMMAND + "setPanAndZoomLevel";//path.ZOOM;
+
+            // this.m_connector.sendCommand( cmd,  newZoom);
+            this.m_connector.sendCommand( cmd,
+                "" + pt.x + " " + pt.y + " " + level);
+        },
+
         sendZoomLevel: function(level) {
             var path = skel.widgets.Path.getInstance();
             var cmd = this.m_viewId + path.SEP_COMMAND + "setZoomLevel";
             console.log("grimmer aspect, set zoom level:",cmd,":", level);
             this.m_connector.sendCommand( cmd, level);
-        },
-
-        _mouseWheelCB : function(ev) {
-            var box = this.overlayWidget().getContentLocation( "box" );
-            var pt = {
-                x: ev.getDocumentLeft() - box.left,
-                y: ev.getDocumentTop() - box.top
-            };
-            //console.log( "vwid wheel", pt.x, pt.y, ev.getWheelDelta());
-            var path = skel.widgets.Path.getInstance();
-            var cmd = this.m_viewId + path.SEP_COMMAND + path.ZOOM;
-            console.log("grimmer aspect, zoom:",cmd,";",pt,";", ev);
-            this.m_connector.sendCommand( cmd,
-                "" + pt.x + " " + pt.y + " " + ev.getWheelDelta());
         },
 
         /**
@@ -117,6 +120,8 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
             delete this.m_inputHandlers[handlerType];
         },
 
+        // m_currentZoomLevel: 1, //fitToWindow時要存. 手動放大放小時也存
+        // m_effectZoomLevel:  1, //???
         m_viewId : null,
         m_inputHandlers : null,
         m_updateViewCallback: null

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/View/PanZoomView.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/View/PanZoomView.js
@@ -67,7 +67,7 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
             this.m_inputHandlers[handlerType] = handler;
         },
 
-        sendPanZoomLevel : function(pt, level) {
+        sendPanZoom : function(pt, wheelFactor) {
             // var box = this.overlayWidget().getContentLocation( "box" );
             // var pt = {
             //     x: ev.getDocumentLeft() - box.left,
@@ -75,18 +75,27 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
             // };
             //console.log( "vwid wheel", pt.x, pt.y, ev.getWheelDelta());
             var path = skel.widgets.Path.getInstance();
-            var cmd = this.m_viewId + path.SEP_COMMAND + "setPanAndZoomLevel";//path.ZOOM;
+            var cmd = this.m_viewId + path.SEP_COMMAND + path.ZOOM;
 
             // this.m_connector.sendCommand( cmd,  newZoom);
             this.m_connector.sendCommand( cmd,
-                "" + pt.x + " " + pt.y + " " + level);
+                "" + pt.x + " " + pt.y + " " + wheelFactor);
         },
 
-        sendZoomLevel: function(level) {
+        sendPanZoomLevel : function(pt, level, id) {
+
+            var path = skel.widgets.Path.getInstance();
+            var cmd = this.m_viewId + path.SEP_COMMAND + "setPanAndZoomLevel";
+            this.m_connector.sendCommand( cmd,
+                "" + pt.x + " " + pt.y + " " + level+" "+ id);
+        },
+
+        // zoom
+        sendZoomLevel: function(level, id) {
             var path = skel.widgets.Path.getInstance();
             var cmd = this.m_viewId + path.SEP_COMMAND + "setZoomLevel";
             console.log("grimmer aspect, set zoom level:",cmd,":", level);
-            this.m_connector.sendCommand( cmd, level);
+            this.m_connector.sendCommand( cmd, ""+level+" "+ id);
         },
 
         /**

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/View/PanZoomView.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/View/PanZoomView.js
@@ -17,7 +17,10 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
      */
     construct: function( viewId )
     {
+        console.log("grimmer view- PanZoomView");
         this.base( arguments, viewId );
+
+        this.m_viewWidget.m_updateViewCallback = this.viewSizeHandler.bind(this);
 
         // monitor mouse move
         this.addListener( "mousewheel", this._mouseWheelCB.bind(this));
@@ -29,7 +32,20 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
     },
 
     members: {
-    	
+
+        viewSizeHandler: function(width, height) {
+            console.log("grimmer test size:", width, ";h:", height);
+            if (this.m_updateViewCallback) {
+                this.m_updateViewCallback(width, height);
+            }
+        },
+
+        // callback for iView refresh
+        // _iviewRefreshCB : function() {
+        //     console.log("grimmer aspect _iviewRefreshCB_parent2");
+        //     this.fireDataEvent( "viewRefreshed");
+        // },
+
         /**
          * Install an input handler.
          * @param handlerType {class}
@@ -49,6 +65,13 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
             this.m_inputHandlers[handlerType] = handler;
         },
 
+        sendZoomLevel: function(level) {
+            var path = skel.widgets.Path.getInstance();
+            var cmd = this.m_viewId + path.SEP_COMMAND + "setZoomLevel";
+            console.log("grimmer aspect, set zoom level:",cmd,":", level);
+            this.m_connector.sendCommand( cmd, level);
+        },
+
         _mouseWheelCB : function(ev) {
             var box = this.overlayWidget().getContentLocation( "box" );
             var pt = {
@@ -58,23 +81,25 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
             //console.log( "vwid wheel", pt.x, pt.y, ev.getWheelDelta());
             var path = skel.widgets.Path.getInstance();
             var cmd = this.m_viewId + path.SEP_COMMAND + path.ZOOM;
+            console.log("grimmer aspect, zoom:",cmd,";",pt,";", ev);
             this.m_connector.sendCommand( cmd,
                 "" + pt.x + " " + pt.y + " " + ev.getWheelDelta());
         },
- 
+
         /**
          * Send an input event to the server side.
          * @param e {object}
          */
         sendInputEvent: function( e ){
-            
+
             var params = JSON.stringify( e );
             //console.log( "Sending input event"+params );
             var path = skel.widgets.Path.getInstance();
             var cmd = this.m_viewId + path.SEP_COMMAND + path.INPUT_EVENT;
+            console.log("grimmer aspect:",cmd,";",params);
             this.m_connector.sendCommand( cmd, params );
         },
-        
+
         /**
          * Install an input handler.
          * @param handlerType {class}
@@ -93,7 +118,8 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
         },
 
         m_viewId : null,
-        m_inputHandlers : null
+        m_inputHandlers : null,
+        m_updateViewCallback: null
 
     }
 } );

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/View/PanZoomView.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/View/PanZoomView.js
@@ -17,7 +17,6 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
      */
     construct: function( viewId )
     {
-        console.log("grimmer view- PanZoomView");
         this.base( arguments, viewId );
 
         this.m_viewWidget.m_updateViewCallback = this.viewSizeHandler.bind(this);

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/View/PanZoomView.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/View/PanZoomView.js
@@ -22,7 +22,7 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
 
         this.m_viewWidget.m_updateViewCallback = this.viewSizeHandler.bind(this);
 
-        // monitor mouse move
+        // monitor mouse move, move to DisplayWindowImage.
         // this.addListener( "mousewheel", this._mouseWheelCB.bind(this));
 
         this.m_viewId = viewId;
@@ -34,19 +34,10 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
     members: {
 
         viewSizeHandler: function(width, height) {
-            console.log("grimmer test size:", width, ";h:", height);
             if (this.m_updateViewCallback) {
                 this.m_updateViewCallback(width, height);
             }
         },
-
-        // callback for iView refresh
-        // _iviewRefreshCB : function() {
-        //     console.log("grimmer aspect _iviewRefreshCB_parent2");
-        //     this.fireDataEvent( "viewRefreshed");
-        // },
-
-
 
         /**
          * Install an input handler.
@@ -67,21 +58,15 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
             this.m_inputHandlers[handlerType] = handler;
         },
 
-        sendPanZoom : function(pt, wheelFactor) {
-            // var box = this.overlayWidget().getContentLocation( "box" );
-            // var pt = {
-            //     x: ev.getDocumentLeft() - box.left,
-            //     y: ev.getDocumentTop() - box.top
-            // };
-            //console.log( "vwid wheel", pt.x, pt.y, ev.getWheelDelta());
-            var path = skel.widgets.Path.getInstance();
-            var cmd = this.m_viewId + path.SEP_COMMAND + path.ZOOM;
+        // sendPanZoom : function(pt, wheelFactor) {
+        //     var path = skel.widgets.Path.getInstance();
+        //     var cmd = this.m_viewId + path.SEP_COMMAND + path.ZOOM;
+        //
+        //     this.m_connector.sendCommand( cmd,
+        //         "" + pt.x + " " + pt.y + " " + wheelFactor);
+        // },
 
-            // this.m_connector.sendCommand( cmd,  newZoom);
-            this.m_connector.sendCommand( cmd,
-                "" + pt.x + " " + pt.y + " " + wheelFactor);
-        },
-
+        // new command for fitToWinowSize and setup minimal zoom level functions.
         sendPanZoomLevel : function(pt, level, id) {
 
             var path = skel.widgets.Path.getInstance();
@@ -90,25 +75,22 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
                 "" + pt.x + " " + pt.y + " " + level+" "+ id);
         },
 
-        // zoom
+        // new command for fitToWinowSize and setup minimal zoom level functions.
         sendZoomLevel: function(level, id) {
             var path = skel.widgets.Path.getInstance();
             var cmd = this.m_viewId + path.SEP_COMMAND + "setZoomLevel";
-            console.log("grimmer aspect, set zoom level:",cmd,":", level);
             this.m_connector.sendCommand( cmd, ""+level+" "+ id);
         },
 
         /**
-         * Send an input event to the server side.
+         * Send an input event to the server side. E.g. mouse hover action
          * @param e {object}
          */
         sendInputEvent: function( e ){
 
             var params = JSON.stringify( e );
-            //console.log( "Sending input event"+params );
             var path = skel.widgets.Path.getInstance();
             var cmd = this.m_viewId + path.SEP_COMMAND + path.INPUT_EVENT;
-            console.log("grimmer aspect:",cmd,";",params);
             this.m_connector.sendCommand( cmd, params );
         },
 
@@ -129,8 +111,6 @@ qx.Class.define( "skel.boundWidgets.View.PanZoomView", {
             delete this.m_inputHandlers[handlerType];
         },
 
-        // m_currentZoomLevel: 1, //fitToWindow時要存. 手動放大放小時也存
-        // m_effectZoomLevel:  1, //???
         m_viewId : null,
         m_inputHandlers : null,
         m_updateViewCallback: null

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/View/View.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/View/View.js
@@ -31,7 +31,6 @@ qx.Class.define( "skel.boundWidgets.View.View", {
      */
     construct: function( viewName )
     {
-        console.log("grimmer view construct");
         this.m_connector = mImport( "connector" );
 
         this.base( arguments );
@@ -46,10 +45,6 @@ qx.Class.define( "skel.boundWidgets.View.View", {
             if (null === this.getContentElement().getDomElement()) {
                 return;
             }
-
-
-            var dom = this.getContentElement().getDomElement();
-            console.log("grimmer aspect, before send, width:", dom.offsetWidth);
 
             // defer calling update size by a little bit, because qooxdoo sent us the
             // resize probably before the actual html has been updated
@@ -84,10 +79,8 @@ qx.Class.define( "skel.boundWidgets.View.View", {
         // callback for appear event
         _appearCB: function()
         {
-            console.log("grimmere view appearCB");
             this.m_iview = this.m_connector.registerViewElement(
             this.getContentElement().getDomElement(), this.m_viewName );
-            // console.log("grimmer aspect image tag size:", this.m_iview.m_imgTag.width,";",this.m_iview.m_imgTag.height);
 
             this.m_iview.updateSize();
             this.m_iview.addViewCallback( this._iviewRefreshCB.bind( this ) );
@@ -96,12 +89,10 @@ qx.Class.define( "skel.boundWidgets.View.View", {
 
         // callback for iView refresh
         _iviewRefreshCB : function() {
-            console.log("grimmer aspect _iviewRefreshCB_parent");
             this.fireDataEvent( "viewRefreshed");
 
             var dom = this.getContentElement().getDomElement();
-            console.log("grimmer aspect, _iviewRefreshCB:", dom.offsetWidth);
-            if (this.m_updateViewCallback){
+            if (this.m_updateViewCallback) {
                 this.m_updateViewCallback(dom.offsetWidth, dom.offsetHeight);
             }
         },

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/View/View.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/View/View.js
@@ -31,11 +31,12 @@ qx.Class.define( "skel.boundWidgets.View.View", {
      */
     construct: function( viewName )
     {
+        console.log("grimmer view construct");
         this.m_connector = mImport( "connector" );
-        
+
         this.base( arguments );
         this.m_viewName = viewName;
-        
+
         var setZeroTimeout = mImport( "setZeroTimeout" );
 
         this.addListenerOnce( "appear", this._appearCB.bind(this));
@@ -45,6 +46,10 @@ qx.Class.define( "skel.boundWidgets.View.View", {
             if (null === this.getContentElement().getDomElement()) {
                 return;
             }
+
+
+            var dom = this.getContentElement().getDomElement();
+            console.log("grimmer aspect, before send, width:", dom.offsetWidth);
 
             // defer calling update size by a little bit, because qooxdoo sent us the
             // resize probably before the actual html has been updated
@@ -79,9 +84,11 @@ qx.Class.define( "skel.boundWidgets.View.View", {
         // callback for appear event
         _appearCB: function()
         {
+            console.log("grimmere view appearCB");
             this.m_iview = this.m_connector.registerViewElement(
             this.getContentElement().getDomElement(), this.m_viewName );
-    
+            // console.log("grimmer aspect image tag size:", this.m_iview.m_imgTag.width,";",this.m_iview.m_imgTag.height);
+
             this.m_iview.updateSize();
             this.m_iview.addViewCallback( this._iviewRefreshCB.bind( this ) );
             this.setQuality( this.m_quality);
@@ -89,7 +96,14 @@ qx.Class.define( "skel.boundWidgets.View.View", {
 
         // callback for iView refresh
         _iviewRefreshCB : function() {
+            console.log("grimmer aspect _iviewRefreshCB_parent");
             this.fireDataEvent( "viewRefreshed");
+
+            var dom = this.getContentElement().getDomElement();
+            console.log("grimmer aspect, _iviewRefreshCB:", dom.offsetWidth);
+            if (this.m_updateViewCallback){
+                this.m_updateViewCallback(dom.offsetWidth, dom.offsetHeight);
+            }
         },
 
         // overridden
@@ -129,8 +143,10 @@ qx.Class.define( "skel.boundWidgets.View.View", {
          * @type {Connector} cached instance of the connector
          */
         m_connector: null,
-        
-        m_quality: null
+
+        m_quality: null,
+
+        m_updateViewCallback: null
     },
 
     destruct: function()

--- a/carta/html5/common/skel/source/class/skel/widgets/Window/DisplayWindowImage.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Window/DisplayWindowImage.js
@@ -63,12 +63,14 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                 if (!this.m_zoomAllmode && !data.selected) {
                     continue;
                 }
-                
+
                 //TODO, m_zoomAllmode
                 if (this.m_zoomAllmode) {
 
                 } else {
                     this.m_view.sendZoomLevel(data.m_minimalZoomLevel);
+                    data.m_currentZoomLevel = data.m_minimalZoomLevel;
+                    data.m_effectZoomLevel = 1;
                 }
             }
 
@@ -105,6 +107,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                     console.log("grimmer aspect, wheel zoom:"+newZoom,";",pt);
 
                     data.m_currentZoomLevel = newZoom;
+                    data.m_effectZoomLevel = data.m_currentZoomLevel / data.m_minimalZoomLevel;
                 }
             }
         },
@@ -161,8 +164,8 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
         _setupDefaultLayerData: function(data) {
 
             data.m_minimalZoomLevel = 1;
-            data.m_currentZoomLevel = 1;
 
+            data.m_currentZoomLevel = 1;
             data.m_effectZoomLevel = 1;
             // m_currentZoomLevel: 1, //fitToWindow時要存. 手動放大放小時也存
             // m_effectZoomLevel:  1, //???
@@ -240,11 +243,12 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
 
                     //zoom level 一定會有個下限, 每次新的stack都要重算.
                     console.log("try to send zoom level:", zoom);
-                    if (zoom != 1) {
-                        this.m_view.sendZoomLevel(zoom);
+                    var finalZoom = zoom*data.m_effectZoomLevel;
+                    if (finalZoom != data.m_currentZoomLevel) {
+                        this.m_view.sendZoomLevel(finalZoom);
 
                         //TODO: grimmer. need to passive-sync m_currentZoomLevel with cpp
-                        data.m_currentZoomLevel = zoom;
+                        data.m_currentZoomLevel = finalZoom;
                     }
 
                     break;

--- a/carta/html5/common/skel/source/class/skel/widgets/Window/DisplayWindowImage.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Window/DisplayWindowImage.js
@@ -325,7 +325,6 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
          * Initializes the region drawing context menu.
          */
         _initMenuRegion : function() {
-            console.log("grimmer menu region")
             var regionMenu = new qx.ui.menu.Menu();
             this._initShapeButtons(regionMenu, false);
 
@@ -346,7 +345,6 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
          * 		back when the shape is finished.
          */
         _initShapeButtons : function(menu, keepMode) {
-            console.log("grimmer menu shape")
             var drawFunction = function(ev) {
                 var buttonText = this.getLabel();
                 var data = {

--- a/carta/html5/common/skel/source/class/skel/widgets/Window/DisplayWindowImage.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Window/DisplayWindowImage.js
@@ -10,7 +10,7 @@
 qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
     extend : skel.widgets.Window.DisplayWindow,
     include : skel.widgets.Window.PreferencesMixin,
-    
+
     /**
      * Constructor.
      */
@@ -19,15 +19,93 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
         this.m_links = [];
         this.m_viewContent = new qx.ui.container.Composite();
         this.m_viewContent.setLayout(new qx.ui.layout.Canvas());
-        
+
         this.m_content.add( this.m_viewContent, {flex:1} );
         this.m_imageControls = new skel.widgets.Image.ImageControls();
         this.m_imageControls.addListener( "gridControlsChanged", this._gridChanged, this );
         this.m_content.add( this.m_imageControls );
+
+        this.m_scheduleZoomFit = false;
+        this.m_viewContent.addListener( "resize", function( /*e*/ ) {
+            console.log("grimmer aspect display window, setupt m_scheduleZoomFit !!!");
+            //先這個(還沒選檔前就會被call一次). 再layoutlead , 再來才是view.js 那邊
+            // 之後主動改視窗大小就靠這個
+            //TODO:
+            //0. 手動zoom , pan後, 再改視窗. 也要維持那個view區塊?
+            //1. resetZoom 要改
+            //2. 切換檔案, 沒有zoom all
+            //3. 切換檔案, 有zoom all
+            //4. 轉置
+
+            //x 測 image layout. x
+
+            this.m_scheduleZoomFit = true;
+        }, this);
     },
 
     members : {
-        
+
+        _adjustZoomToFitWindow : function(view_width, view_height){
+            console.log("grimmer displaywindow, adjustZoomToFitWindow:"+view_width+";"+view_height);
+            console.log("grimmer aspec datas:", this.m_datas);
+            if (!view_width || !view_height) {
+                console.log("invalid width or height");
+                return;
+            }
+
+            //638, 666
+
+            if (this.m_scheduleZoomFit && this.m_datas) {
+                console.log("grimmer aspec datas2");
+                this.m_scheduleZoomFit = false;
+
+                var dataLen = this.m_datas.length;
+                for (var i = 0; i < dataLen; i++) {
+                    console.log("grimmer aspec datas loop:", i);
+
+                    var data = this.m_datas[i];
+
+                    //TODO: if zoomALL.
+                    if (true || data.selected) {
+
+                        if (!data.pixelX || !data.pixelY){
+                            console.log("not invalid layerdata.pixelXorY");
+                            continue;
+                        }
+
+                        var zoomX = view_width / data.pixelX;
+                        var zoomY = view_height / data.pixelY;
+                        var zoom = -1;
+
+                        if (zoomX < 1 || zoomY < 1) {
+                            if (zoomX > zoomY){
+                                zoom = zoomY; //aj.fits, 512x1024, slim
+                            } else {
+                                zoom = zoomX; //502nmos.fits, 1600x1600, fat
+                            }
+
+                        }  else {
+                            if (zoomX > zoomY){
+                                zoom = zoomY; // M100_alma.fits,52x62 slim
+                            } else {
+                                zoom = zoomX; // cube_x220_z100_17MB,220x220 fat
+                            }
+                        }
+
+                        console.log("try to send zoom level:", zoom);
+                        this.m_view.sendZoomLevel(zoom);
+
+                        //Adjust Zoom level
+                        // If zoomAll = false
+                        if (false){
+                            break;
+                        }
+                    }
+                }
+            }
+        },
+
+
         /**
          * Add or remove the grid control settings based on whether the user
          * had configured any of the settings visible.
@@ -37,18 +115,18 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
             this.m_controlsVisible = content;
             this._layoutControls();
         },
-        
-        
+
+
         /**
          * Clean-up items; this window is going to disappear.
          */
         clean : function(){
-            //Remove the view so we don't get spurious mouse events sent to a 
+            //Remove the view so we don't get spurious mouse events sent to a
             //controller that no longer exists.
             if ( this.m_view !== null ){
                 if ( this.m_viewContent.indexOf( this.m_view) >= 0 ){
                     this.m_viewContent.remove( this.m_view);
-                   
+
                 }
             }
         },
@@ -57,20 +135,24 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
          * Call back that initializes the View when data is loaded.
          */
         _dataLoadedCB : function(){
+            console.log("grimmer aspect displayWindow dataloadedCB !!!");
             if (this.m_view === null) {
                 this.m_view = new skel.boundWidgets.View.PanZoomView(this.m_identifier);
                 this.m_view.installHandler( skel.boundWidgets.View.InputHandler.Drag );
+
+                this.m_view.m_updateViewCallback = this._adjustZoomToFitWindow.bind(this);
             }
-            
+
             if (this.m_viewContent.indexOf(this.m_view) < 0) {
                 var overlayMap = {left:"0%",right:"0%",top:"0%",bottom: "0%"};
+                console.log("grimmer aspect dataloadedCB m_viewContent");
                 this.m_viewContent.add(this.m_view, overlayMap );
-                
+
             }
-           
+
             this.m_view.setVisibility( "visible" );
         },
-        
+
         /**
          * Notify the server that data has been loaded.
          * @param path {String} an identifier for locating the data.
@@ -96,7 +178,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
         getDatas : function(){
             return this.m_datas;
         },
-        
+
         /**
          * Return the identifier for the region controller.
          * @return {String} - the identifier of the region controller.
@@ -104,7 +186,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
         getRegionIdentifier : function(){
         	return this.m_regionId;
         },
-        
+
         /**
          * Return a list of regions in the image.
          * @return {Array} - a list of regions in the image.
@@ -112,7 +194,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
         getRegions : function(){
             return this.m_regions;
         },
-        
+
         /**
          * Notification that the grid controls have changed on the server-side.
          * @param ev {qx.event.type.Data}.
@@ -127,6 +209,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
          * Initializes the region drawing context menu.
          */
         _initMenuRegion : function() {
+            console.log("grimmer menu region")
             var regionMenu = new qx.ui.menu.Menu();
             this._initShapeButtons(regionMenu, false);
 
@@ -147,6 +230,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
          * 		back when the shape is finished.
          */
         _initShapeButtons : function(menu, keepMode) {
+            console.log("grimmer menu shape")
             var drawFunction = function(ev) {
                 var buttonText = this.getLabel();
                 var data = {
@@ -162,7 +246,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                 menu.add(shapeButton);
             }
         },
-        
+
         /**
          * Initialize the label for displaying cursor statistics.
          */
@@ -176,13 +260,13 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                 this.m_statLabel.setRich( true );
             }
         },
-        
+
         /**
          * Initialize the list of window specific commands this window supports.
          */
         _initSupportedCommands : function(){
             this.m_supportedCmds = [];
-            
+
             var clipCmd = skel.Command.Clip.CommandClip.getInstance();
             this.m_supportedCmds.push( clipCmd.getLabel() );
             var dataCmd = skel.Command.Data.CommandData.getInstance();
@@ -203,7 +287,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
             this.m_supportedCmds.push( panResetCmd.getLabel() );
             arguments.callee.base.apply(this, arguments);
         },
-        
+
         /**
          * Returns whether or not this window can be linked to a window
          * displaying a named plug-in.
@@ -212,15 +296,15 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
         isLinkable : function(pluginId) {
             var linkable = false;
             var path = skel.widgets.Path.getInstance();
-            if (pluginId == path.ANIMATOR || 
-                    pluginId == path.COLORMAP_PLUGIN ||pluginId == path.HISTOGRAM_PLUGIN || 
+            if (pluginId == path.ANIMATOR ||
+                    pluginId == path.COLORMAP_PLUGIN ||pluginId == path.HISTOGRAM_PLUGIN ||
                     pluginId == path.STATISTICS || pluginId == path.PROFILE ||
                     pluginId == path.IMAGE_CONTEXT || pluginId == path.IMAGE_ZOOM ) {
                 linkable = true;
             }
             return linkable;
         },
-               
+
 
         /**
          * Returns whether or not this window supports establishing a two-way
@@ -234,7 +318,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
             }
             return biLink;
         },
-        
+
         /**
          * Add/remove content based on user visibility preferences.
          */
@@ -267,7 +351,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                 }
             }
         },
-        
+
         /**
          * Register to get updates on stack data settings from the server.
          */
@@ -287,18 +371,18 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
             var params = "";
             this.m_connector.sendCommand( cmd, params, this._registrationStackCallback( this));
         },
-        
-        
+
+
         /**
          * Callback for when the registration is complete and an id is available.
          * @param anObject {skel.widgets.Image.Region.RegionControls}.
          */
         _registrationRegionCallback : function( anObject ){
-            return function( id ){           	
+            return function( id ){
                 anObject._setRegionId( id );
             };
         },
-        
+
         /**
          * Callback for when the registration is complete and an id is available.
          * @param anObject {skel.widgets.Image.Stack.StackControls}.
@@ -308,7 +392,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                 anObject._setStackId( id );
             };
         },
-        
+
         /**
          * Show/hide the cursor statistics control.
          * @param visible {boolean} - true if the cursor statistics widget
@@ -318,14 +402,14 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
             this.m_statisticsVisible = visible;
             this._layoutControls();
         },
-        
+
 
         setDrawMode : function(drawInfo) {
             if (this.m_drawCanvas !== null) {
                 this.m_drawCanvas.setDrawMode(drawInfo);
             }
         },
-        
+
         /**
          * Set the appearance of this window based on whether or not it is selected.
          * @param selected {boolean} true if the window is selected; false otherwise.
@@ -336,7 +420,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
             this.updateCmds();
             arguments.callee.base.apply(this, arguments, selected, multiple );
         },
-        
+
         /**
          * Update region specific elements from the shared variable.
          */
@@ -346,7 +430,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                 try {
                     var winObj = JSON.parse( val );
                     var regionShape = winObj.createType;
-                  
+
                     var regionDrawCmds = skel.Command.Region.CommandRegions.getInstance();
                     regionDrawCmds.setDrawType( regionShape );
                 }
@@ -356,7 +440,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                 }
             }
         },
-        
+
         /**
          * Update region data specific elements from the shared variable.
          */
@@ -371,7 +455,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                     }
                     var dataCmd = skel.Command.Data.CommandData.getInstance();
                     dataCmd.datasChanged();
-                    this._initContextMenu();       
+                    this._initContextMenu();
                 }
                 catch( err ){
                     console.log( "DisplayWindowImage could not parse region data update: "+val );
@@ -379,7 +463,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                 }
             }
         },
-        
+
         /**
          * Update window specific elements from the shared variable.
          * @param winObj {String} represents the server state of this window.
@@ -388,7 +472,9 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
             var val = this.m_sharedVarStack.get();
             if ( val ){
                 try {
+                    console.log("grimmer aspect: sharedStack1:", val);
                     var winObj = JSON.parse( val );
+                    console.log("grimmer aspect: sharedStack2:", val);
                     this.m_datas = [];
                     //Add close menu buttons for all the images that are loaded.
                     var dataObjs = winObj.layers;
@@ -401,14 +487,28 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                             }
                         }
                     }
+                    console.log("grimmer aspect: sharedStack3:", val);
+
                     if ( dataObjs && dataObjs.length > 0 ){
                         for ( var i = 0; i < dataObjs.length; i++ ){
+                            // 存起來
                             this.m_datas[i] = dataObjs[i];
+                            console.log("grimmer aspect data1");
                         }
                         if ( visibleData ){
                             this._dataLoadedCB();
                         }
                     }
+
+                    if (this.m_datas && this.m_datas.length > 0){
+                        console.log("grimmer aspect data2, setup m_scheduleZoomFit");
+                        // this.m_scheduleZoomFit =true;
+                    }
+
+                    console.log("grimmer aspect: sharedStack4:", val);
+
+                    //TODO
+
                     if ( !visibleData ){
                         //No images to show so set the view hidden.
                         if ( this.m_view !== null ){
@@ -418,6 +518,9 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                     var dataCmd = skel.Command.Data.CommandData.getInstance();
                     dataCmd.datasChanged();
                     this._initContextMenu();
+
+                    console.log("grimmer aspect: sharedStack, after dataLoadedCB");
+
                 }
                 catch( err ){
                     console.log( "DisplayWindowImage could not parse: "+val );
@@ -425,37 +528,41 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
                 }
             }
         },
-               
-     
+
+
         /**
          * Set the identifier for the server-side object that manages the stack.
          * @param id {String} - the server-side id of the object that manages the stack.
          */
         _setRegionId : function( id ){
+          console.log("grimmer DisplayWindowImage");
+
             this.m_regionId = id;
             this.m_sharedVarRegions = this.m_connector.getSharedVar( id );
             this.m_sharedVarRegions.addCB(this._sharedVarRegionsCB.bind(this));
             this._sharedVarRegionsCB();
-            
+
             var path = skel.widgets.Path.getInstance();
         	var regionDataId = id + path.SEP + path.DATA;
         	this.m_sharedVarRegionsData = this.m_connector.getSharedVar( regionDataId );
         	this.m_sharedVarRegionsData.addCB( this._sharedVarRegionsDataCB.bind(this));
         	this._sharedVarRegionsDataCB();
         },
-        
+
         /**
          * Set the identifier for the server-side object that manages the stack.
          * @param id {String} - the server-side id of the object that manages the stack.
          */
         _setStackId : function( id ){
+            console.log("grimmer DisplayWindowImage-stack");
+
             this.m_stackId = id;
             this.m_sharedVarStack = this.m_connector.getSharedVar( id );
             this.m_sharedVarStack.addCB(this._sharedVarStackCB.bind(this));
             this._sharedVarStackCB();
         },
-        
-        
+
+
         /**
          * Update the commands about clip settings.
          */
@@ -465,24 +572,24 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
             var clipValsCmd = skel.Command.Clip.CommandClipValues.getInstance();
             clipValsCmd.setClipValue( this.m_clipPercent );
         },
-        
-        
+
+
         /**
          * Implemented to initialize the context menu.
          */
         windowIdInitialized : function() {
             arguments.callee.base.apply(this, arguments);
-           
+
             this._registerControlsStack();
             this._registerControlsRegion();
             this._initStatistics();
             this._dataLoadedCB();
-            
+
             //Get the shared variable for preferences
             this.initializePrefs();
             this.m_imageControls.setId( this.getIdentifier());
         },
-        
+
         /**
          * Update from the server.
          * @param winObj {Object} - an object containing server side information values.
@@ -491,12 +598,15 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
             if ( winObj !== null ){
                 this.m_autoClip = winObj.autoClip;
                 this.m_clipPercent = winObj.clipValueMax - winObj.clipValueMin;
+                console.log("grimmer clip,max:",winObj.clipValueMax,";min:",winObj.clipValueMin);
+                //grimmer clip,max: 0.975 ;min: 0.025
             }
         },
-        
+
+        m_scheduleZoomFit : false,
         m_autoClip : false,
         m_clipPercent : 0,
-        
+
         m_regionButton : null,
         m_renderButton : null,
         m_drawCanvas : null,
@@ -507,7 +617,7 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
         m_sharedVarRegionsData : null,
         m_stackId : null,
         m_regionId : null,
-       
+
         m_view : null,
         m_viewContent : null,
         m_imageControls : null,


### PR DESCRIPTION
update (some things are needed re-fix):
ref: #80 
--
Will clean up some comments, experiment code, and some debug logs later. 

Actually, some of the changed/added on JS side can be done on the cpp side. But after some consideration, just to put on JS first. This thing can be discussed later. 

Change:
1. Show the whole image in the imageLoader window when open a new image file. 
2. Setup the minimal zoom level is to fit the window size. So users can not zoom out too much anymore. 
3. Change the behavior of resetZoom to show the whole image.

They all work well in 
1. axis-permutation status.
2. zoomAll mode, non-zoomAll and  This setting is in `Image settings -> Stack -> Pan/Zoom all`. 
3. Also, it should work well either checked status of `Image settings -> Canvas -> All Images` or unchecked status. 

Potential issues: 
1. JavaScript saves a copy of current zoom level, but may not be the same as the value stored in cpp side if cpp side does some extra things and let the setZoom fail. Need test more.  

2. [not done] Some values are needed to use stateChange to sync info. with cpp side, otherwise shared session may have bug, such as A share session with B, B zoom in, A need to get this info.

3. In zoom all mode, now we send one by one command for each file, the original way is to send one command and let cpp calculate itself, so the current way may result in duplicate rendering, since the current design is to render all so two commands will result 4 rendering. Need improvement. 
update: even only set new Zoom for 1 image in images, but `DrawStackSynchronizer::_getLoadableData.` may re-render all other image. 

ref: #66
ref: #64