### PR TITLE
WCSPlotter/drawTitle

### DIFF
--- a/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
@@ -330,9 +330,9 @@ AstWcsGridRenderService::renderNow()
 
     // draw title
     sgp.setPlotOption( "DrawTitle=0" );
-    //sgp.setPlotOption( QString( "Font(title)=%1" ).arg( Please set the font );
-    //sgp.setPlotOption( QString( "Size(title)=%1" ).arg( Please set the size );
-    //sgp.setPlotOption( QString( "Colour(title)=%1" ).arg( Please set the color);
+    //sgp.setPlotOption( QString( "Font(title)=%1" ).arg( Please set the font ));
+    //sgp.setPlotOption( QString( "Size(title)=%1" ).arg( Please set the size ));
+    //sgp.setPlotOption( QString( "Colour(title)=%1" ).arg( Please set the color));
     //sgp.setPlotOption( "TitleGap=0.0" );
     //sgp.setPlotOption(QString("Title=%1").arg( m().fitsName ));
 

--- a/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
@@ -250,10 +250,6 @@ AstWcsGridRenderService::renderNow()
     sgp.setOutputVGComposer( & m_vgc );
 
 //    sgp.setPlotOption( "tol=0.001" ); // this can slow down the grid rendering!!!
-    // draw title
-    sgp.setPlotOption( "DrawTitle=0" );
-    //sgp.setPlotOption( "TitleGap=0.0" );
-    //sgp.setPlotOption(QString("Title=%1").arg( m().fitsName ));
 
     if ( !m_gridLines ){
         sgp.setPlotOption( "Grid=0");
@@ -332,13 +328,15 @@ AstWcsGridRenderService::renderNow()
     sgp.setPlotOption( QString( "Colour(TextLab1)=%1" ).arg( si( Element::LabelText1 ) ) );
     sgp.setPlotOption( QString( "Colour(TextLab2)=%1" ).arg( si( Element::LabelText2 ) ) );
 
+    // draw title
+    sgp.setPlotOption( "DrawTitle=0" );
+    //sgp.setPlotOption( QString( "Font(title)=%1" ).arg( Please set the font );
+    //sgp.setPlotOption( QString( "Size(title)=%1" ).arg( Please set the size );
+    //sgp.setPlotOption( QString( "Colour(title)=%1" ).arg( Please set the color);
+    //sgp.setPlotOption( "TitleGap=0.0" );
+    //sgp.setPlotOption(QString("Title=%1").arg( m().fitsName ));
+
     sgp.setShadowPenIndex( si( Element::Shadow ) );
-
-
-
-//    sgp.setPlotOption( "Format(1)=\"+tms.10\"");
-//            sgp.setPlotOption( "Format(1)=\"gtms\"");
-    // grid density
     sgp.setDensityModifier( m_gridDensity );
 
 

--- a/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
@@ -28,6 +28,9 @@ struct AstWcsGridRenderService::Pimpl
     // fits header from the input image
     QStringList fitsHeader;
 
+    // fits file name
+    QString fitsName;
+
     // current sky CS
     Carta::Lib::KnownSkyCS knownSkyCS = Carta::Lib::KnownSkyCS::J2000;
 
@@ -93,6 +96,7 @@ AstWcsGridRenderService::setInputImage( Carta::Lib::Image::ImageInterface::Share
         FitsHeaderExtractor fhExtractor;
         fhExtractor.setInput( m_iimage );
         QStringList header = fhExtractor.getHeader();
+        QString fileName = fhExtractor.getFileName();
 
         // sanity check
         if ( header.size() < 1 ) {
@@ -106,6 +110,12 @@ AstWcsGridRenderService::setInputImage( Carta::Lib::Image::ImageInterface::Share
             std::sort(&header[0],&header[len-2]);
             m().fitsHeader = header;
         }
+
+        if(fileName != m().fitsName)
+        {
+            m().fitsName = fileName;
+        }
+
     }
 } // setInputImage
 
@@ -240,7 +250,10 @@ AstWcsGridRenderService::renderNow()
     sgp.setOutputVGComposer( & m_vgc );
 
 //    sgp.setPlotOption( "tol=0.001" ); // this can slow down the grid rendering!!!
+    // draw title
     sgp.setPlotOption( "DrawTitle=0" );
+    //sgp.setPlotOption( "TitleGap=0.0" );
+    //sgp.setPlotOption(QString("Title=%1").arg( m().fitsName ));
 
     if ( !m_gridLines ){
         sgp.setPlotOption( "Grid=0");

--- a/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
@@ -96,6 +96,10 @@ AstWcsGridRenderService::setInputImage( Carta::Lib::Image::ImageInterface::Share
         FitsHeaderExtractor fhExtractor;
         fhExtractor.setInput( m_iimage );
         QStringList header = fhExtractor.getHeader();
+        // Maybe, We can get the file name from "DataSource::_getFileName()"
+        // add a new menber fuction "AstWcsGridRenderService::setFileName"
+        // and remove "FitsHeaderExtractor::getFileName()"
+        // I think it will work when image is permuted
         QString fileName = fhExtractor.getFileName();
 
         // sanity check
@@ -334,7 +338,8 @@ AstWcsGridRenderService::renderNow()
     //sgp.setPlotOption( QString( "Size(title)=%1" ).arg( Please set the size ));
     //sgp.setPlotOption( QString( "Colour(title)=%1" ).arg( Please set the color));
     //sgp.setPlotOption( "TitleGap=0.0" );
-    //sgp.setPlotOption(QString("Title(1)=%1").arg( m().fitsName ));
+    //sgp.setPlotOption(QString("Title(1)=%1").arg( m().fitsName )); // for SKY-SPECTRUM image
+    //sgp.setPlotOption(QString("Title=%1").arg( m().fitsName ));    // for SKY , LINEAR image
 
     sgp.setShadowPenIndex( si( Element::Shadow ) );
     sgp.setDensityModifier( m_gridDensity );

--- a/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
@@ -334,7 +334,7 @@ AstWcsGridRenderService::renderNow()
     //sgp.setPlotOption( QString( "Size(title)=%1" ).arg( Please set the size ));
     //sgp.setPlotOption( QString( "Colour(title)=%1" ).arg( Please set the color));
     //sgp.setPlotOption( "TitleGap=0.0" );
-    //sgp.setPlotOption(QString("Title=%1").arg( m().fitsName ));
+    //sgp.setPlotOption(QString("Title(1)=%1").arg( m().fitsName ));
 
     sgp.setShadowPenIndex( si( Element::Shadow ) );
     sgp.setDensityModifier( m_gridDensity );

--- a/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.cpp
+++ b/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.cpp
@@ -19,6 +19,39 @@
 #include <casacore/coordinates/Coordinates/LinearCoordinate.h>
 #include <casacore/images/Images/ImageInterface.h>
 
+casa::ImageInterface < casa::Float > * InterfaceConverter(QStringList & errorInfo, Carta::Lib::Image::ImageInterface::SharedPtr cartaImage)
+{
+    casa::ImageInterface < casa::Float > *fii;
+
+    // was this created using CasaImageLoader plugin?
+    CCImageBase * base = dynamic_cast < CCImageBase * > ( & * cartaImage );
+    if ( base )
+    {
+        casa::LatticeBase * latticeBase = base-> getCasaImage();
+        if ( latticeBase )
+        {
+            // can we get float image interface ?
+            #ifndef Q_OS_MAC
+                fii = dynamic_cast < casa::ImageInterface < casa::Float > * > ( latticeBase );
+            #else
+                fii = static_cast < casa::ImageInterface < casa::Float > * > ( latticeBase );
+            #endif
+
+            if ( ! fii )
+            {
+                errorInfo << "Could not convert base to float image";
+            }
+        }
+        else
+        {
+            errorInfo << "Cannot produce FITS header for this image because"
+                     << "I have no idea where this image came from.";
+        }
+    }
+
+    return fii;
+}
+
 void FitsLine::_parse(QString &key, QString &value, QString &comment) {
     // key is the first 8 characters (trimmed)
     key = _raw.left(8).trimmed();
@@ -90,23 +123,7 @@ FitsHeaderExtractor::getHeader()
         return QStringList();
     }
 
-    QStringList result;
-
-    // was this created using CasaImageLoader plugin?
-    CCImageBase * base = dynamic_cast < CCImageBase * > ( & * m_cartaImage );
-    if ( base ) {
-        casa::LatticeBase * latticeBase = base-> getCasaImage();
-        if ( latticeBase ) {
-
-            // casacore's fits parser
-            result = _CasaFitsConverter( latticeBase );
-        }
-        else {
-            m_errors << "Cannot produce FITS header for this image because"
-                     << "I have no idea where this image came from.";
-        }
-    }
-
+    QStringList result = _CasaFitsConverter();
     return result;
 } // getHeader
 
@@ -120,24 +137,21 @@ FitsHeaderExtractor::getErrors()
 // tree. There are probably unused pieces of code/weird comments,etc...
 /// \todo clean up the code below
 QStringList
-FitsHeaderExtractor::_CasaFitsConverter( casa::LatticeBase * lbase )
+FitsHeaderExtractor::_CasaFitsConverter()
 {
-    // can we get float image interface ?
-    casa::ImageInterface < casa::Float > * fii = nullptr;
-    #ifndef Q_OS_MAC
-        fii = dynamic_cast < casa::ImageInterface < casa::Float > * > ( lbase );
-    #else
-        fii = static_cast < casa::ImageInterface < casa::Float > * > ( lbase );
-    #endif
 
-    if ( ! fii ) {
-        m_errors << "Could not convert base to float image";
+    // can we get float image interface ?
+    casa::ImageInterface < casa::Float > * fii = InterfaceConverter(m_errors, m_cartaImage);
+
+    if ( ! fii )
+    {
         return QStringList();
     }
 
     // alias image to be reference to the image, since the original code used a reference
     // rather than a pointer and I'm too lazy to convert everything to pointers :)
-    casa::ImageInterface < casa::Float > & image = * fii;
+    casa::ImageInterface < casa::Float > & image = *InterfaceConverter(m_errors, m_cartaImage);
+
 
     using namespace casa;
 

--- a/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.cpp
+++ b/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.cpp
@@ -114,6 +114,30 @@ FitsHeaderExtractor::setInput( Carta::Lib::Image::ImageInterface::SharedPtr imag
     m_cartaImage = image;
 }
 
+QString FitsHeaderExtractor::getFileName()
+{
+    m_errors.clear();
+    if ( ! m_cartaImage ) {
+        m_errors << "Input is NULL";
+        return QString();
+    }
+
+    // can we get float image interface ?
+    casa::ImageInterface < casa::Float > * fii = InterfaceConverter(m_errors, m_cartaImage);
+
+    if ( ! fii )
+    {
+        return QString();
+    }
+
+    // alias image to be reference to the image, since the original code used a reference
+    // rather than a pointer and I'm too lazy to convert everything to pointers :)
+    casa::ImageInterface < casa::Float > & image = *fii;
+
+    QString result = image.name(1).c_str();
+    return result;
+}
+
 QStringList
 FitsHeaderExtractor::getHeader()
 {
@@ -150,7 +174,7 @@ FitsHeaderExtractor::_CasaFitsConverter()
 
     // alias image to be reference to the image, since the original code used a reference
     // rather than a pointer and I'm too lazy to convert everything to pointers :)
-    casa::ImageInterface < casa::Float > & image = *InterfaceConverter(m_errors, m_cartaImage);
+    casa::ImageInterface < casa::Float > & image = *fii;
 
 
     using namespace casa;

--- a/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.h
+++ b/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.h
@@ -33,7 +33,7 @@ public:
 private:
 
     QString _FITSKeyWordParser(QString _raw);
-    QStringList _CasaFitsConverter( casa::LatticeBase * lbase);
+    QStringList _CasaFitsConverter();
 
     Carta::Lib::Image::ImageInterface::SharedPtr m_cartaImage = nullptr;
     QStringList m_errors;

--- a/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.h
+++ b/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.h
@@ -27,6 +27,8 @@ public:
     /// \note all entries are padded/truncated to 80 chars
     QStringList getHeader();
 
+    QString getFileName();
+
     /// \return list of errors (if any)
     QStringList getErrors();
 


### PR DESCRIPTION
This pull request is based on #42.

And, this pull request is related to #52.

"DrawTitle" is ready in WCSPlotter plugin but may affect other parts of code.

Known issue:
1. ~~FontSize can not be changed.~~ [fixed in commit 2e524d3 ]
2. ~~It only works on 2-D images.~~ [fixed in commit 8bdfb8c ]
3. It may affect aspect ratio. [#52]
4. DrawTitle may fail when image is permuted. (RA-channel)

If someone wants to enable this function, please modify the following code:

``` diff
In carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
AstWcsGridRenderService::renderNow()
    // draw title
-    sgp.setPlotOption( "DrawTitle=0" );
-    //sgp.setPlotOption( QString( "Font(title)=%1" ).arg( Please set the font );
-    //sgp.setPlotOption( QString( "Size(title)=%1" ).arg( Please set the size );
-    //sgp.setPlotOption( QString( "Colour(title)=%1" ).arg( Please set the color);
-    //sgp.setPlotOption( "TitleGap=0.0" );
-    //sgp.setPlotOption(QString("Title(1)=%1").arg( m().fitsName )); // for SKY-SPECTRUM image
-    //sgp.setPlotOption(QString("Title=%1").arg( m().fitsName ));    // for SKY , LINEAR image
+    sgp.setPlotOption( "DrawTitle=1" );
+    sgp.setPlotOption( QString( "Font(title)=%1" ).arg( Please set the font );
+    sgp.setPlotOption( QString( "Size(title)=%1" ).arg( Please set the size );
+    sgp.setPlotOption( QString( "Colour(title)=%1" ).arg( Please set the color);
+    sgp.setPlotOption( "TitleGap=0.0" );
+    sgp.setPlotOption(QString("Title(1)=%1").arg( m().fitsName )); // for SKY-SPECTRUM image
+    sgp.setPlotOption(QString("Title=%1").arg( m().fitsName ));    // for SKY , LINEAR image

```

```diff
In carta/cpp/core/Data/Image/Grid/DataGrid.cpp
-  const int DataGrid::MARGIN_DEFAULT = 10;
+  const int DataGrid::MARGIN_DEFAULT = 30;

```