### PR TITLE
Mark / create "make install" 

### DIFF
--- a/carta/carta.pro
+++ b/carta/carta.pro
@@ -14,11 +14,18 @@ dbg( "===---------------------------------------------====")
 
 TEMPLATE = subdirs
 SUBDIRS += cpp
-SUBDIRS += scriptedClient
-SUBDIRS += scripts
+# SUBDIRS += scriptedClient
+# SUBDIRS += scripts
 
 OTHER_FILES += readme.txt uncrustify.cfg
 
+#
+# Apply make install option to copy the config folder and its file to the build directory
+#
+install_config.path = $${OUT_PWD}
+install_config.files += config/
+
+INSTALLS += install_config
 
 # make sure user did not specify debug version...
 # it's probably harmless, but that's probably not what the user wanted

--- a/carta/config/config.json
+++ b/carta/config/config.json
@@ -1,0 +1,15 @@
+{
+    "_comment" : "List of plugin directories",
+    "pluginDirs": [
+        "$(APPDIR)/../plugins",
+        "$(APPDIR)/../../../../plugins"
+    ],
+    "disabledPlugins" : ["casaCore-2.0.1"],
+    "plugins": {
+        "PCacheSqlite3" : {
+            "dbPath": "/tmp/pcache.sqlite"
+        }
+    },
+    "qtDecorations" : "true"
+}
+


### PR DESCRIPTION
This branch is in response to the issue raised by CNOCycle, where I merge and improve previous pull requested branches: "mark/addGridLinesOption", mark/removeGridLines", "mark/reLocateConfigJson", "grimmer/fixIncompatibleAxesCrash" and "grimmer/fixAnimatorCrash". The changed files compared to my latest pull request are 

$CARTAWORKHOME/CARTAvis/carta/config/config.json
$CARTAWORKHOME/CARTAvis/carta/carta.pro  and  
$CARTAWORKHOME/CARTAvis/carta/cpp/core/CmdLine.cpp

We have used "make -j2" to build the Carta viewer, now we can use "make install" command to copy the necessary files or data in the building directory. For example, in my case I copy the main configuration folder and file "config/config.json" to the root of building directory. So users can built their own Carta viewer in any directory without been affected by the absolute path that set in the Carta code.
