### PR TITLE
Mark / install config.json

### DIFF
--- a/carta/carta.pro
+++ b/carta/carta.pro
@@ -14,8 +14,9 @@ dbg( "===---------------------------------------------====")
 
 TEMPLATE = subdirs
 SUBDIRS += cpp
-SUBDIRS += scriptedClient
-SUBDIRS += scripts
+SUBDIRS += config
+# SUBDIRS += scriptedClient
+# SUBDIRS += scripts
 
 OTHER_FILES += readme.txt uncrustify.cfg
 

--- a/carta/config/config.json
+++ b/carta/config/config.json
@@ -1,0 +1,14 @@
+{
+    "_comment" : "List of plugin directories",
+    "pluginDirs": [
+        "$(APPDIR)/../plugins",
+        "$(APPDIR)/../../../../plugins"
+    ],
+    "disabledPlugins" : ["casaCore-2.0.1"],
+    "plugins": {
+        "PCacheSqlite3" : {
+            "dbPath": "/tmp/pcache.sqlite"
+        }
+    },
+    "qtDecorations" : "true"
+}

--- a/carta/config/config.pro
+++ b/carta/config/config.pro
@@ -1,0 +1,10 @@
+TEMPLATE = aux
+
+MYFILES = $$files($${PWD}/config.json)
+copy_files.name = copy project files
+copy_files.input = MYFILES
+copy_files.output = ${QMAKE_FILE_BASE}${QMAKE_FILE_EXT}
+copy_files.commands = ${COPY_FILE} ${QMAKE_FILE_IN} ${QMAKE_FILE_OUT}
+copy_files.CONFIG += no_link target_predeps
+QMAKE_EXTRA_COMPILERS += copy_files
+

--- a/carta/cpp/core/CmdLine.cpp
+++ b/carta/cpp/core/CmdLine.cpp
@@ -7,6 +7,9 @@
 #include <QDebug>
 #include <QCommandLineParser>
 #include <QDir>
+#include <QCoreApplication>
+#include <QFile>
+#include <qglobal.h>
 
 static QString cartaGetEnv( const QString & name)
 {
@@ -45,11 +48,20 @@ ParsedInfo parse(const QStringList & argv)
         info.m_configFilePath = cartaGetEnv( "CONFIG");
     }
     // if the config file was not specified neither through command line or environment
-    // assign a default value
+    // assign a default value (search the config file under the home directory first)
     if( info.m_configFilePath.isEmpty()) {
         info.m_configFilePath = QDir::homePath() + "/.cartavis/config.json";
     }
 
+    // if the config file was not specified neither through command line or environment
+    // assign a default value (search the config file under the carta build directory second)
+    if (!QFile::exists(info.m_configFilePath)) {
+#ifdef Q_OS_LINUX
+        info.m_configFilePath = QCoreApplication::applicationDirPath() + "/../../config/config.json";
+#else
+        info.m_configFilePath = QCoreApplication::applicationDirPath() + "/../../../../../config/config.json";
+#endif
+    }
 
     // get html path
     if( parser.isSet( htmlPathOption)) {

--- a/carta/cpp/core/CmdLine.cpp
+++ b/carta/cpp/core/CmdLine.cpp
@@ -63,7 +63,7 @@ ParsedInfo parse(const QStringList & argv)
         }
 #else
         info.m_configFilePath = QCoreApplication::applicationDirPath() + "/../../../../../config/config.json";
-if (!QFile::exists(info.m_configFilePath)) {
+        if (!QFile::exists(info.m_configFilePath)) {
             info.m_configFilePath = QCoreApplication::applicationDirPath() + "/../Resources/config/config.json";
         }
 #endif

--- a/carta/cpp/core/CmdLine.cpp
+++ b/carta/cpp/core/CmdLine.cpp
@@ -58,8 +58,14 @@ ParsedInfo parse(const QStringList & argv)
     if (!QFile::exists(info.m_configFilePath)) {
 #ifdef Q_OS_LINUX
         info.m_configFilePath = QCoreApplication::applicationDirPath() + "/../../config/config.json";
+        if (!QFile::exists(info.m_configFilePath)) {
+            info.m_configFilePath = QCoreApplication::applicationDirPath() + "/../etc/config/config.json";
+        }
 #else
         info.m_configFilePath = QCoreApplication::applicationDirPath() + "/../../../../../config/config.json";
+if (!QFile::exists(info.m_configFilePath)) {
+            info.m_configFilePath = QCoreApplication::applicationDirPath() + "/../Resources/config/config.json";
+        }
 #endif
     }
 

--- a/carta/cpp/core/CmdLine.h
+++ b/carta/cpp/core/CmdLine.h
@@ -17,7 +17,7 @@ public:
     /// returns the path to the configuaration file
     /// set either through '--cfg file' option or $CARTAVIS_CONFIG environment
     /// if config file was not provided, the default is used, which is:
-    /// $HOME/.cartavis/config.json
+    /// $HOME/.cartavis/config.json (1st option) or $(carta build)/config/config.json (2nd option)
     QString configFilePath() const;
 
     /// returns the path to the html file, only used by the desktop version


### PR DESCRIPTION
I modify the file "carta/carta.pro", add two files "carta/config/config.json" and "carta/config/config.pro" in this branch. So the main configuration file will automatically install in the Carta build directory as the default set. 