### PR TITLE
fix for re-use gridline

### DIFF
--- a/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
@@ -501,7 +501,10 @@ void AstWcsGridRenderService::setAxisDisplayInfo( std::vector<Carta::Lib::AxisDi
         for ( int i = 0; i < infoCount; i++ ){
             if ( displayInfos[i] != m_axisDisplayInfos[i] ){
                 m_axisDisplayInfos[i] = displayInfos[i];
-                //m_vgValid = false;
+                if(displayInfos[i].getAxisType() != Carta::Lib::AxisInfo::KnownType::SPECTRAL)
+                {
+                    m_vgValid = false;
+                }
             }
         }
     }


### PR DESCRIPTION
In pull request #14, #6, it may not get the right result.
Gridline can be reused only when switching channels