### PR TITLE
Mark / Change Item Names

### DIFF
--- a/carta/config/config.json
+++ b/carta/config/config.json
@@ -4,7 +4,7 @@
         "$(APPDIR)/../plugins",
         "$(APPDIR)/../../../../plugins"
     ],
-    "disabledPlugins" : ["casaCore-2.0.1"],
+    "disabledPlugins" : ["tester1", "clock1", "blurpy"],
     "plugins": {
         "PCacheSqlite3" : {
             "dbPath": "/tmp/pcache.sqlite"

--- a/carta/cpp/CartaLib/StatInfo.cpp
+++ b/carta/cpp/CartaLib/StatInfo.cpp
@@ -105,10 +105,10 @@ QString StatInfo::toString( StatType statType){
         label = "Median Restoring Beam";
     }
     else if ( statType == StatType::RightAscensionRange ){
-        label = "Right Ascension Range";
+        label = "RA Range";
     }
     else if ( statType == StatType::DeclinationRange ){
-        label = "Declination Range";
+        label = "Dec Range";
     }
     else if ( statType == StatType::FrequencyRange ){
         label = "Frequency Range";

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -53,7 +53,7 @@ const QString Controller::CURSOR = "formattedCursorCoordinates";
 const QString Controller::CENTER = "center";
 const QString Controller::IMAGE = "image";
 const QString Controller::PAN_ZOOM_ALL = "panZoomAll";
-const QString Controller::PLUGIN_NAME = "CasaImageLoader";
+const QString Controller::PLUGIN_NAME = "ImageViewer";
 const QString Controller::STACK_SELECT_AUTO = "stackAutoSelect";
 
 

--- a/carta/cpp/desktop/MainWindow.cpp
+++ b/carta/cpp/desktop/MainWindow.cpp
@@ -40,12 +40,12 @@ MainWindow::MainWindow( )
 
 #ifdef Q_OS_LINUX
     // add Carta option
-    QMenu *cartaMenu = menuBar()->addMenu(tr("&Carta"));
+    QMenu *cartaMenu = menuBar()->addMenu(tr("&CARTA"));
     cartaMenu->addAction(tr("Copyright and License"), this, SLOT(cartaLicense()));
     cartaMenu->addAction(tr("Version 0.9"));
 #else
     // add Carta option
-    QMenu *cartaMenu = menuBar()->addMenu(tr("&Carta"));
+    QMenu *cartaMenu = menuBar()->addMenu(tr("&CARTA"));
     //cartaMenu->addAction(tr("&About"), this, SLOT(cartaLicense()));
 
     QAction *aboutCopyright = new QAction(tr("Copyright and License"), this);

--- a/carta/cpp/desktop/MainWindow.cpp
+++ b/carta/cpp/desktop/MainWindow.cpp
@@ -15,6 +15,7 @@ MainWindow::MainWindow( )
     m_progress = 0;
 
     QNetworkProxyFactory::setUseSystemConfiguration(true);
+    setUnifiedTitleAndToolBarOnMac(true);
 
     m_view = new QWebView(this);
     connect(m_view, SIGNAL(loadFinished(bool)), SLOT(adjustLocation()));
@@ -42,16 +43,22 @@ MainWindow::MainWindow( )
     QMenu *cartaMenu = menuBar()->addMenu(tr("&Carta"));
     cartaMenu->addAction(tr("Copyright and License"), this, SLOT(cartaLicense()));
     cartaMenu->addAction(tr("Version 0.9"));
-
-    QMenu *toolsMenu = menuBar()->addMenu(tr("&Tools"));
-    toolsMenu->addAction(tr("Show JS Console"), this, SLOT(showJsConsole()));
-
-    // add Help option
-    QMenu *helpMenu = menuBar()->addMenu(tr("&Help"));
-    helpMenu->addAction(tr("GitHub Home"), this, SLOT(helpUrlGitHubHome()));
-    helpMenu->addAction(tr("GitHub Wiki"), this, SLOT(helpUrlGitHubWiki()));
-    helpMenu->addAction(tr("GitHub Issues"), this, SLOT(helpUrlGitHubIssues()));
 #else
+    // add Carta option
+    QMenu *cartaMenu = menuBar()->addMenu(tr("&Carta"));
+    //cartaMenu->addAction(tr("&About"), this, SLOT(cartaLicense()));
+
+    QAction *aboutCopyright = new QAction(tr("Copyright and License"), this);
+    connect(aboutCopyright, SIGNAL(triggered()), this, SLOT(cartaLicense()));
+    aboutCopyright->setMenuRole(QAction::ApplicationSpecificRole);
+    cartaMenu->addAction(aboutCopyright);
+
+    QAction *aboutVersion = new QAction(tr("Version 0.9"), this);
+    aboutVersion->setMenuRole(QAction::ApplicationSpecificRole);
+    cartaMenu->addAction(aboutVersion);
+#endif
+
+    // add Tool option
     QMenu *toolsMenu = menuBar()->addMenu(tr("&Tools"));
     toolsMenu->addAction(tr("Show JS Console"), this, SLOT(showJsConsole()));
 
@@ -60,12 +67,6 @@ MainWindow::MainWindow( )
     helpMenu->addAction(tr("GitHub Home"), this, SLOT(helpUrlGitHubHome()));
     helpMenu->addAction(tr("GitHub Wiki"), this, SLOT(helpUrlGitHubWiki()));
     helpMenu->addAction(tr("GitHub Issues"), this, SLOT(helpUrlGitHubIssues()));
-
-    // add About option
-    QMenu *cartaMenu = menuBar()->addMenu(tr("&About"));
-    cartaMenu->addAction(tr("Copyright and License"), this, SLOT(cartaLicense()));
-    cartaMenu->addAction(tr("Version 0.9"));
-#endif
 
     setCentralWidget(m_view);
     setUnifiedTitleAndToolBarOnMac(true);

--- a/carta/cpp/desktop/desktop.pro
+++ b/carta/cpp/desktop/desktop.pro
@@ -44,6 +44,9 @@ else{
     PRE_TARGETDEPS += $$OUT_PWD/../core/libcore.so
 }
 
+# set the name of Desktop Application
+TARGET = CARTA
+
 # for release builds
 carta_qrc {
 

--- a/carta/html5/common/skel/source/class/skel/simulation/Util.py
+++ b/carta/html5/common/skel/source/class/skel/simulation/Util.py
@@ -255,7 +255,7 @@ def load_image_different_window(unittest, driver, imageName):
 
 def load_image_windowIndex( unittest,driver,imageName,windowIndex):
     # Ensure that there is a new image window
-    windowId = "CasaImageLoader"+str(windowIndex)
+    windowId = "ImageViewer"+str(windowIndex)
     imageWindow = WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.ID, windowId)))
     ActionChains(driver).double_click( imageWindow ).perform()
 

--- a/carta/html5/common/skel/source/class/skel/simulation/tWindow.py
+++ b/carta/html5/common/skel/source/class/skel/simulation/tWindow.py
@@ -43,14 +43,14 @@ class tWindow(unittest.TestCase):
         ActionChains(driver).click( minimizeButton ).perform()
 
         # Verify that there is a Restore button on the status bar and no DisplayWindowImage.
-        restoreButton = WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//div[@qxclass='qx.ui.toolbar.MenuButton']/div[contains(text(), 'Restore: CasaImageLoader')]/..")))
+        restoreButton = WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.XPATH, "//div[@qxclass='qx.ui.toolbar.MenuButton']/div[contains(text(), 'Restore: ImageViewer')]/..")))
 
         # Restore the window.  Verify the restore button is gone from the status bar and there is a DisplayWindowImage
         ActionChains(driver).click( restoreButton ).perform()
 
         #Check that the clipping menu item is no longer available
         try:
-            restoreLabel = WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.XPATH, "//div[@qxclass='qx.ui.toolbar.MenuButton']/div[contains(text(), 'Restore: CasaImageLoader')]")))
+            restoreLabel = WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.XPATH, "//div[@qxclass='qx.ui.toolbar.MenuButton']/div[contains(text(), 'Restore: ImageViewer')]")))
             self.assertTrue( False, "Should not be able to locate the restore image loader button")
         except Exception:
             print "Test restore button was successfully removed"

--- a/carta/html5/common/skel/source/class/skel/widgets/Path.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Path.js
@@ -58,7 +58,7 @@ qx.Class.define("skel.widgets.Path", {
         AUTO_CLIP : "setAutoClip",
         BASE_PATH : "",
         CARTA : "CartaObjects",
-        CASA_LOADER : "CasaImageLoader",
+        CASA_LOADER : "ImageViewer",
         CHANNEL_UNITS : "",
         //CENTER : "center",
         CLIP_VALUE : "setClipValue",

--- a/carta/html5/desktop/desktopIndex.html
+++ b/carta/html5/desktop/desktopIndex.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
-    <title>CartaVis</title>
+    <title>CARTA</title>
 
     <!--<base href="qrc:///html5/"/>-->
     <base href="../"/>

--- a/carta/html5/desktop/desktopIndexRelease.html
+++ b/carta/html5/desktop/desktopIndexRelease.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
-    <title>CartaVis</title>
+    <title>CARTA</title>
 
     <!--<base href="qrc:///html5/"/>-->
     <script src="libs.js"></script>

--- a/carta/html5/server/serverIndex.html
+++ b/carta/html5/server/serverIndex.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
-    <title>CartaVis</title>
+    <title>CARTA</title>
 
     <!--<base href="/Apps/carta/html5/"/>-->
 

--- a/carta/html5/server/serverIndexRelease.html
+++ b/carta/html5/server/serverIndexRelease.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
-    <title>CartaVis</title>
+    <title>CARTA</title>
 
     <script type="text/javascript">
         function getURLParameter(name) {

--- a/carta/scripts/setupDesktopForMac.sh
+++ b/carta/scripts/setupDesktopForMac.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+export CARTAWORKHOME=`pwd`
+
+cd $CARTAWORKHOME/CARTAvis
+export CARTABUILDHOME=`pwd`
+
+mkdir -p $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/
+cp $CARTABUILDHOME/build/cpp/core/libcore.1.dylib $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/
+
+# need to rm for qt creator 4.2, otherwise when build+run together will result in core/libcore.1.dylib not able find out qwt
+rm $CARTABUILDHOME/build/cpp/core/libcore.1.dylib
+cp $CARTABUILDHOME/build/cpp/CartaLib/libCartaLib.1.dylib $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/
+
+install_name_tool -change qwt.framework/Versions/6/qwt $CARTABUILDHOME/ThirdParty/qwt-6.1.2/lib/qwt.framework/Versions/6/qwt $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/MacOS/CARTA
+install_name_tool -change qwt.framework/Versions/6/qwt $CARTABUILDHOME/ThirdParty/qwt-6.1.2/lib/qwt.framework/Versions/6/qwt $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/libcore.1.dylib
+
+# not sure the effect of the below line, try comment
+# install_name_tool -change libplugin.dylib $CARTABUILDHOME/build/cpp/plugins/CasaImageLoader/libplugin.dylib $CARTABUILDHOME/build/cpp/plugins/ImageStatistics/libplugin.dylib
+install_name_tool -change libcore.1.dylib  $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/libcore.1.dylib $CARTABUILDHOME/build/cpp/plugins/ImageStatistics/libplugin.dylib
+
+install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/libCartaLib.1.dylib $CARTABUILDHOME/build/cpp/plugins/ImageStatistics/libplugin.dylib
+install_name_tool -change libcore.1.dylib  $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/libcore.1.dylib $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/MacOS/CARTA
+install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/libCartaLib.1.dylib $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/MacOS/CARTA
+install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/libCartaLib.1.dylib $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/libcore.1.dylib
+
+for f in `find . -name libplugin.dylib`; do install_name_tool -change libcore.1.dylib  $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/libcore.1.dylib $f; done
+for f in `find . -name libplugin.dylib`; do install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/build/cpp/desktop/CARTA.app/Contents/Frameworks/libCartaLib.1.dylib $f; done
+for f in `find . -name "*.dylib"`; do install_name_tool -change libwcs.5.15.dylib  $CARTABUILDHOME/ThirdParty/wcslib/lib/libwcs.5.15.dylib $f; echo $f; done
+


### PR DESCRIPTION
1. The changed item names are 
    "Right Ascension Range" --> "RA Range"
    "Declination Range" --> "Dec Range"
    "CasaImageLoader" --> "ImageViewer"

2. The name of desktop/server application is also changed: 
    "CartaVis" --> "CARTA"

3. The tool bar for Mac is rearranged:
    moving "Copyright and License" and "Version 0.9" into the CARTA application tool bar.

4. Add a script "carta/scripts/setupDesktopForMac.sh" in order to setup the new CARTA name app for Mac. 
