### PR TITLE
File list in animator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ build*/
 PureWeb*.lic
 
 carta.pro.user
+node_modules

--- a/carta/cpp/core/Data/Animator/Animator.cpp
+++ b/carta/cpp/core/Data/Animator/Animator.cpp
@@ -549,10 +549,14 @@ void Animator::_resetAnimationParameters( int selectedImage ){
             m_animators[Selection::IMAGE]->setUpperBound(maxImages);
         }
         if ( selectedImage >= 0 ){
-            QStringList fileList;
-//            m_animators[Selection::IMAGE]->setFrame( selectedImage );
-            m_animators[Selection::IMAGE]->setFrameAddFileListInfo( selectedImage, fileList);
 
+            Controller* controller = _getControllerSelected();
+            if (controller != nullptr) {
+                //AddFileListInfo
+                m_animators[Selection::IMAGE]->setFrame( selectedImage, controller->getFileList());
+            } else {
+                m_animators[Selection::IMAGE]->setFrame( selectedImage );
+            }
         }
         else {
             int index = m_animators[Selection::IMAGE]->getFrame();
@@ -755,4 +759,3 @@ Animator::~Animator(){
 
 }
 }
-

--- a/carta/cpp/core/Data/Animator/Animator.cpp
+++ b/carta/cpp/core/Data/Animator/Animator.cpp
@@ -549,7 +549,10 @@ void Animator::_resetAnimationParameters( int selectedImage ){
             m_animators[Selection::IMAGE]->setUpperBound(maxImages);
         }
         if ( selectedImage >= 0 ){
-            m_animators[Selection::IMAGE]->setFrame( selectedImage );
+            QStringList fileList;
+//            m_animators[Selection::IMAGE]->setFrame( selectedImage );
+            m_animators[Selection::IMAGE]->setFrameAddFileListInfo( selectedImage, fileList);
+
         }
         else {
             int index = m_animators[Selection::IMAGE]->getFrame();

--- a/carta/cpp/core/Data/Animator/AnimatorType.cpp
+++ b/carta/cpp/core/Data/Animator/AnimatorType.cpp
@@ -282,7 +282,7 @@ QString AnimatorType::setFrameStep( int step ){
     return result;
 }
 
-QString setFrame( int frameIndex, QStringList fileList ) {
+QString AnimatorType::setFrame( int frameIndex, QStringList fileList ) {
     QString result;
     //Set our state to reflect the new image.
     if ( frameIndex >= 0 ){

--- a/carta/cpp/core/Data/Animator/AnimatorType.cpp
+++ b/carta/cpp/core/Data/Animator/AnimatorType.cpp
@@ -282,6 +282,22 @@ QString AnimatorType::setFrameStep( int step ){
     return result;
 }
 
+QString setFrame( int frameIndex, QStringList fileList ) {
+    QString result;
+    //Set our state to reflect the new image.
+    if ( frameIndex >= 0 ){
+        int oldIndex = m_select->getIndex();
+        if ( frameIndex != oldIndex ){
+            result = m_select->setIndex( frameIndex, fileList );
+        }
+    }
+    else {
+        result="Frame index must be nonnegative: "+QString::number(frameIndex);
+    }
+    return result;
+}
+
+
 QString AnimatorType::setFrame( int frameIndex ){
     QString result;
     //Set our state to reflect the new image.

--- a/carta/cpp/core/Data/Animator/AnimatorType.h
+++ b/carta/cpp/core/Data/Animator/AnimatorType.h
@@ -76,7 +76,6 @@ public:
      */
     QString setFrame( int frameIndex, QStringList fileList );
 
-
     /**
      * Set the animation speed.
      * @param rate a positive rate indicator.

--- a/carta/cpp/core/Data/Animator/AnimatorType.h
+++ b/carta/cpp/core/Data/Animator/AnimatorType.h
@@ -72,6 +72,12 @@ public:
     QString setFrame( int frameIndex );
 
     /**
+     * Same as setFrame but add FileListInfo to let animators show file list
+     */
+    QString setFrame( int frameIndex, QStringList fileList );
+
+
+    /**
      * Set the animation speed.
      * @param rate a positive rate indicator.
      */

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -149,12 +149,7 @@ QString Controller::_addDataImage(const QString& fileName, bool* success ) {
 
 
 QStringList Controller::getFileList(){
-
-    //QString& fileName
-    QStringList result;
-    //result.append;
-    return result;
-
+  return m_stack->_getFileList();
 }
 
 

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -122,6 +122,7 @@ void Controller::addContourSet( std::shared_ptr<DataContours> contourSet){
 	m_stack->_addContourSet( contourSet );
 }
 
+
 QString Controller::addData(const QString& fileName, bool* success) {
 	*success = false;
 	QString result = DataFactory::addData( this, fileName, success );
@@ -144,7 +145,17 @@ QString Controller::_addDataImage(const QString& fileName, bool* success ) {
     return result;
 }
 
+//void Controller::setFrameImage( int val) {
 
+
+QStringList Controller::getFileList(){
+
+    //QString& fileName
+    QStringList result;
+    //result.append;
+    return result;
+
+}
 
 
 QString Controller::applyClips( double minIntensityPercentile, double maxIntensityPercentile ){
@@ -239,7 +250,7 @@ void Controller::_contourSetRemoved( const QString setName ){
 void Controller::_displayAxesChanged(std::vector<AxisInfo::KnownType> displayAxisTypes,
         bool applyAll ){
     m_stack->_displayAxesChanged( displayAxisTypes, applyAll );
-    emit axesChanged();
+    emit axesChanged(); //animator has this signal axesChanged, also frameChanged
     _updateCursorText( true );
 }
 
@@ -1190,6 +1201,7 @@ QString Controller::setLayerName( const QString& id, const QString& name ){
     return result;
 }
 
+// 20170420, no one use yet
 QString Controller::setLayersSelected( const QStringList indices ){
     QString result;
     if ( indices.size() > 0 ){

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -115,20 +115,15 @@ Controller::Controller( const QString& path, const QString& id ) :
 	m_regionControls.reset( regionObj );
 }
 
-
-
-
 void Controller::addContourSet( std::shared_ptr<DataContours> contourSet){
 	m_stack->_addContourSet( contourSet );
 }
-
 
 QString Controller::addData(const QString& fileName, bool* success) {
 	*success = false;
 	QString result = DataFactory::addData( this, fileName, success );
     return result;
 }
-
 
 QString Controller::_addDataImage(const QString& fileName, bool* success ) {
     QString result = m_stack->_addDataImage( fileName, success );
@@ -145,13 +140,9 @@ QString Controller::_addDataImage(const QString& fileName, bool* success ) {
     return result;
 }
 
-//void Controller::setFrameImage( int val) {
-
-
 QStringList Controller::getFileList(){
   return m_stack->_getFileList();
 }
-
 
 QString Controller::applyClips( double minIntensityPercentile, double maxIntensityPercentile ){
     QString result;

--- a/carta/cpp/core/Data/Image/Controller.h
+++ b/carta/cpp/core/Data/Image/Controller.h
@@ -61,6 +61,12 @@ class Controller: public QObject, public Carta::State::CartaObject,
 public:
 
     /**
+     * let Anmiator get file List
+     */
+    QStringList getFileList();
+
+
+    /**
      * Clear the view.
      */
     void clear();

--- a/carta/cpp/core/Data/Image/Controller.h
+++ b/carta/cpp/core/Data/Image/Controller.h
@@ -65,7 +65,6 @@ public:
      */
     QStringList getFileList();
 
-
     /**
      * Clear the view.
      */
@@ -538,7 +537,7 @@ public:
      * Update the pan and zoom level settings.
      * @param centerX the screen x-coordinate where the zoom was centered.
      * @param centerY the screen y-coordinate where the zoom was centered.
-     * @param zoomLevel zoom level 
+     * @param zoomLevel zoom level
      * @param layerId specify the id of a layerData to update its Pan and Zoom level
      */
     void updatePanZoomLevel( double centerX, double centerY, double zoomLevel, double layerId );

--- a/carta/cpp/core/Data/Image/Layer.cpp
+++ b/carta/cpp/core/Data/Image/Layer.cpp
@@ -100,6 +100,10 @@ QStringList Layer::_getLayerIds( ) const {
     return idList;
 }
 
+QString Layer::_getFileName() {
+    return "";
+}
+
 QString Layer::_getLayerName() const {
     return m_state.getValue<QString>( Util::NAME );
 }

--- a/carta/cpp/core/Data/Image/Layer.h
+++ b/carta/cpp/core/Data/Image/Layer.h
@@ -514,6 +514,7 @@ protected:
     virtual QString _setFileName( const QString& fileName, bool* success );
 
     virtual QString _getFileName();
+    
     /**
      * Give the layer (a more user-friendly) name.
      * @param id - an identifier for the layer to rename.

--- a/carta/cpp/core/Data/Image/Layer.h
+++ b/carta/cpp/core/Data/Image/Layer.h
@@ -513,7 +513,7 @@ protected:
      */
     virtual QString _setFileName( const QString& fileName, bool* success );
 
-
+    virtual QString _getFileName();
     /**
      * Give the layer (a more user-friendly) name.
      * @param id - an identifier for the layer to rename.

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -935,6 +935,9 @@ void LayerData::_resetPan( ){
     _setPan( panValue.x(), panValue.y() );
 }
 
+QString LayerData::_getFileName() {
+    return m_dataSource->_getFileName();
+}
 
 QString LayerData::_setFileName( const QString& fileName, bool * success ){
     QString result = m_dataSource->_setFileName( fileName, success );

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -323,6 +323,8 @@ protected:
      */
     virtual void _resetZoom() Q_DECL_OVERRIDE;
 
+    virtual QString _getFileName();
+
     /**
      * Attempts to load an image file.
      * @param fileName - an identifier for the location of the image file.

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -231,8 +231,6 @@ int Stack::_getFrameUpperBound( AxisInfo::KnownType axisType ) const {
 
 QStringList Stack::_getFileList() {
 
-    // ref: _getLayerIds
-
     QStringList nameList;
     for ( std::shared_ptr<Layer> layer : m_children ){
         nameList.append( layer->_getFileName());

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -229,6 +229,13 @@ int Stack::_getFrameUpperBound( AxisInfo::KnownType axisType ) const {
     return upperBound;
 }
 
+QStringList getFileList() {
+    QStringList nameList;
+    for ( std::shared_ptr<Layer> layer : m_children ){
+        nameList.append( layer->_getFileName());
+    }
+    return nameList;
+}
 
 std::vector<int> Stack::_getImageSlice() const {
     std::vector<int> result;

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -229,7 +229,10 @@ int Stack::_getFrameUpperBound( AxisInfo::KnownType axisType ) const {
     return upperBound;
 }
 
-QStringList getFileList() {
+QStringList Stack::_getFileList() {
+
+    // ref: _getLayerIds
+
     QStringList nameList;
     for ( std::shared_ptr<Layer> layer : m_children ){
         nameList.append( layer->_getFileName());

--- a/carta/cpp/core/Data/Image/Stack.h
+++ b/carta/cpp/core/Data/Image/Stack.h
@@ -81,6 +81,8 @@ private slots:
 
 private:
 
+    QStringList _getFileList();
+
     QString _addDataImage(const QString& fileName, bool* success );
 
     void _displayAxesChanged(std::vector<Carta::Lib::AxisInfo::KnownType> displayAxisTypes, bool applyAll );

--- a/carta/cpp/core/Data/Selection.cpp
+++ b/carta/cpp/core/Data/Selection.cpp
@@ -39,7 +39,7 @@ void Selection::_initializeStates(){
     m_state.insertValue<int>( HIGH_KEY, 1);
     m_state.insertValue<int>( HIGH_KEY_USER, 0 );
     m_state.insertValue<int>( INDEX_KEY, 0);
-    m_state.insertArray( FILELIST, 0 );
+    m_state.insertArray(FILELIST, 0);
     m_state.flushState();
 }
 
@@ -182,8 +182,6 @@ void Selection::setLowerBound(int newLowerBound) {
 
 void Selection::setFileList(QStringList fileList) {
 
-    // 有絕對path !!!
-
     int dataCount = fileList.count();
 
     int oldDataCount = m_state.getArraySize( FILELIST );
@@ -192,22 +190,14 @@ void Selection::setFileList(QStringList fileList) {
       m_state.resizeArray(FILELIST, dataCount, Carta::State::StateInterface::PreserveNone );
     }
 
-    //     m_state.insertArray( LayerGroup::LAYERS, 0 );
-//    m_state.insertArray( SUPPORTED_AXES, 0);
-    // layers, stats, shape!!
-
     for (int i = 0; i < dataCount; i++) {
        QString absFileName = fileList[i];
-//      QString fileName = "test";
-//      QString dataKey = Carta::State::UtilState::getLookup( FILELIST, i);
-      //m_state.setObject(FILELIST, fileName);
-
-       QString lookup = Carta::State::UtilState::getLookup( FILELIST, i );
-
        QFileInfo fileInfo(absFileName);
        QString fileName(fileInfo.fileName());
 
-       m_state.setValue<QString>(lookup, fileName );
+       QString lookup = Carta::State::UtilState::getLookup( FILELIST, i );
+
+       m_state.setValue<QString>(lookup, fileName);
 
     }
 
@@ -223,8 +213,8 @@ QString Selection::setIndex(int frameValue, QStringList fileList) {
             if ( oldValue != frameValue ){
                 m_state.setValue<int>(INDEX_KEY, frameValue);
 
-                setFileList(fileList);
                 // Append fileList info
+                setFileList(fileList);
 
                 m_state.flushState();
                 emit indexChanged( );

--- a/carta/cpp/core/Data/Selection.cpp
+++ b/carta/cpp/core/Data/Selection.cpp
@@ -175,7 +175,32 @@ void Selection::setLowerBound(int newLowerBound) {
 }
 
 
+QString Selection::setIndex(int frameValue, QStringList fileList) {
+    QString result;
+    if ( frameValue >= 0 ){
+        int upperBound = getUpperBoundUser();
+        int lowerBound = getLowerBoundUser();
+        if ( lowerBound <= frameValue && frameValue <= upperBound ){
+            int oldValue = m_state.getValue<int>(INDEX_KEY );
+            if ( oldValue != frameValue ){
+                m_state.setValue<int>(INDEX_KEY, frameValue);
 
+                // Append fileList info
+
+                m_state.flushState();
+                emit indexChanged( );
+            }
+        }
+        else {
+            result = "Selection index "+ QString::number(frameValue)+" must be between "+
+                    QString::number(lowerBound) + " and " + QString::number(upperBound);
+        }
+    }
+    else {
+        result = "Selection index must be nonnegative: "+ QString::number( frameValue );
+    }
+    return result;
+}
 
 QString Selection::setIndex(int frameValue) {
     QString result;

--- a/carta/cpp/core/Data/Selection.h
+++ b/carta/cpp/core/Data/Selection.h
@@ -65,6 +65,8 @@ public:
      */
     QString setIndex( int val);
 
+    QString setIndex( int val, QStringList fileList );
+
     /**
      * Sets the lower bound of the selection.
      * @param newLowerBound a nonnegative integer representing the new selection lower bound.

--- a/carta/cpp/core/Data/Selection.h
+++ b/carta/cpp/core/Data/Selection.h
@@ -67,6 +67,9 @@ public:
 
     QString setIndex( int val, QStringList fileList );
 
+    void setFileList(QStringList fileList);
+
+
     /**
      * Sets the lower bound of the selection.
      * @param newLowerBound a nonnegative integer representing the new selection lower bound.
@@ -112,6 +115,7 @@ public:
     const static QString REGION;
     //Identifier for a channel.
     static const QString CHANNEL;
+    static const QString FILELIST;
 
     static bool m_registered;
 

--- a/carta/cpp/core/Data/Selection.h
+++ b/carta/cpp/core/Data/Selection.h
@@ -69,7 +69,6 @@ public:
 
     void setFileList(QStringList fileList);
 
-
     /**
      * Sets the lower bound of the selection.
      * @param newLowerBound a nonnegative integer representing the new selection lower bound.

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
@@ -4,7 +4,7 @@
 
 /*******************************************************************************
  * @ignore( mImport)
- * 
+ *
  * @asset(skel/icons/movie-next-frame16.png)
  * @asset(skel/icons/movie-pause16.png)
  * @asset(skel/icons/movie-play-reverse16.png)
@@ -22,7 +22,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
 
     /**
      * Constructor.
-     * 
+     *
      * @param title {String} descriptor for what will be animated (Channel,Region, Image, etc).
      * @param winId {String} the unique server id.
      */
@@ -30,14 +30,17 @@ qx.Class.define("skel.boundWidgets.Animator", {
         this.base(arguments);
         this.m_title = title;
         this.m_winId = winId;
+        this.testCount = 0;
+
+        console.log("grimmer animator create");
 
         // Create the GUI
         this._initUI();
-        
+
         // Create the shared variable for the settings
         this._initSharedVars();
     },
-    
+
     events : {
         "movieStart" : "qx.event.type.Data",
         "movieStop" : "qx.event.type.Data"
@@ -63,7 +66,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 }
             }
         },
-        
+
 
         /**
          * Decrease the frame value.
@@ -83,7 +86,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
             if (this.m_endJumpRadio.getValue()) {
                 if (this.m_frame > lowerBound) {
                     val = lowerBound;
-                } 
+                }
                 else {
                     val = this.m_highBoundsSpinner.getValue();
                 }
@@ -131,7 +134,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 }
             }
         },
-        
+
         /**
          * Updates the user set lower and upper bounds based on server values.
          * @param start {Number} - the user settable lower bound.
@@ -156,10 +159,101 @@ qx.Class.define("skel.boundWidgets.Animator", {
            if ( this.m_slider.getValue() != this.m_frame ){
                 this.m_slider.setValue( this.m_frame );
            }
-           var valStr = this.m_frame + "";
-           if ( this.m_indexText.getValue() !== valStr ){
-                this.m_indexText.setValue( valStr );
-           }
+
+           this._fileSelectorUIChange()
+        },
+
+        _getFileIndex : function(file) {
+            //1.aj.fits ->aj.fits.
+            // file.replace(/^[0-9]*\./,"");
+            var info  = file.match(/[0-9]*/);
+            if (info) {
+                return info[0];
+            }
+            return null;
+        }
+
+        _addFileIndex : function(fileList) {
+
+            //aj.fits-> 1.aj.fits
+            var len = fileList.length;
+            var newFileList = fileList.map( function(file, i) {
+                return i+"."+file;
+            });
+
+            return newFileList;
+        }
+
+        _fileSelectorUIInit: function() {
+
+            // this.m_fileCombo = new qx.ui.form.SelectBox();
+            this.m_fileCombo = new qx.ui.form.ComboBox();
+
+            this.m_fileCombo = new skel.boundWidgets.ComboBox();
+
+            this.m_fileCombo.setToolTipText( "Select the file");
+
+            //changeValue
+            // this.m_selectListener = this.addListener( "changeSelection", this._sendCmd, this );
+            this.m_fileCombo.addListener( "comboChanged", function(){
+
+                var data = this.m_fileCombo.getValue();
+                var index = this._getFileIndex(data);
+                if (index) {
+                    this._sendFrame(index);
+                }
+
+                // var selections = this.getSelection();
+                // if ( selections.length > 0 ){
+                //
+                // }
+
+                // var selectIndex = this.m_imageCombo.getIndex();
+                // var data = {
+                //     index: selectIndex
+                // }
+
+            }, this );
+
+
+            // this.m_indexText = new skel.widgets.CustomUI.NumericTextField(0,null);
+            // this.m_indexText.setIntegerOnly( true );
+            // this.m_indexText.setToolTipText( "Set the current value.");
+            // this.m_indexText.setTextId( this.m_title +"IndexText"); //for testing
+            // this.m_indexText.setValue( "0");
+            // this.m_indexText.addListener("textChanged", function(e) {
+            //     var value = this.m_indexText.getValue();
+            //     var valueInt = parseInt(value);
+            //     if (!isNaN(valueInt)) {
+            //         if (valueInt <= this.m_slider.getMaximum() && valueInt >= this.m_slider.getMinimum()) {
+            //             if ( valueInt != this.m_frame ){
+            //                 this._sendFrame(valueInt);
+            //             }
+            //         }
+            //     }
+            // }, this);
+        },
+
+        // fileList and possible sendFrame
+        _fileSelectorUIChange: function() {
+
+            // var indexStr = this.m_frame + "";
+
+            // if ( this.m_indexText.getValue() !== indexStr ){
+            //      this.m_indexText.setValue( indexStr );
+            // }
+
+            // 2. 現在是 同時得到fileList, 沒有的話要set
+            // 1. 原本是得到變化後的 index,改text
+            var newFileList = this._addFileIndex(this.m_fileList);
+            this.m_fileCombo.setComboItems(newFileList);
+            if (this.m_frame < newFileList.length) {
+                this.m_fileCombo.setComboValue(newFileList[this.m_frame]);
+            }
+
+            // default:
+            // this.m_indexText.setValue( "0");
+
         },
 
         /**
@@ -179,6 +273,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
             var valStr = limit + "";
             if ( this.m_endLabel.getValue() !== valStr ){
                 this.m_endLabel.setValue( valStr);
+                console.log("grimmer animator1 setVAlue:", valStr);
             }
         },
 
@@ -221,7 +316,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 this.m_slider.setMinimum( this.m_frameLow );
             }
         },
-        
+
         /**
          * Return the type of the animator.
          * @return {String} - the type of animator.
@@ -251,7 +346,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 this._sendFrame( highBound );
             }
         },
-        
+
         /**
          * Notify the server if the user set high bound changes.
          */
@@ -277,6 +372,10 @@ qx.Class.define("skel.boundWidgets.Animator", {
          * Increase the frame value taking into account end behavior.
          */
         _increaseValue : function() {
+            if(this.testCount>98){
+                return;
+            }
+
             var val = this.m_frame + this.getFrameStep();
 
             var upperBound = this.m_highBoundsSpinner.getValue();
@@ -292,7 +391,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
             if (val > upperBound) {
                 if (this.m_endWrapRadio.getValue()) {
                     val = this.m_lowBoundsSpinner.getValue();
-                } 
+                }
                 else if (this.m_endReverseRadio.getValue()) {
                     // If we are playing, reverse play. otherwise decrease the
                     // value
@@ -305,6 +404,8 @@ qx.Class.define("skel.boundWidgets.Animator", {
                     console.log("Unhandled wrap val=" + val);
                 }
             }
+
+            console.log("grimmer JS send frame:", val);
             this._sendFrame(val);
         },
 
@@ -316,12 +417,12 @@ qx.Class.define("skel.boundWidgets.Animator", {
             var buttonComposite = this._initToolBar();
             var sliderComposite = this._initSliderControls();
             this._initSettings();
-            
+
             this.m_content = new qx.ui.container.Composite();
             this.m_content.setLayout( new qx.ui.layout.VBox(2));
             this._setLayout(new qx.ui.layout.VBox(0));
             this._add( this.m_content );
-            
+
             this.m_content.add(locationComposite);
             this.m_content.add(sliderComposite);
             this.m_content.add(buttonComposite);
@@ -335,24 +436,11 @@ qx.Class.define("skel.boundWidgets.Animator", {
          * @return {qx.ui.container.Composite} a container containing the location UI.
          */
         _initLocation : function() {
+
             var titleLabel = new qx.ui.basic.Label(this.m_title);
             skel.widgets.TestID.addTestId( titleLabel, this.m_title+"AnimatorType");
-            this.m_indexText = new skel.widgets.CustomUI.NumericTextField(0,null);
-            this.m_indexText.setIntegerOnly( true );
-            this.m_indexText.setToolTipText( "Set the current value.");
-            this.m_indexText.setTextId( this.m_title +"IndexText");
-            this.m_indexText.setValue( "0");
-            this.m_indexText.addListener("textChanged", function(e) {
-                var value = this.m_indexText.getValue();
-                var valueInt = parseInt(value);
-                if (!isNaN(valueInt)) {
-                    if (valueInt <= this.m_slider.getMaximum() && valueInt >= this.m_slider.getMinimum()) {
-                        if ( valueInt != this.m_frame ){
-                            this._sendFrame(valueInt);
-                        }
-                    }
-                }
-            }, this);
+
+            this._fileSelectorUIInit();
 
             var endLabel = new qx.ui.basic.Label("<= ");
             this.m_endLabel = new qx.ui.basic.Label("");
@@ -360,9 +448,13 @@ qx.Class.define("skel.boundWidgets.Animator", {
             var locationComposite = new qx.ui.container.Composite();
             locationComposite.setLayout(new qx.ui.layout.HBox(5));
             locationComposite.add(titleLabel);
-            locationComposite.add(this.m_indexText);
+
+            locationComposite.add(this.m_fileCombo)
+            // locationComposite.add(this.m_indexText);
+
             locationComposite.add(endLabel);
             locationComposite.add(this.m_endLabel);
+            console.log("grimmer animator1 init:", this.m_endLabel);
             locationComposite.add(new qx.ui.core.Spacer(10, 10), {
                 flex : 1
             });
@@ -373,8 +465,8 @@ qx.Class.define("skel.boundWidgets.Animator", {
             locationComposite.add(this.m_settingsCheck);
             return locationComposite;
         },
-        
-        
+
+
 
         /**
          * Initialize the additional less-used settings in the UI.
@@ -388,7 +480,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                     this._sendEndBehavior(this.m_endWrapRadio.getLabel());
                 }
             }, this);
-            
+
             this.m_endReverseRadio = new qx.ui.form.RadioButton("Reverse");
             skel.widgets.TestID.addTestId( this.m_endReverseRadio, this.m_title+"ReverseRadioButton");
             this.m_endReverseRadio.setToolTipText( "Change direction when reaching an end value.");
@@ -397,7 +489,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                     this._sendEndBehavior(this.m_endReverseRadio.getLabel());
                 }
             }, this);
-            
+
             this.m_endJumpRadio = new qx.ui.form.RadioButton("Jump");
             skel.widgets.TestID.addTestId( this.m_endJumpRadio, this.m_title+"JumpRadioButton");
             this.m_endJumpRadio.setToolTipText( "Move from one end to the other end.");
@@ -406,7 +498,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                     this._sendEndBehavior(this.m_endJumpRadio.getLabel());
                 }
             }, this);
-           
+
             var endRadioGroup = new qx.ui.form.RadioGroup();
             endRadioGroup.add(this.m_endWrapRadio, this.m_endReverseRadio, this.m_endJumpRadio);
 
@@ -450,9 +542,9 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 flex : 1
             });
         },
-        
- 
-        
+
+
+
 
         /**
          * Initialize the shared variable for the settings.
@@ -466,8 +558,8 @@ qx.Class.define("skel.boundWidgets.Animator", {
             var regCmd = this.m_winId + pathDict.SEP_COMMAND + "registerAnimator";
             this.m_connector.sendCommand( regCmd, paramMap, this._registrationCB(this));
         },
-        
-        
+
+
         /**
          * Initialize the shared variable for the selection.
          */
@@ -477,7 +569,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
             var regCmd = this.m_animId +pathDict.SEP_COMMAND + "getSelection";
             this.m_connector.sendCommand( regCmd, "", this._selectionCB(this));
         },
-        
+
 
         /**
          * Initialize the slider controls.
@@ -504,7 +596,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                     this._sendFrame( sliderValue );
                 }
             }, this);
-           
+
             //Added because of issue #154.  If you click somewhere in the slider
             //it should move to that position.
             this.m_slider.addListener( "click", function(ev){
@@ -522,7 +614,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
             }, this );
 
             this.m_highBoundsSpinner = new qx.ui.form.Spinner(0, 100, 100);
-            this.m_highBoundsSpinner.addListener("changeValue", this._highChanged, this); 
+            this.m_highBoundsSpinner.addListener("changeValue", this._highChanged, this);
             skel.widgets.TestID.addTestId( this.m_highBoundsSpinner, this.m_title+"UpperBoundSpin");
             this.m_highBoundsSpinner.setToolTipText( "Set an upper bound for valid values");
             var sliderComposite = new qx.ui.container.Composite();
@@ -564,7 +656,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
             skel.widgets.TestID.addTestId( this.m_revStepButton, this.m_title+"TapeDeckDecrement");
             this.m_revStepButton.setToolTipText( "Decrease by one step value.");
             this.m_revStepButton.addListener("execute", this._decrementValue, this);
-            
+
             this.m_stopButton = new qx.ui.toolbar.Button("",
                     "skel/icons/movie-stop16.png");
             skel.widgets.TestID.addTestId( this.m_stopButton, this.m_title+"TapeDeckStopAnimation");
@@ -622,7 +714,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
 
         /**
          * Show or hide the less-used additional animator settings.
-         * 
+         *
          * @param maximize {Boolean} true if all the additional settings should
          *                be shown; false otherwise.
          */
@@ -638,7 +730,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 }
             }
         },
-        
+
         /**
          * One of the animators has started playing a movie; set movie widgets disabled
          * if it is not us.
@@ -649,7 +741,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 this._setWidgetsEnabled( false );
             }
         },
-        
+
         /**
          * One of the animators has stopped playing a movie; set movie widgets disabled
          * if it is not us.
@@ -687,7 +779,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 this.m_timer.start();
             }
         },
-        
+
         /**
          * Initialize the shared variable that controls the settings.
          * @param anObject {skel.boundWidgets.Animator}.
@@ -703,8 +795,8 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 anObject._initSharedVarsSelection();
             };
         },
-        
-        
+
+
         /**
          * Initialization of the shared variable that controls the selection.
          * @param anObject {skel.boundWidgets.Animator}.
@@ -717,7 +809,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 anObject._selectionResetCB();
             };
         },
-        
+
         /**
          * Callback for a change in the selection.
          * @param val {String} the JSON representing the animation selection.
@@ -729,6 +821,12 @@ qx.Class.define("skel.boundWidgets.Animator", {
                     if ( this._frameCB ){
                         try {
                             var frameObj = JSON.parse( val );
+
+                            if (frameObj.fileList) {
+                                console.log("grimmer animatorjs:", frameObj);
+                                //fileList: ["aJ.fits", "502nmos.fits"]
+                                this.m_fileList = frameObj.fileList;
+                            }
                             this.m_noSends = true;
                             this.m_frame = frameObj.frame;
                             this.m_frameLow = frameObj.frameStart;
@@ -770,6 +868,8 @@ qx.Class.define("skel.boundWidgets.Animator", {
         _sendFrame : function(frameIndex) {
             if (this.m_connector !== null && !this.m_noSends) {
                 if ( this.m_animId !== null && this.m_animId.length > 0 ){
+
+                    this.testCount++;
                     var paramMap = frameIndex;
                     var path = skel.widgets.Path.getInstance();
                     var setFramePath = this.m_animId  + path.SEP_COMMAND + "setFrame";
@@ -777,7 +877,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 }
             }
         },
-        
+
         /**
          * Send a command to the server indicating the new frame rate.
          */
@@ -791,7 +891,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 }
             }
         },
-        
+
         /**
          * Send a command to the server indicating the new frame step size.
          */
@@ -805,7 +905,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 }
             }
         },
-        
+
         /**
          * Send a command to the server to change the visibility of the
          * animator settings.
@@ -820,7 +920,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 }
             }
         },
-        
+
         /**
          * Send the user set lower bound to the server.
          */
@@ -834,7 +934,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 }
             }
         },
-        
+
         /**
          * Send the user set upper bound to the server.
          */
@@ -848,7 +948,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 }
             }
         },
-        
+
         /**
          * Set the animator available/unavailable for display to the user.
          * @param available {boolean} - true if the animator is available for display to
@@ -876,7 +976,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 this.m_timer.setInterval(interval);
             }
         },
-        
+
         /**
          * Callback from the server to update the visibility of animator
          * settings.
@@ -889,14 +989,15 @@ qx.Class.define("skel.boundWidgets.Animator", {
             this._minMaxSettings( visible );
             this.m_settingsListener = this.m_settingsCheck.addListener(skel.widgets.Path.CHANGE_VALUE, this._sendSettingsCmd, this);
         },
-        
+
         /**
          * Change the enabled status of the movie widgets.
          * @param enable {boolean} - true if the widgets should be enabled; false otherwise.
          */
         _setWidgetsEnabled : function( enable ){
             this.m_slider.setEnabled( enable );
-            this.m_indexText.setEnabled( enable );
+            //this.m_indexText.setEnabled( enable );
+            this.m_fileCombo.setEnabled(enable);
             this.m_playButton.setEnabled( enable );
             this.m_revPlayButton.setEnabled( enable );
             this.m_startButton.setEnabled( enable );
@@ -939,6 +1040,8 @@ qx.Class.define("skel.boundWidgets.Animator", {
         m_slider : null,
         m_timerListener : null,
         m_indexText : null,
+        m_fileCombo: null,
+        m_fileList: null,
         m_endWrapRadio : null,
         m_stepSpin : null,
         m_endReverseRadio : null,
@@ -959,7 +1062,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
         m_sharedVar : null,
         m_sharedVarSelection : null,
         m_identifier : null,
-        
+
         m_available : true,
         m_frame : null,
         m_frameLow : null,

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
@@ -32,8 +32,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
         this.m_winId = winId;
         this.testCount = 0;
 
-        console.log("grimmer animator create");
-
         // Create the GUI
         this._initUI();
 
@@ -163,9 +161,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
            this._fileSelectorUIChange()
         },
 
-        _getFileIndex : function(file) {
-            //1.aj.fits ->aj.fits.
-            // file.replace(/^[0-9]*\./,"");
+        _getFileIndex: function(file) {
             var info  = file.match(/[0-9]*/);
             if (info) {
                 return info[0];
@@ -173,7 +169,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
             return null;
         },
 
-        _addFileIndex : function(fileList) {
+        _addFileIndex: function(fileList) {
 
             var len = fileList.length;
             var newFileList = fileList.map( function(file, i) {
@@ -183,7 +179,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
             return newFileList;
         },
 
-
         _fileSelectorUIInit: function() {
 
             if (this.m_title == "Image") {
@@ -191,7 +186,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 this.m_fileCombo = new skel.boundWidgets.ComboBox();
                 this.m_fileCombo.setToolTipText( "Select the file");
                 this.m_fileCombo.addListener( "comboChanged", function(){
-
                     var data = this.m_fileCombo.getValue();
                     var index = this._getFileIndex(data);
                     if (index) {
@@ -227,13 +221,10 @@ qx.Class.define("skel.boundWidgets.Animator", {
             }
         },
 
-
         // fileList and possible sendFrame
         _fileSelectorUIChange: function() {
 
             if (this.m_title == "Image") {
-                // 2. 現在是 同時得到fileList, 沒有的話要set
-                // 1. 原本是得到變化後的 index,改text
                 var newFileList = this._addFileIndex(this.m_fileList);
                 this.m_fileCombo.setComboItems(newFileList);
                 if (this.m_frame < newFileList.length) {
@@ -264,7 +255,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
             var valStr = limit + "";
             if ( this.m_endLabel.getValue() !== valStr ){
                 this.m_endLabel.setValue( valStr);
-                console.log("grimmer animator1 setVAlue:", valStr);
             }
         },
 
@@ -396,7 +386,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 }
             }
 
-            console.log("grimmer JS send frame:", val);
             this._sendFrame(val);
         },
 
@@ -444,7 +433,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
 
             locationComposite.add(endLabel);
             locationComposite.add(this.m_endLabel);
-            console.log("grimmer animator1 init:", this.m_endLabel);
             locationComposite.add(new qx.ui.core.Spacer(10, 10), {
                 flex : 1
             });
@@ -990,7 +978,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
             if (this.m_fileCombo) {
                 this.m_fileCombo.setEnabled(enable);
             }
-            
+
             this.m_playButton.setEnabled( enable );
             this.m_revPlayButton.setEnabled( enable );
             this.m_startButton.setEnabled( enable );

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
@@ -202,7 +202,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                     var valueInt = parseInt(value);
                     if (!isNaN(valueInt)) {
                         if (valueInt <= this.m_slider.getMaximum() && valueInt >= this.m_slider.getMinimum()) {
-                            if ( valueInt != this.m_frame ){
+                            if ( valueInt !== this.m_frame ){
                                 this._sendFrame(valueInt);
                             }
                         }

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
@@ -175,7 +175,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
 
         _addFileIndex : function(fileList) {
 
-            //aj.fits-> 1.aj.fits
             var len = fileList.length;
             var newFileList = fileList.map( function(file, i) {
                 return i+"."+file;
@@ -184,76 +183,68 @@ qx.Class.define("skel.boundWidgets.Animator", {
             return newFileList;
         },
 
+
         _fileSelectorUIInit: function() {
 
-            // this.m_fileCombo = new qx.ui.form.SelectBox();
-            this.m_fileCombo = new qx.ui.form.ComboBox();
+            if (this.m_title == "Image") {
+                this.m_fileCombo = new qx.ui.form.ComboBox();
+                this.m_fileCombo = new skel.boundWidgets.ComboBox();
+                this.m_fileCombo.setToolTipText( "Select the file");
+                this.m_fileCombo.addListener( "comboChanged", function(){
 
-            this.m_fileCombo = new skel.boundWidgets.ComboBox();
+                    var data = this.m_fileCombo.getValue();
+                    var index = this._getFileIndex(data);
+                    if (index) {
+                        this._sendFrame(index);
+                    }
 
-            this.m_fileCombo.setToolTipText( "Select the file");
-
-            //changeValue
-            // this.m_selectListener = this.addListener( "changeSelection", this._sendCmd, this );
-            this.m_fileCombo.addListener( "comboChanged", function(){
-
-                var data = this.m_fileCombo.getValue();
-                var index = this._getFileIndex(data);
-                if (index) {
-                    this._sendFrame(index);
-                }
-
-                // var selections = this.getSelection();
-                // if ( selections.length > 0 ){
-                //
-                // }
-
-                // var selectIndex = this.m_imageCombo.getIndex();
-                // var data = {
-                //     index: selectIndex
-                // }
-
-            }, this );
-
-
-            // this.m_indexText = new skel.widgets.CustomUI.NumericTextField(0,null);
-            // this.m_indexText.setIntegerOnly( true );
-            // this.m_indexText.setToolTipText( "Set the current value.");
-            // this.m_indexText.setTextId( this.m_title +"IndexText"); //for testing
-            // this.m_indexText.setValue( "0");
-            // this.m_indexText.addListener("textChanged", function(e) {
-            //     var value = this.m_indexText.getValue();
-            //     var valueInt = parseInt(value);
-            //     if (!isNaN(valueInt)) {
-            //         if (valueInt <= this.m_slider.getMaximum() && valueInt >= this.m_slider.getMinimum()) {
-            //             if ( valueInt != this.m_frame ){
-            //                 this._sendFrame(valueInt);
-            //             }
-            //         }
-            //     }
-            // }, this);
+                }, this );
+            } else {
+                this.m_indexText = new skel.widgets.CustomUI.NumericTextField(0,null);
+                this.m_indexText.setIntegerOnly( true );
+                this.m_indexText.setToolTipText( "Set the current value.");
+                this.m_indexText.setTextId( this.m_title +"IndexText"); //for testing
+                this.m_indexText.setValue( "0");
+                this.m_indexText.addListener("textChanged", function(e) {
+                    var value = this.m_indexText.getValue();
+                    var valueInt = parseInt(value);
+                    if (!isNaN(valueInt)) {
+                        if (valueInt <= this.m_slider.getMaximum() && valueInt >= this.m_slider.getMinimum()) {
+                            if ( valueInt != this.m_frame ){
+                                this._sendFrame(valueInt);
+                            }
+                        }
+                    }
+                }, this);
+            }
         },
+
+        _addFileSelectionUItoComposite: function(locationComposite) {
+            if (this.m_title == "Image") {
+                locationComposite.add(this.m_fileCombo);
+            } else {
+                locationComposite.add(this.m_indexText);
+            }
+        },
+
 
         // fileList and possible sendFrame
         _fileSelectorUIChange: function() {
 
-            // var indexStr = this.m_frame + "";
-
-            // if ( this.m_indexText.getValue() !== indexStr ){
-            //      this.m_indexText.setValue( indexStr );
-            // }
-
-            // 2. 現在是 同時得到fileList, 沒有的話要set
-            // 1. 原本是得到變化後的 index,改text
-            var newFileList = this._addFileIndex(this.m_fileList);
-            this.m_fileCombo.setComboItems(newFileList);
-            if (this.m_frame < newFileList.length) {
-                this.m_fileCombo.setComboValue(newFileList[this.m_frame]);
+            if (this.m_title == "Image") {
+                // 2. 現在是 同時得到fileList, 沒有的話要set
+                // 1. 原本是得到變化後的 index,改text
+                var newFileList = this._addFileIndex(this.m_fileList);
+                this.m_fileCombo.setComboItems(newFileList);
+                if (this.m_frame < newFileList.length) {
+                    this.m_fileCombo.setComboValue(newFileList[this.m_frame]);
+                }
+            } else {
+                var indexStr = this.m_frame + "";
+                if ( this.m_indexText.getValue() !== indexStr ){
+                     this.m_indexText.setValue( indexStr );
+                }
             }
-
-            // default:
-            // this.m_indexText.setValue( "0");
-
         },
 
         /**
@@ -449,8 +440,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
             locationComposite.setLayout(new qx.ui.layout.HBox(5));
             locationComposite.add(titleLabel);
 
-            locationComposite.add(this.m_fileCombo)
-            // locationComposite.add(this.m_indexText);
+            this._addFileSelectionUItoComposite(locationComposite);
 
             locationComposite.add(endLabel);
             locationComposite.add(this.m_endLabel);
@@ -465,8 +455,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
             locationComposite.add(this.m_settingsCheck);
             return locationComposite;
         },
-
-
 
         /**
          * Initialize the additional less-used settings in the UI.
@@ -823,8 +811,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
                             var frameObj = JSON.parse( val );
 
                             if (frameObj.fileList) {
-                                console.log("grimmer animatorjs:", frameObj);
-                                //fileList: ["aJ.fits", "502nmos.fits"]
                                 this.m_fileList = frameObj.fileList;
                             }
                             this.m_noSends = true;
@@ -996,8 +982,15 @@ qx.Class.define("skel.boundWidgets.Animator", {
          */
         _setWidgetsEnabled : function( enable ){
             this.m_slider.setEnabled( enable );
-            //this.m_indexText.setEnabled( enable );
-            this.m_fileCombo.setEnabled(enable);
+
+            if (this.m_indexText) {
+                this.m_indexText.setEnabled( enable );
+            }
+
+            if (this.m_fileCombo) {
+                this.m_fileCombo.setEnabled(enable);
+            }
+            
             this.m_playButton.setEnabled( enable );
             this.m_revPlayButton.setEnabled( enable );
             this.m_startButton.setEnabled( enable );

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
@@ -30,7 +30,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
         this.base(arguments);
         this.m_title = title;
         this.m_winId = winId;
-        this.testCount = 0;
 
         // Create the GUI
         this._initUI();
@@ -182,7 +181,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
         _fileSelectorUIInit: function() {
 
             if (this.m_title == "Image") {
-                this.m_fileCombo = new qx.ui.form.ComboBox();
                 this.m_fileCombo = new skel.boundWidgets.ComboBox();
                 this.m_fileCombo.setToolTipText( "Select the file");
                 this.m_fileCombo.addListener( "comboChanged", function(){
@@ -353,9 +351,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
          * Increase the frame value taking into account end behavior.
          */
         _increaseValue : function() {
-            if(this.testCount>98){
-                return;
-            }
 
             var val = this.m_frame + this.getFrameStep();
 
@@ -843,7 +838,6 @@ qx.Class.define("skel.boundWidgets.Animator", {
             if (this.m_connector !== null && !this.m_noSends) {
                 if ( this.m_animId !== null && this.m_animId.length > 0 ){
 
-                    this.testCount++;
                     var paramMap = frameIndex;
                     var path = skel.widgets.Path.getInstance();
                     var setFramePath = this.m_animId  + path.SEP_COMMAND + "setFrame";

--- a/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
+++ b/carta/html5/common/skel/source/class/skel/boundWidgets/Animator.js
@@ -171,7 +171,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
                 return info[0];
             }
             return null;
-        }
+        },
 
         _addFileIndex : function(fileList) {
 
@@ -182,7 +182,7 @@ qx.Class.define("skel.boundWidgets.Animator", {
             });
 
             return newFileList;
-        }
+        },
 
         _fileSelectorUIInit: function() {
 


### PR DESCRIPTION
Previous:
Used a textField to show the current image and switch it to switch in animators. But no file name information. Only index part. 

Now:
Use a combobox to switch and include the file name information of each file. 

There are two ways to add file list in animators. 
1. Send stack if to animator related UI (e.g. animator.js or DisplayWindowAnimator.js), then they can use this id to get the stack information of the related images which having file list. But the problem is that DisplayWindowImage.js parse the stack info and store inside. but not store somewhere others can access. So other objects need to use this stack id to get the raw string from DesktopConnector.js ( or server connector), then parse again. 

2. The current solution, Controller.cpp sends data into Animator.cpp , AnimatorType.cpp, Selection.cpp , then flush the file list info to Animator.js. (e.g. Animator.js is related to AnimatorType.cpp). 

p.s. 
this issue uses qx.ui.form.ComboBox, not qx.ui.form.SelectBox. It is because the latter one will not dismiss automatically. 

