### PR TITLE
Calculate the percentile only for Intensity stoke by default and add UI to switch stoke

### DIFF
--- a/carta/cpp/core/Algorithms/quantileAlgorithms.h
+++ b/carta/cpp/core/Algorithms/quantileAlgorithms.h
@@ -55,7 +55,8 @@ quantiles2pixels(
     std::vector < Scalar > allValues;
     view.forEach(
         [& allValues] ( const Scalar & val ) {
-            if ( ! std::isnan( val ) ) {
+            // check if the value from raw data is finite
+            if ( std::isfinite( val ) ) {
                 allValues.push_back( val );
             }
         }
@@ -87,10 +88,13 @@ quantiles2pixels(
                 if( inp <= v) cnt ++;
             }
             double qq = double(cnt)/allValues.size();
-            qDebug() << "  " << q << "->" << v << qq << fabs(q-qq)
+            qDebug() << "  Set percentile" << q << "->"
+                     << "the intensity is" << v
+                     << ", its actual percentile is" << qq
+                     << ", the absolute difference between set and actual percentiles is" << fabs(q-qq)
                      << ((fabs(q-qq) > 0.01) ? "!!!" : "");
         }
-        qDebug() << "-----------------------------";
+        qDebug() << "--------------------------------------------";
     }
 
     return result;

--- a/carta/cpp/core/Algorithms/quantileAlgorithms.h
+++ b/carta/cpp/core/Algorithms/quantileAlgorithms.h
@@ -56,7 +56,9 @@ quantiles2pixels(
     view.forEach(
         [& allValues] ( const Scalar & val ) {
             // check if the value from raw data is finite
-            if ( std::isfinite( val ) ) {
+            //if ( std::isfinite( val ) ) {
+            // check if the raw data is NaN
+            if ( ! std::isnan( val ) ) {
                 allValues.push_back( val );
             }
         }

--- a/carta/cpp/core/Data/Colormap/Colormap.cpp
+++ b/carta/cpp/core/Data/Colormap/Colormap.cpp
@@ -334,7 +334,11 @@ std::vector<std::pair<int,double> > Colormap::_getIntensityForPercents( std::vec
     Controller* controller = _getControllerSelected();
     if ( controller != nullptr ){
         std::pair<int,int> bounds(-1,-1);
+        // show colormap for Percentile mode
         values = controller->getIntensity( -1, -1, percents );
+        // show colormap for Quantile mode
+        // TODO: need to modify _updateIntensityBounds() as well !!
+        // values = controller->getIntensity( percents );
     }
     return values;
 }
@@ -1158,7 +1162,7 @@ void Colormap::_updateIntensityBounds( double minPercent, double maxPercent ){
                   m_stateData.setValue<int>( INTENSITY_MAX_INDEX, intensities[1].first );
               }
               if ( intensityChanged ){
-            	  _colorStateChanged();
+                  _colorStateChanged();
                   m_stateData.flushState();
               }
         }

--- a/carta/cpp/core/Data/Colormap/Colormap.cpp
+++ b/carta/cpp/core/Data/Colormap/Colormap.cpp
@@ -276,7 +276,7 @@ std::pair<double,double> Colormap::_convertIntensity( const QString& oldUnit, co
                 auto result2 = Globals::instance()-> pluginManager()
                                                                 -> prepare <Carta::Lib::Hooks::ConversionIntensityHook>(image,
                                                                         oldUnit, newUnit, hertzValues, converted,
-                                                                        1, "" );;
+                                                                        1, "" );
 
                 auto lam2 = [&convertedIntensity] ( const Carta::Lib::Hooks::ConversionIntensityHook::ResultType &data ) {
                     if ( data.size() == 2 ){

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1089,7 +1089,7 @@ void Controller::saveImageResultCB( bool result ){
 
 void Controller::setAutoClip( bool autoClip ){
     bool oldAutoClip = m_state.getValue<bool>(AUTO_CLIP );
-    if ( autoClip != oldAutoClip ){
+    if ( autoClip != oldAutoClip ) {
         m_state.setValue<bool>( AUTO_CLIP, autoClip );
         m_state.flushState();
     }
@@ -1335,7 +1335,13 @@ void Controller::_updateCursorText(bool notifyClients ){
     QString formattedCursor;
     int mouseX = m_stateMouse.getValue<int>(ImageView::MOUSE_X );
     int mouseY = m_stateMouse.getValue<int>(ImageView::MOUSE_Y );
-    QString cursorText = m_stack->_getCursorText( mouseX, mouseY);
+
+    // get Quantile information and show them on the image viewer
+    double minPercent = m_state.getValue<double>(CLIP_VALUE_MIN);
+    double maxPercent = m_state.getValue<double>(CLIP_VALUE_MAX);
+    bool isAutoClip = m_state.getValue<bool>(AUTO_CLIP);
+    QString cursorText = m_stack->_getCursorText(isAutoClip, minPercent, maxPercent, mouseX, mouseY);
+
     if ( !cursorText.isEmpty()){
         if ( cursorText != m_stateMouse.getValue<QString>(CURSOR)){
             m_stateMouse.setValue<QString>( CURSOR, cursorText );

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -361,7 +361,9 @@ std::vector<std::pair<int,double> > Controller::getIntensity( const std::vector<
 }
 
 std::vector<std::pair<int,double> > Controller::getIntensity( int frameLow, int frameHigh, const std::vector<double>& percentiles ) const{
-    std::vector<std::pair<int,double> > intensities = m_stack->_getIntensity( frameLow, frameHigh, percentiles );
+    int stokeFrame = getFrame(AxisInfo::KnownType::STOKES);
+    qDebug() << "++++++++ get the stoke frame=" << stokeFrame << "( -1: no stoke, 0: stoke I, 1: stoke Q, 2: stoke U, 3: stoke V)";
+    std::vector<std::pair<int,double> > intensities = m_stack->_getIntensity( frameLow, frameHigh, percentiles, stokeFrame );
     return intensities;
 }
 

--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -397,7 +397,7 @@ std::vector<std::pair<int,double> > DataSource::_getIntensityCache( int frameLow
 
             // disk cache
             // Look for the location first
-            QString locationKey = QString("%1/%2/%3/%4/%5/location").arg(m_fileName).arg(frameLow).arg(frameHigh).arg(percentiles[i]).arg(stokeFrame);
+            QString locationKey = QString("%1/%2/%3/%4/%5/location").arg(m_fileName).arg(frameLow).arg(frameHigh).arg(stokeFrame).arg(percentiles[i]);
             QByteArray locationVal;
 
             bool locationInCache = m_diskCache->readEntry(locationKey.toUtf8(), locationVal);
@@ -406,7 +406,7 @@ std::vector<std::pair<int,double> > DataSource::_getIntensityCache( int frameLow
 
             if (locationInCache) {
 
-                QString intensityKey = QString("%1/%2/%3/%4/%5/intensity").arg(m_fileName).arg(frameLow).arg(frameHigh).arg(percentiles[i]).arg(stokeFrame);
+                QString intensityKey = QString("%1/%2/%3/%4/%5/intensity").arg(m_fileName).arg(frameLow).arg(frameHigh).arg(stokeFrame).arg(percentiles[i]);
                 QByteArray intensityVal;
 
                 bool intensityInCache = m_diskCache->readEntry(intensityKey.toUtf8(), intensityVal);
@@ -526,8 +526,8 @@ std::vector<std::pair<int,double> > DataSource::_getIntensityCache( int frameLow
 
                     if (m_diskCache) {
 
-                        QString locationKey = QString("%1/%2/%3/%4/%5/location").arg(m_fileName).arg(frameLow).arg(frameHigh).arg(percentiles[i]).arg(stokeFrame);
-                        QString intensityKey = QString("%1/%2/%3/%4/%5/intensity").arg(m_fileName).arg(frameLow).arg(frameHigh).arg(percentiles[i]).arg(stokeFrame);
+                        QString locationKey = QString("%1/%2/%3/%4/%5/location").arg(m_fileName).arg(frameLow).arg(frameHigh).arg(stokeFrame).arg(percentiles[i]);
+                        QString intensityKey = QString("%1/%2/%3/%4/%5/intensity").arg(m_fileName).arg(frameLow).arg(frameHigh).arg(stokeFrame).arg(percentiles[i]);
 
 						m_diskCache->setEntry(locationKey.toUtf8(), i2qb(intensities[i].first), 0);
 						m_diskCache->setEntry(intensityKey.toUtf8(), d2qb(intensities[i].second), 0);

--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -221,7 +221,7 @@ QString DataSource::_getCursorText(bool isAutoClip, double minPercent, double ma
             std::vector<double> intensity = _getQuantileIntensityCache(view, minPercent, maxPercent, frames);
             double percent = (maxPercent - minPercent)*100;
             out << "<span style=\"color: #0000ff;\">with intensity bounds for Quantile mode "
-                << percent << "%: [Max, Min] = "
+                << percent << "%: [Min, Max] = "
                 << "[" << intensity[0]
                 << ", " << intensity[1] << "] "
                 << pixelUnits << "</span>"

--- a/carta/cpp/core/Data/Image/DataSource.h
+++ b/carta/cpp/core/Data/Image/DataSource.h
@@ -304,7 +304,8 @@ private:
      * @return the raw data or nullptr if there is none.
      */
     Carta::Lib::NdArray::RawViewInterface *  _getRawData( int frameLow, int frameHigh, int axisIndex ) const;
-    Carta::Lib::NdArray::RawViewInterface *  _getRawDataForIntensity( int frameLow, int frameHigh, int axisIndex, int axisStokeIndex ) const;
+    Carta::Lib::NdArray::RawViewInterface *  _getRawDataForIntensity( int frameLow, int frameHigh, int axisIndex,
+                                                                      int axisStokeIndex, int stokeSliceIndex ) const;
 
     /**
      * Returns the raw data for the current view.

--- a/carta/cpp/core/Data/Image/DataSource.h
+++ b/carta/cpp/core/Data/Image/DataSource.h
@@ -297,6 +297,10 @@ private:
 
     int _getQuantileCacheIndex( const std::vector<int>& frames ) const;
 
+    std::vector<int> _getStokeIndex( const std::vector<int>& frames ) const;
+
+    std::vector<int> _getChannelIndex( const std::vector<int>& frames ) const;
+
     /**
      * Returns the raw data as an array.
      * @param axisIndex - an index of an image axis.
@@ -306,8 +310,19 @@ private:
      * @return the raw data or nullptr if there is none.
      */
     Carta::Lib::NdArray::RawViewInterface *  _getRawData( int frameLow, int frameHigh, int axisIndex ) const;
-    Carta::Lib::NdArray::RawViewInterface *  _getRawDataForIntensity( int frameLow, int frameHigh, int axisIndex,
-                                                                      int axisStokeIndex, int stokeSliceIndex ) const;
+
+    /**
+     * Returns the raw data as an array.
+     * @param axisIndex - an index of an image axis.
+     * @param frameLow the lower bound for the frames or -1 for the whole image.
+     * @param frameHigh the upper bound for the frames or -1 for the whole image.
+     * @param axisIndex - the axis for the frames or -1 for all axes.
+     * @param axisStokeIndex - the axis for the stoke frame.
+     * @param stokeSliceIndex - the index of the stoke frame (-1: no stoke, 0: stoke I, 1: stoke Q, 2: stoke U, 3: stoke V).
+     * @return the raw data or nullptr if there is none.
+     */
+    Carta::Lib::NdArray::RawViewInterface *  _getRawDataForStoke( int frameLow, int frameHigh, int axisIndex,
+            int axisStokeIndex, int stokeSliceIndex ) const;
 
     /**
      * Returns the raw data for the current view.

--- a/carta/cpp/core/Data/Image/DataSource.h
+++ b/carta/cpp/core/Data/Image/DataSource.h
@@ -133,7 +133,7 @@ private:
      * @param frames - a list of current image frames.
      * @return a QString containing cursor text.
      */
-    QString _getCursorText( int mouseX, int mouseY, Carta::Lib::KnownSkyCS cs, const std::vector<int>& frames,
+    QString _getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY, Carta::Lib::KnownSkyCS cs, const std::vector<int>& frames,
             double zoom, const QPointF& pan, const QSize& outputSize );
 
 
@@ -488,6 +488,8 @@ private:
      */
     void _viewResize( const QSize& newSize );
 
+    std::vector<double> _getQuantileIntensityCache( std::shared_ptr<Carta::Lib::NdArray::RawViewInterface>& view,
+            double minClipPercentile, double maxClipPercentile, const std::vector<int>& frames );
 
     void _updateClips( std::shared_ptr<Carta::Lib::NdArray::RawViewInterface>& view,
             double minClipPercentile, double maxClipPercentile, const std::vector<int>& frames );

--- a/carta/cpp/core/Data/Image/DataSource.h
+++ b/carta/cpp/core/Data/Image/DataSource.h
@@ -304,6 +304,7 @@ private:
      * @return the raw data or nullptr if there is none.
      */
     Carta::Lib::NdArray::RawViewInterface *  _getRawData( int frameLow, int frameHigh, int axisIndex ) const;
+    Carta::Lib::NdArray::RawViewInterface *  _getRawDataForIntensity( int frameLow, int frameHigh, int axisIndex ) const;
 
     /**
      * Returns the raw data for the current view.

--- a/carta/cpp/core/Data/Image/DataSource.h
+++ b/carta/cpp/core/Data/Image/DataSource.h
@@ -304,7 +304,7 @@ private:
      * @return the raw data or nullptr if there is none.
      */
     Carta::Lib::NdArray::RawViewInterface *  _getRawData( int frameLow, int frameHigh, int axisIndex ) const;
-    Carta::Lib::NdArray::RawViewInterface *  _getRawDataForIntensity( int frameLow, int frameHigh, int axisIndex ) const;
+    Carta::Lib::NdArray::RawViewInterface *  _getRawDataForIntensity( int frameLow, int frameHigh, int axisIndex, int axisStokeIndex ) const;
 
     /**
      * Returns the raw data for the current view.

--- a/carta/cpp/core/Data/Image/DataSource.h
+++ b/carta/cpp/core/Data/Image/DataSource.h
@@ -209,20 +209,22 @@ private:
      * @param frameLow - a lower bound for the image channels or -1 if there is no lower bound.
      * @param frameHigh - an upper bound for the image channels or -1 if there is no upper bound.
      * @param percentiles - a list of numbers in [0,1] for which an intensity is desired.
+     * @param stokeFrame - the index number of stoke slice
      * @return - a list of corresponding (location,intensity) pairs.
      */
     std::vector<std::pair<int,double> > _getIntensity( int frameLow, int frameHigh,
-            const std::vector<double>& percentiles);
+            const std::vector<double>& percentiles, int stokeFrame);
 
     /**
      * Returns the intensities corresponding to a given percentiles.
      * @param frameLow - a lower bound for the image channels or -1 if there is no lower bound.
      * @param frameHigh - an upper bound for the image channels or -1 if there is no upper bound.
      * @param percentiles - a list of numbers in [0,1] for which an intensity is desired.
+     * @param stokeFrame - the index number of stoke slice
      * @return - a list of corresponding (location,intensity) pairs.
      */
     std::vector<std::pair<int,double> > _getIntensityCache( int frameLow, int frameHigh,
-        const std::vector<double>& percentiles );
+        const std::vector<double>& percentiles, int stokeFrame );
 
     /**
      * Returns the color used to draw nan pixels.

--- a/carta/cpp/core/Data/Image/Layer.h
+++ b/carta/cpp/core/Data/Image/Layer.h
@@ -265,10 +265,11 @@ protected:
      * @param frameLow - a lower bound for the image frames or -1 if there is no lower bound.
      * @param frameHigh - an upper bound for the image frames or -1 if there is no upper bound.
      * @param percentiles - a list of numbers in [0,1] for which an intensity is desired.
+     * @param stokeFrame - the index number of stoke slice
      * @return - a list of (location,intensity) pairs.
      */
     virtual std::vector<std::pair<int,double> > _getIntensity( int frameLow, int frameHigh,
-            const std::vector<double>& percentiles ) const = 0;
+            const std::vector<double>& percentiles, int stokeFrame) const = 0;
 
     /**
      * Returns whether or not the layer can be loaded with the indicated frames.

--- a/carta/cpp/core/Data/Image/Layer.h
+++ b/carta/cpp/core/Data/Image/Layer.h
@@ -182,7 +182,7 @@ protected:
      * @param outputSize - the size of the image in pixels.
      * @return a QString containing cursor text.
      */
-    virtual QString _getCursorText( int mouseX, int mouseY,
+    virtual QString _getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY,
             const std::vector<int>& frames, const QSize& outputSize ) = 0;
 
 

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -364,10 +364,10 @@ QRectF LayerData::_getInputRectangle( const QPointF& pan, double zoom, const QRe
 }
 
 std::vector<std::pair<int,double> > LayerData::_getIntensity( int frameLow, int frameHigh,
-        const std::vector<double>& percentiles ) const{
+        const std::vector<double>& percentiles, int stokeFrame ) const{
     std::vector<std::pair<int,double> > intensities;
     if ( m_dataSource ){
-        intensities = m_dataSource->_getIntensity( frameLow, frameHigh, percentiles );
+        intensities = m_dataSource->_getIntensity( frameLow, frameHigh, percentiles, stokeFrame );
     }
     return intensities;
 }

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -213,14 +213,14 @@ Carta::Lib::KnownSkyCS LayerData::_getCoordinateSystem() const {
     return cs;
 }
 
-QString LayerData::_getCursorText( int mouseX, int mouseY, const std::vector<int>& frames,
-        const QSize& outputSize ){
+QString LayerData::_getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY, const std::vector<int>& frames,
+        const QSize& outputSize){
     QString cursorText;
     if ( m_dataSource ){
         Carta::Lib::KnownSkyCS cs = m_dataGrid->_getSkyCS();
         QPointF pan = _getPan();
         double zoom = _getZoom();
-        cursorText = m_dataSource->_getCursorText( mouseX, mouseY, cs, frames, zoom, pan, outputSize );
+        cursorText = m_dataSource->_getCursorText(isAutoClip, minPercent, maxPercent, mouseX, mouseY, cs, frames, zoom, pan, outputSize);
     }
     return cursorText;
 }

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -357,10 +357,11 @@ protected:
      * @param frameLow - a lower bound for the image frames or -1 if there is no lower bound.
      * @param frameHigh - an upper bound for the image frames or -1 if there is no upper bound.
      * @param percentiles - a list of numbers in [0,1] for which an intensity is desired.
+     * @param stokeFrame - the index number of stoke slice
      * @return - a list of (location,intensity) pairs.
      */
     virtual std::vector<std::pair<int,double> > _getIntensity( int frameLow, int frameHigh,
-            const std::vector<double>& percentiles ) const Q_DECL_OVERRIDE;
+            const std::vector<double>& percentiles, int stokeFrame ) const Q_DECL_OVERRIDE;
 
 
     /**

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -141,8 +141,8 @@ protected:
      * @param frames - list of image frames.
      * @return a QString containing cursor text.
      */
-    virtual QString _getCursorText( int mouseX, int mouseY,
-            const std::vector<int>& frames, const QSize& outputSize ) Q_DECL_OVERRIDE;
+    virtual QString _getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY,
+            const std::vector<int>& frames, const QSize& outputSize) Q_DECL_OVERRIDE;
 
     /**
      * Return the data source of the image.

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -321,13 +321,13 @@ Carta::Lib::KnownSkyCS LayerGroup::_getCoordinateSystem() const {
     return cs;
 }
 
-QString LayerGroup::_getCursorText( int mouseX, int mouseY,
-        const std::vector<int>& frames, const QSize& outputSize ){
+QString LayerGroup::_getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY,
+        const std::vector<int>& frames, const QSize& outputSize) {
     QString cursorText;
     int dataIndex = _getIndexCurrent();
     if ( dataIndex >= 0 ){
-        cursorText = m_children[dataIndex]->_getCursorText( mouseX, mouseY,
-                frames, outputSize );
+        cursorText = m_children[dataIndex]->_getCursorText(isAutoClip, minPercent, maxPercent, mouseX, mouseY,
+                frames, outputSize);
     }
     return cursorText;
 

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -482,12 +482,12 @@ QRectF LayerGroup::_getInputRect( const QSize& size ) const {
 }
 
 std::vector<std::pair<int,double> > LayerGroup::_getIntensity( int frameLow, int frameHigh,
-        const std::vector<double>& percentiles ) const{
+        const std::vector<double>& percentiles, int stokeFrame ) const{
     std::vector<std::pair<int,double> > results;
     int dataIndex = _getIndexCurrent();
     if ( dataIndex >= 0 ){
         results = m_children[dataIndex]->_getIntensity( frameLow, frameHigh,
-                percentiles );
+                percentiles, stokeFrame );
     }
     return results;
 }

--- a/carta/cpp/core/Data/Image/LayerGroup.h
+++ b/carta/cpp/core/Data/Image/LayerGroup.h
@@ -141,7 +141,7 @@ protected:
      * @param frames - list of image frames.
      * @return a QString containing cursor text.
      */
-    virtual QString _getCursorText( int mouseX, int mouseY,
+    virtual QString _getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY,
             const std::vector<int>& frames, const QSize& outputSize ) Q_DECL_OVERRIDE;
 
     /**

--- a/carta/cpp/core/Data/Image/LayerGroup.h
+++ b/carta/cpp/core/Data/Image/LayerGroup.h
@@ -221,10 +221,11 @@ protected:
      * @param frameLow - a lower bound for the image frames or -1 if there is no lower bound.
      * @param frameHigh - an upper bound for the image frames or -1 if there is no upper bound.
      * @param percentiles - a list of numbers in [0,1] for which an intensity is desired.
+     * @param stokeFrame - the index number of stoke slice
      * @return - a list of (location,intensity) pairs.
      */
     virtual std::vector<std::pair<int,double> > _getIntensity( int frameLow, int frameHigh,
-            const std::vector<double>& percentiles ) const Q_DECL_OVERRIDE;
+            const std::vector<double>& percentiles, int stokeFrame ) const Q_DECL_OVERRIDE;
 
     /**
      * Return the layer with the given name, if a name is specified; otherwise, return the current

--- a/carta/cpp/core/Data/Image/LeastRecentlyUsedCache.cpp
+++ b/carta/cpp/core/Data/Image/LeastRecentlyUsedCache.cpp
@@ -17,17 +17,14 @@ std::pair<int,double> LeastRecentlyUsedCache::getIntensity(int frameLow, int fra
     int position = 0;
     for ( QLinkedList<LeastRecentlyUsedCacheEntry>::iterator iter = m_cache.begin();
          iter != m_cache.end(); iter++ ){
-        if ( (*iter).getFrameLow() == frameLow ){
-            if ( (*iter).getFrameHigh() == frameHigh ){
-                if ( (*iter).getStokeFrame() == stokeFrame ) {
-                    if ( qAbs( percentile - (*iter).getPercentile() )< ERROR_MARGIN ){
-                        intensities.first = (*iter).getLocation();
-                        intensities.second = (*iter).getIntensity();
-                        _refresh(position);
-                        break;
-                    }
-                }
-            }
+        if ( (*iter).getFrameLow() == frameLow &&
+             (*iter).getFrameHigh() == frameHigh &&
+             (*iter).getStokeFrame() == stokeFrame &&
+             qAbs( percentile - (*iter).getPercentile() )< ERROR_MARGIN ) {
+            intensities.first = (*iter).getLocation();
+            intensities.second = (*iter).getIntensity();
+            _refresh(position);
+            break;
         }
         position++;
     }

--- a/carta/cpp/core/Data/Image/LeastRecentlyUsedCache.cpp
+++ b/carta/cpp/core/Data/Image/LeastRecentlyUsedCache.cpp
@@ -12,18 +12,20 @@ LeastRecentlyUsedCache::LeastRecentlyUsedCache(int size){
 }
 
 
-std::pair<int,double> LeastRecentlyUsedCache::getIntensity(int frameLow, int frameHigh, double percentile ){
+std::pair<int,double> LeastRecentlyUsedCache::getIntensity(int frameLow, int frameHigh, double percentile, int stokeFrame ){
     std::pair<int,double> intensities( -1, 0 );
     int position = 0;
     for ( QLinkedList<LeastRecentlyUsedCacheEntry>::iterator iter = m_cache.begin();
          iter != m_cache.end(); iter++ ){
         if ( (*iter).getFrameLow() == frameLow ){
             if ( (*iter).getFrameHigh() == frameHigh ){
-                if ( qAbs( percentile - (*iter).getPercentile() )< ERROR_MARGIN ){
-                    intensities.first = (*iter).getLocation();
-                    intensities.second = (*iter).getIntensity();
-                    _refresh(position);
-                    break;
+                if ( (*iter).getStokeFrame() == stokeFrame ) {
+                    if ( qAbs( percentile - (*iter).getPercentile() )< ERROR_MARGIN ){
+                        intensities.first = (*iter).getLocation();
+                        intensities.second = (*iter).getIntensity();
+                        _refresh(position);
+                        break;
+                    }
                 }
             }
         }
@@ -32,8 +34,8 @@ std::pair<int,double> LeastRecentlyUsedCache::getIntensity(int frameLow, int fra
     return intensities;
 }
 
-void LeastRecentlyUsedCache::put(int frameLow, int frameHigh, int location, double percentile, double intensity){
-    LeastRecentlyUsedCacheEntry entry( frameLow, frameHigh, location, percentile, intensity );
+void LeastRecentlyUsedCache::put(int frameLow, int frameHigh, int location, double percentile, double intensity, int stokeFrame){
+    LeastRecentlyUsedCacheEntry entry( frameLow, frameHigh, location, percentile, intensity, stokeFrame);
     if ( ! m_cache.contains( entry )){
         //Store at the end of the list.
         m_cache.push_back( entry );

--- a/carta/cpp/core/Data/Image/LeastRecentlyUsedCache.h
+++ b/carta/cpp/core/Data/Image/LeastRecentlyUsedCache.h
@@ -29,7 +29,7 @@ public:
      * @param percentile - the percentile as a number in [0,1].
      * @param intensity - the intensity.
      */
-    void put(int frameLow, int frameHigh, int location, double percentile, double intensity );
+    void put(int frameLow, int frameHigh, int location, double percentile, double intensity , int stokeFrame);
 
     /**
      * Returns the (location,intensity) corresponding to the given frame range and
@@ -37,9 +37,10 @@ public:
      * @param frameLow - lower boundary of the channel range.
      * @param frameHigh - upper boundary of the channel range.
      * @param percentile - the percentile in [0,1] that is needed.
+     * stokeFrame - the index number of stoke slice
      * @return - the (location,intensity) corresponding to the passed in information.
      */
-    std::pair<int,double> getIntensity( int frameLow, int frameHigh, double percentile);
+    std::pair<int,double> getIntensity( int frameLow, int frameHigh, double percentile, int stokeFrame);
 
     /**
      * Return a string representation of the contents of the cache.

--- a/carta/cpp/core/Data/Image/LeastRecentlyUsedCacheEntry.cpp
+++ b/carta/cpp/core/Data/Image/LeastRecentlyUsedCacheEntry.cpp
@@ -44,7 +44,8 @@ bool LeastRecentlyUsedCacheEntry::operator==( const LeastRecentlyUsedCacheEntry&
     if (m_frameLow == other.m_frameLow &&
         m_frameHigh == other.m_frameHigh &&
         m_location == other.m_location &&
-        m_percentile == other.m_percentile ){
+        m_percentile == other.m_percentile &&
+        m_stokeFrame == other.m_stokeFrame ){
         equalEntries = true;
     }
     return equalEntries;

--- a/carta/cpp/core/Data/Image/LeastRecentlyUsedCacheEntry.cpp
+++ b/carta/cpp/core/Data/Image/LeastRecentlyUsedCacheEntry.cpp
@@ -6,17 +6,19 @@ namespace Carta {
 namespace Data {
 
 LeastRecentlyUsedCacheEntry::LeastRecentlyUsedCacheEntry( int frameLow, int frameHigh,
-        int location, double percentile, double intensity ){
+        int location, double percentile, double intensity, int stokeFrame ){
     m_frameLow = frameLow;
     m_frameHigh = frameHigh;
     m_location = location;
     m_percentile = percentile;
     m_intensity = intensity;
+    m_stokeFrame = stokeFrame;
 }
 
 int LeastRecentlyUsedCacheEntry::getFrameLow() const {
     return m_frameLow;
 }
+
 int LeastRecentlyUsedCacheEntry::getFrameHigh() const {
     return m_frameHigh;
 }
@@ -31,6 +33,10 @@ double LeastRecentlyUsedCacheEntry::getPercentile() const {
 
 double LeastRecentlyUsedCacheEntry::getIntensity() const {
     return m_intensity;
+}
+
+int LeastRecentlyUsedCacheEntry::getStokeFrame() const {
+    return m_stokeFrame;
 }
 
 bool LeastRecentlyUsedCacheEntry::operator==( const LeastRecentlyUsedCacheEntry& other ) const {

--- a/carta/cpp/core/Data/Image/LeastRecentlyUsedCacheEntry.h
+++ b/carta/cpp/core/Data/Image/LeastRecentlyUsedCacheEntry.h
@@ -20,8 +20,8 @@ public:
      * @param percentile - a number in [0,1].
      * @param intensity - the intensity corresponding to the percentile.
      */
-    LeastRecentlyUsedCacheEntry( int frameLow, int frameHigh, int location,
-            double percentile, double intensity );
+    LeastRecentlyUsedCacheEntry(int frameLow, int frameHigh, int location,
+            double percentile, double intensity , int stokeFrame);
 
     /**
      * Returns the lower boundary of the spectral index.
@@ -34,6 +34,12 @@ public:
      * @return - the upper boundary of the spectral index.
      */
     int getFrameHigh() const;
+
+    /**
+     * Returns the stoke frame slice index.
+     * @return - the stoke frame slice index.
+     */
+    int getStokeFrame() const;
 
     /**
      * Returns the index in the image data where the information is located.
@@ -77,6 +83,7 @@ private:
     int m_location;
     double m_percentile;
     double m_intensity;
+    int m_stokeFrame;
     LeastRecentlyUsedCacheEntry& operator=( const LeastRecentlyUsedCacheEntry& other );
 };
 }

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -166,13 +166,13 @@ QString Stack::_getCurrentId() const {
     return id;
 }
 
-QString Stack::_getCursorText( int mouseX, int mouseY ){
+QString Stack::_getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY) {
     int dataIndex = _getIndexCurrent();
     QString cursorText;
     if ( dataIndex >= 0 ){
         std::vector<int> frameIndices = _getFrameIndices();
         QSize outputSize = m_stackDraw->getClientSize();
-        cursorText = m_children[dataIndex]->_getCursorText( mouseX, mouseY,
+        cursorText = m_children[dataIndex]->_getCursorText( isAutoClip, minPercent, maxPercent, mouseX, mouseY,
                 frameIndices, outputSize );
     }
     return cursorText;

--- a/carta/cpp/core/Data/Image/Stack.h
+++ b/carta/cpp/core/Data/Image/Stack.h
@@ -93,7 +93,7 @@ private:
     QStringList _getCoords( double x, double y,
                 Carta::Lib::KnownSkyCS system ) const;
 
-    QString _getCursorText( int mouseX, int mouseY );
+    QString _getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY );
 
     QList<std::shared_ptr<Layer> > _getDrawChildren() const;
     int _getFrame( Carta::Lib::AxisInfo::KnownType axisType ) const;


### PR DESCRIPTION
Grimmer update:
- [x] May need to disable switching to stoke[>=1] in animators. 
- [x] handle quantile mode (per frame mode)
---

Changes in this branch:

I modify `DataSource.h` and `DataSource.cpp` codes, add a private function `_getRawDataForIntensity(frameLow, frameHigh, spectralIndex, stokeIndex)` which is applied in the function `_getIntensityCache(frameLow, frameHigh, percentiles)`. It allows us to calculate the percentile only for Intensity if we have image files (Casa or fits/miriad image files) with multiple stokes. 

Notes:

Since the memory cache can store old information from image files. In order to test codes, we have to prepare the same image file with different names, like `HH211_IQU.image.pbcor` and `HH211_IQU_2.image.pbcor`. Each image file is used to test the codes before and after modifications.

Some Issues:

1. The dump values of intensity from CARTA is not the same with the real intensity values shown in CASA. Is there any unit transformation we need to apply first? It might affect the colormap setting.
<img width="641" alt="2017-05-03 12 05 57" src="https://cloud.githubusercontent.com/assets/5379602/25689827/f8d54236-30bd-11e7-9ddf-031e258e86d9.png">

2. The way we calculate the percentile (e.q. 99%) is to use the selection algorithm supplied by cpp std utilies. In the process, it may do some sort-like action for the data array.

The selection algorithm we use is `std::nth_element(vector.begin(), vector.begin() + nth-Index, vector.end());` one can refer to http://en.cppreference.com/w/cpp/algorithm/nth_element or http://www.cplusplus.com/reference/algorithm/nth_element/

3. Now we calculate the percentile only for Intensity stoke, but it is for all channels. Do we also need to calculate the percentile for each channel?
