### PR TITLE
Upgrade to new namespace and better build scripts

### DIFF
--- a/carta/cpp/common.pri
+++ b/carta/cpp/common.pri
@@ -3,6 +3,9 @@ defineTest(dbg) {
 #    message( $$1)
 }
 
+DEFINES += "UseCasacoreNamespace=1"
+
+
 ! include(common_config.pri) {
   error( "Could not find the common_config.pri file!" )
 }
@@ -122,4 +125,3 @@ PROJECT_ROOT = $$IN_PWD
 # add include/depend path to start from root
 INCLUDEPATH += $$PROJECT_ROOT
 DEPENDPATH += $$PROJECT_ROOT
-

--- a/carta/cpp/common_config.pri
+++ b/carta/cpp/common_config.pri
@@ -10,7 +10,7 @@ ASTLIBDIR = ../../ThirdParty/ast
 WCSLIBDIR=../../ThirdParty/wcslib
 CFITSIODIR=../../ThirdParty/cfitsio
 IMAGEANALYSISDIR=../../ThirdParty/imageanalysis
-FLEXANDBISONDIR=../../ThirdParty/macports
+FLEXANDBISONDIR=../../ThirdParty/flex
 
 # don't edit these:
 # relative links are replaced by absolute paths

--- a/carta/cpp/common_config.pri
+++ b/carta/cpp/common_config.pri
@@ -10,7 +10,7 @@ ASTLIBDIR = ../../ThirdParty/ast
 WCSLIBDIR=../../ThirdParty/wcslib
 CFITSIODIR=../../ThirdParty/cfitsio
 IMAGEANALYSISDIR=../../ThirdParty/imageanalysis
-FLEXANDBISONDIR=../../ThirdParty/flexandbison
+FLEXANDBISONDIR=../../ThirdParty/macports
 
 # don't edit these:
 # relative links are replaced by absolute paths

--- a/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
@@ -113,7 +113,7 @@ getDefaultForSkyCS( const Carta::Lib::KnownSkyCS & skyCS )
     }
 }
 
-CCCoordinateFormatter::CCCoordinateFormatter( std::shared_ptr < casa::CoordinateSystem > casaCS )
+CCCoordinateFormatter::CCCoordinateFormatter( std::shared_ptr < casacore::CoordinateSystem > casaCS )
     :  m_displayAxes( 2, Carta::Lib::AxisInfo::KnownType::OTHER )
 {
     // remember the pointer to casa coordinate systems
@@ -127,7 +127,7 @@ CCCoordinateFormatter *
 CCCoordinateFormatter::clone() const
 {
     CCCoordinateFormatter * res = new CCCoordinateFormatter( * this );
-    res->m_casaCS.reset( new casa::CoordinateSystem( * m_casaCS ) );
+    res->m_casaCS.reset( new casacore::CoordinateSystem( * m_casaCS ) );
     return res;
 }
 
@@ -142,18 +142,18 @@ QStringList
 CCCoordinateFormatter::formatFromPixelCoordinate( const CoordinateFormatterInterface::VD & pix )
 {
     // first convert the pixel coordinates to world coordinates
-    casa::Vector < casa::Double > world;
-    casa::Vector < casa::Double > pixel = pix;
+    casacore::Vector < casacore::Double > world;
+    casacore::Vector < casacore::Double > pixel = pix;
     m_casaCS->toWorld( world, pix );
 
     // for spectral axis
     // convert freq to radio velocity
     int NumberofSpectralAxis = -1;
-    casa::Quantum<casa::Double> velocity;
+    casacore::Quantum<casacore::Double> velocity;
     if(m_casaCS->hasSpectralAxis())
     {
         NumberofSpectralAxis = m_casaCS->spectralAxisNumber();
-        casa::SpectralCoordinate casaSpeSystem = m_casaCS->spectralCoordinate();
+        casacore::SpectralCoordinate casaSpeSystem = m_casaCS->spectralCoordinate();
         casaSpeSystem.pixelToVelocity(velocity,pixel(NumberofSpectralAxis));
     }
 
@@ -161,8 +161,8 @@ CCCoordinateFormatter::formatFromPixelCoordinate( const CoordinateFormatterInter
     // format each axis
 //    QStringList list;
 //    for (unsigned int i = 0; i < m_casaCS->nCoordinates(); i++) {
-//        casa::String units;
-//        casa::String s = m_casaCS->format(units, casa::Coordinate::FIXED, world[i], i);
+//        casacore::String units;
+//        casacore::String s = m_casaCS->format(units, casacore::Coordinate::FIXED, world[i], i);
 //        list.append(QString("%1%2").arg(s.c_str()).arg(units.c_str()));
 //    }
 //    return list;
@@ -174,7 +174,7 @@ CCCoordinateFormatter::formatFromPixelCoordinate( const CoordinateFormatterInter
            NumberofSpectralAxis != -1)
         {
             val += " VRAD:";
-            val +=  QString::number(casa::Double(velocity.getValue()));
+            val +=  QString::number(casacore::Double(velocity.getValue()));
             val +=  " ";
             val +=  velocity.getUnit().c_str();
         }
@@ -212,8 +212,8 @@ bool
 CCCoordinateFormatter::toWorld( const CoordinateFormatterInterface::VD & pixel,
                                 CoordinateFormatterInterface::VD & world ) const
 {
-    casa::Vector< casa::Double > worldD = world;
-    casa::Vector< casa::Double > pixelD = pixel;
+    casacore::Vector< casacore::Double > worldD = world;
+    casacore::Vector< casacore::Double > pixelD = pixel;
     bool valid = m_casaCS->toWorld( worldD, pixelD );
     world = {worldD[0], worldD[1] };
     return valid;
@@ -223,8 +223,8 @@ bool
 CCCoordinateFormatter::toPixel( const CoordinateFormatterInterface::VD & world,
                                 CoordinateFormatterInterface::VD & pixel ) const
 {
-    casa::Vector < casa::Double > worldD = world;
-    casa::Vector < casa::Double > pixelD = pixel;
+    casacore::Vector < casacore::Double > worldD = world;
+    casacore::Vector < casacore::Double > pixelD = pixel;
     bool valid = m_casaCS->toPixel( pixelD, worldD );
     pixel = { pixelD[0], pixelD[1] };
     return valid;
@@ -264,23 +264,23 @@ CCCoordinateFormatter::skyCS()
         return KnownSkyCS::Unknown;
     }
     int which = m_casaCS->directionCoordinateNumber();
-    const casa::DirectionCoordinate & dirCoord = m_casaCS->directionCoordinate( which );
-    casa::MDirection::Types dirType = dirCoord.directionType( true );
+    const casacore::DirectionCoordinate & dirCoord = m_casaCS->directionCoordinate( which );
+    casacore::MDirection::Types dirType = dirCoord.directionType( true );
     switch ( dirType )
     {
-    case casa::MDirection::Types::B1950 :
+    case casacore::MDirection::Types::B1950 :
         return KnownSkyCS::B1950;
 
-    case casa::MDirection::Types::J2000 :
+    case casacore::MDirection::Types::J2000 :
         return KnownSkyCS::J2000;
 
-    case casa::MDirection::Types::ICRS :
+    case casacore::MDirection::Types::ICRS :
         return KnownSkyCS::ICRS;
 
-    case casa::MDirection::Types::GALACTIC :
+    case casacore::MDirection::Types::GALACTIC :
         return KnownSkyCS::Galactic;
 
-    case casa::MDirection::Types::ECLIPTIC :
+    case casacore::MDirection::Types::ECLIPTIC :
         return KnownSkyCS::Ecliptic;
 
     default :
@@ -312,27 +312,27 @@ CCCoordinateFormatter::setSkyCS( const KnownSkyCS & scs )
     CARTA_ASSERT( 0 <= pixelAxes[1] && pixelAxes[1] < nAxes() );
 
     // make a copy of it
-    casa::DirectionCoordinate dirCoordCopy =
-        casa::DirectionCoordinate( m_casaCS->directionCoordinate( which ) );
+    casacore::DirectionCoordinate dirCoordCopy =
+        casacore::DirectionCoordinate( m_casaCS->directionCoordinate( which ) );
 
     // change the system in the copy
-    casa::MDirection::Types mdir;
+    casacore::MDirection::Types mdir;
     switch ( scs )
     {
     case KnownSkyCS::B1950 :
-        mdir = casa::MDirection::B1950;
+        mdir = casacore::MDirection::B1950;
         break;
     case KnownSkyCS::J2000 :
-        mdir = casa::MDirection::J2000;
+        mdir = casacore::MDirection::J2000;
         break;
     case KnownSkyCS::ICRS :
-        mdir = casa::MDirection::ICRS;
+        mdir = casacore::MDirection::ICRS;
         break;
     case KnownSkyCS::Ecliptic :
-        mdir = casa::MDirection::ECLIPTIC;
+        mdir = casacore::MDirection::ECLIPTIC;
         break;
     case KnownSkyCS::Galactic :
-        mdir = casa::MDirection::GALACTIC;
+        mdir = casacore::MDirection::GALACTIC;
         break;
     default :
         CARTA_ASSERT_ALWAYS_X( false, "Internal error" );
@@ -420,7 +420,7 @@ CCCoordinateFormatter::parseCasaCSi( int pixelAxis )
 
     //qDebug() << pixelAxis << "-->" << coord << "," << coord2;
     //qDebug() << "   "
-    //         << casa::Coordinate::typeToString( m_casaCS->coordinate( coord ).type() ).c_str();
+    //         << casacore::Coordinate::typeToString( m_casaCS->coordinate( coord ).type() ).c_str();
     
     AxisInfo & aInfo = m_axisInfos[pixelAxis];
 
@@ -436,7 +436,7 @@ CCCoordinateFormatter::parseCasaCSi( int pixelAxis )
         auto skycs = skyCS();
 
         // we handle sky coordinate
-        if ( cc.type() == casa::Coordinate::DIRECTION ) {
+        if ( cc.type() == casacore::Coordinate::DIRECTION ) {
             // is it longitude?
             if ( coord2 == 0 ) {
                 aInfo.setKnownType( AxisInfo::KnownType::DIRECTION_LON );
@@ -500,25 +500,25 @@ CCCoordinateFormatter::parseCasaCSi( int pixelAxis )
                 }
             }
         }
-        else if ( cc.type() == casa::Coordinate::SPECTRAL ) {
+        else if ( cc.type() == casacore::Coordinate::SPECTRAL ) {
             aInfo.setKnownType( AxisInfo::KnownType::SPECTRAL )
                 .setLongLabel( HtmlString::fromPlain( "Frequency" ) )
                 .setShortLabel( HtmlString( "Freq", "Freq" ) );
             m_precisions[pixelAxis] = 9;
         }
-        else if ( cc.type() == casa::Coordinate::STOKES ) {
+        else if ( cc.type() == casacore::Coordinate::STOKES ) {
             aInfo.setKnownType( AxisInfo::KnownType::STOKES )
                 .setLongLabel( HtmlString::fromPlain( "Stokes" ) )
                 .setShortLabel( HtmlString::fromPlain( "Stokes" ) );
         }
-        else if ( cc.type() == casa::Coordinate::TABULAR ) {
+        else if ( cc.type() == casacore::Coordinate::TABULAR ) {
             aInfo.setKnownType( AxisInfo::KnownType::TABULAR );
 
-            //            else if ( cc.type() == casa::Coordinate::QUALITY ) {
+            //            else if ( cc.type() == casacore::Coordinate::QUALITY ) {
             //                aInfo.setKnownType( aInfo.KnownType::QUALITY);
             //            }
         }
-        else if ( cc.type() == casa::Coordinate::LINEAR ){
+        else if ( cc.type() == casacore::Coordinate::LINEAR ){
             aInfo.setKnownType( AxisInfo::KnownType::LINEAR )
                 .setLongLabel( HtmlString::fromPlain( "Linear"))
                 .setShortLabel( HtmlString::fromPlain( "Linear"));
@@ -592,7 +592,7 @@ CCCoordinateFormatter::formatWorldValue( int whichAxis, double worldValue )
 
     // for stokes we convert to a string using casacore's Stokes class
     else if ( ai.knownType() == AxisInfo::KnownType::STOKES ) {
-        return casa::Stokes::name( static_cast < casa::Stokes::StokesTypes > ( round( worldValue ) ) )
+        return casacore::Stokes::name( static_cast < casacore::Stokes::StokesTypes > ( round( worldValue ) ) )
                    .c_str();
     }
     else if ( ai.knownType() == AxisInfo::KnownType::SPECTRAL ){

--- a/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.h
+++ b/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.h
@@ -19,7 +19,7 @@ class CCCoordinateFormatter : public CoordinateFormatterInterface
 
 public:
 
-    CCCoordinateFormatter( std::shared_ptr < casa::CoordinateSystem > casaCS );
+    CCCoordinateFormatter( std::shared_ptr < casacore::CoordinateSystem > casaCS );
 
     virtual CCCoordinateFormatter * clone() const override;
 
@@ -77,7 +77,7 @@ protected:
     void
     parseCasaCSi(int pixelAxis);
 
-    std::shared_ptr < casa::CoordinateSystem > m_casaCS;
+    std::shared_ptr < casacore::CoordinateSystem > m_casaCS;
 
     /// cached info per axis
     std::vector < AxisInfo > m_axisInfos;

--- a/carta/cpp/plugins/CasaImageLoader/CCImage.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CCImage.cpp
@@ -5,7 +5,7 @@
 #include <QDebug>
 #include "CCImage.h"
 
-casa::ImageInterface < casa::Float > *
+casacore::ImageInterface < casacore::Float > *
 cartaII2casaII_float( std::shared_ptr < Carta::Lib::Image::ImageInterface > ii )
 {
     // first we convert to base, this seems to work on all platforms
@@ -17,9 +17,9 @@ cartaII2casaII_float( std::shared_ptr < Carta::Lib::Image::ImageInterface > ii )
     auto latticeBase = base-> getCasaImage();
 
     // now we try to cast the base to casacore image interface float type
-    return dynamic_cast< casa::ImageInterface < casa::Float > * > ( latticeBase);
+    return dynamic_cast< casacore::ImageInterface < casacore::Float > * > ( latticeBase);
 
-//    casa::ImageInterface < casa::Float > * ciif = dynamic_cast< casa::ImageInterface < casa::Float > * > ( latticeBase );
+//    casacore::ImageInterface < casacore::Float > * ciif = dynamic_cast< casacore::ImageInterface < casacore::Float > * > ( latticeBase );
 //    qWarning() << "ciif" << ciif;
 //    return ciif;
 }

--- a/carta/cpp/plugins/CasaImageLoader/CCImage.h
+++ b/carta/cpp/plugins/CasaImageLoader/CCImage.h
@@ -34,15 +34,15 @@ public:
 //    }
 
     /**
-     * Returns a pointer to the underlying casa::LatticeBase* or null if there is no underlying
+     * Returns a pointer to the underlying casacore::LatticeBase* or null if there is no underlying
      * casacore image.
-     * @return casa::LatticeBase *
+     * @return casacore::LatticeBase *
      */
-    virtual casa::LatticeBase * getCasaImage() = 0;
+    virtual casacore::LatticeBase * getCasaImage() = 0;
 
-    virtual casa::ImageInfo getImageInfo() const = 0;
+    virtual casacore::ImageInfo getImageInfo() const = 0;
 
-//    virtual casa::ImageInterface<casa::Float> * getCasaIIfloat() = 0;
+//    virtual casacore::ImageInterface<casacore::Float> * getCasaIIfloat() = 0;
 
 
 };
@@ -86,31 +86,31 @@ public:
         }
 
         //Convert to a CASA data type.
-        casa::Vector<int> newOrder( indexCount );
+        casacore::Vector<int> newOrder( indexCount );
         for ( int i = 0; i < indexCount; i++ ){
             newOrder[i] = indices[i];
         }
         //Change the order of the axes in the coordinate system
-        casa::CoordinateSystem coordSys = m_casaII->coordinates();
+        casacore::CoordinateSystem coordSys = m_casaII->coordinates();
         coordSys.transpose( newOrder, newOrder );
-        casa::IPosition oldShape = m_casaII->shape();
-        casa::IPosition newShape( indexCount );
+        casacore::IPosition oldShape = m_casaII->shape();
+        casacore::IPosition newShape( indexCount );
         for ( int i = 0; i < indexCount; i++ ){
             newShape[i] = oldShape[newOrder[i]];
         }
 
         //Make a new image and copy the data into it.
-        casa::ImageInterface<PType>* newImage = new casa::TempImage<PType>(casa::TiledShape( newShape), coordSys);
-        casa::Array<PType> dataCopy = m_casaII->get();
+        casacore::ImageInterface<PType>* newImage = new casacore::TempImage<PType>(casacore::TiledShape( newShape), coordSys);
+        casacore::Array<PType> dataCopy = m_casaII->get();
         newImage->put( reorderArray( dataCopy, newOrder ));
         if ( m_casaII->hasPixelMask()){
-            std::unique_ptr<casa::Lattice<casa::Bool> > maskLattice( m_casaII->pixelMask().clone());
-            casa::Array<casa::Bool> maskCopy = maskLattice->get();
-            dynamic_cast< casa::TempImage<PType> *>(newImage)->attachMask( casa::ArrayLattice<casa::Bool>(reorderArray( maskCopy, newOrder )));
+            std::unique_ptr<casacore::Lattice<casacore::Bool> > maskLattice( m_casaII->pixelMask().clone());
+            casacore::Array<casacore::Bool> maskCopy = maskLattice->get();
+            dynamic_cast< casacore::TempImage<PType> *>(newImage)->attachMask( casacore::ArrayLattice<casacore::Bool>(reorderArray( maskCopy, newOrder )));
         }
 
         //Finish the copy and create a CARTA image with permuted axes.
-        casa::ImageUtilities::copyMiscellaneous( *newImage, *m_casaII );
+        casacore::ImageUtilities::copyMiscellaneous( *newImage, *m_casaII );
         std::shared_ptr<Carta::Lib::Image::ImageInterface> permuteImage =  create( newImage);
         return permuteImage;
     }
@@ -130,7 +130,7 @@ public:
     virtual bool
     hasBeam() const override
     {
-        casa::ImageInfo imagef = m_casaII->imageInfo();
+        casacore::ImageInfo imagef = m_casaII->imageInfo();
         return imagef.hasBeam();
     }
 
@@ -186,10 +186,10 @@ public:
 
     /// call this to create an instance of this class, do not use constructor
     static CCImage::SharedPtr
-    create( casa::ImageInterface < PType > * casaImage )
+    create( casacore::ImageInterface < PType > * casaImage )
     {
         // create an image interface instance and populate it with various
-        // values from casa::ImageInterface
+        // values from casacore::ImageInterface
         CCImage::SharedPtr img = std::make_shared < CCImage < PType > > ();
         img-> m_pixelType = Carta::Lib::Image::CType2PixelType < PType >::type;
         img-> m_dims      = casaImage-> shape().asStdVector();
@@ -201,34 +201,34 @@ public:
         htmlTitle = htmlTitle.toHtmlEscaped();
 
         // make our own copy of the coordinate system using 'clone'
-        std::shared_ptr<casa::CoordinateSystem> casaCS(
-                    static_cast<casa::CoordinateSystem *> (casaImage->coordinates().clone()));
+        std::shared_ptr<casacore::CoordinateSystem> casaCS(
+                    static_cast<casacore::CoordinateSystem *> (casaImage->coordinates().clone()));
 
         // construct a meta data instance
         img-> m_meta = std::make_shared < CCMetaDataInterface > ( htmlTitle, casaCS );
 
         /// \todo remove this test code
-       /* casa::Record rec;
+       /* casacore::Record rec;
         if( ! casaCS-> save( rec, "")) {
             std::string err = casaCS-> errorMessage();
             qWarning() << "Could not serialize coordinate system";
         }
         else {
             rec.print( std::cerr);
-            casa::AipsIO os("/tmp/file.name", casa::ByteIO::New);
+            casacore::AipsIO os("/tmp/file.name", casacore::ByteIO::New);
             rec.putRecord( os);
         }*/
 
         return img;
     } // create
 
-    virtual casa::LatticeBase *
+    virtual casacore::LatticeBase *
     getCasaImage() override
     {
         return m_casaII;
     }
 
-    casa::ImageInfo getImageInfo() const {
+    casacore::ImageInfo getImageInfo() const {
                return m_casaII->imageInfo();
            }
 
@@ -258,8 +258,8 @@ protected:
     /// cached dimensions of the image
     std::vector < int > m_dims;
 
-    /// pointer to the actual casa::ImageInterface
-    casa::ImageInterface < PType > * m_casaII;
+    /// pointer to the actual casacore::ImageInterface
+    casacore::ImageInterface < PType > * m_casaII;
 
     /// cached unit
     Carta::Lib::Unit m_unit;
@@ -273,5 +273,5 @@ protected:
 };
 
 /// helper to convert carta's image to casacore image interface
-casa::ImageInterface<casa::Float> *
+casacore::ImageInterface<casacore::Float> *
 cartaII2casaII_float( std::shared_ptr<Carta::Lib::Image::ImageInterface> ii) ;

--- a/carta/cpp/plugins/CasaImageLoader/CCMetaDataInterface.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CCMetaDataInterface.cpp
@@ -10,7 +10,7 @@
 #include <casacore/coordinates/Coordinates/StokesCoordinate.h>
 
 CCMetaDataInterface::CCMetaDataInterface( QString htmlTitle,
-                                          std::shared_ptr < casa::CoordinateSystem > casaCS )
+                                          std::shared_ptr < casacore::CoordinateSystem > casaCS )
 {
     m_title = Carta::Lib::HtmlString::fromHtml( htmlTitle );
     m_casaCS = casaCS;
@@ -28,7 +28,7 @@ CCMetaDataInterface::coordinateFormatter()
     return std::make_shared < CCCoordinateFormatter > ( m_casaCS );
 }
 
-std::shared_ptr<casa::CoordinateSystem> CCMetaDataInterface::getCoordinateSystem() const {
+std::shared_ptr<casacore::CoordinateSystem> CCMetaDataInterface::getCoordinateSystem() const {
     return m_casaCS;
 }
 
@@ -74,7 +74,7 @@ class CCCoordSystemConverter : public Carta::Lib::Regions::ICoordSystemConverter
 {
 public:
 
-    CCCoordSystemConverter( std::shared_ptr < casa::CoordinateSystem > casaCS )
+    CCCoordSystemConverter( std::shared_ptr < casacore::CoordinateSystem > casaCS )
     {
         m_casaCS = casaCS;
 
@@ -104,31 +104,31 @@ public:
             qDebug() << "    -type:" << subcs.type();
 
             // warn about subaxis not being 0 for everything but direction
-            if( subcs.type() != casa::Coordinate::Type::DIRECTION && coordAxis != 0) {
+            if( subcs.type() != casacore::Coordinate::Type::DIRECTION && coordAxis != 0) {
                 qWarning() << "CasaImageLoader plugin: coordAxis should be 0 for non-direction";
                 coordAxis = 0;
             }
             // warn about subaxis not being 0 or 1 for direction
-            if( subcs.type() == casa::Coordinate::Type::DIRECTION &&
+            if( subcs.type() == casacore::Coordinate::Type::DIRECTION &&
                 (coordAxis != 0 && coordAxis != 1))
             {
                 qWarning() << "CasaImageLoader plugin: coordAxis should be 0 or 1 for direction";
                 coordAxis = 0;
             }
 
-            if ( subcs.type() == casa::Coordinate::Type::DIRECTION ) {
-                const casa::DirectionCoordinate & dirc = m_casaCS-> directionCoordinate();
-                if ( dirc.directionType() == casa::MDirection::Types::J2000 ) {
+            if ( subcs.type() == casacore::Coordinate::Type::DIRECTION ) {
+                const casacore::DirectionCoordinate & dirc = m_casaCS-> directionCoordinate();
+                if ( dirc.directionType() == casacore::MDirection::Types::J2000 ) {
                     m_dstCS.setAxis( i,
                                      Carta::Lib::Regions::BasicCoordinateSystemInfo::j2000(),
                                      coordAxis );
                 }
-                else if ( dirc.directionType() == casa::MDirection::Types::GALACTIC ) {
+                else if ( dirc.directionType() == casacore::MDirection::Types::GALACTIC ) {
                     m_dstCS.setAxis( i,
                                      Carta::Lib::Regions::BasicCoordinateSystemInfo::galactic(),
                                      coordAxis );
                 }
-                else if ( dirc.directionType() == casa::MDirection::Types::ECLIPTIC ) {
+                else if ( dirc.directionType() == casacore::MDirection::Types::ECLIPTIC ) {
                     m_dstCS.setAxis( i,
                                      Carta::Lib::Regions::BasicCoordinateSystemInfo::ecliptic(),
                                      coordAxis );
@@ -136,25 +136,25 @@ public:
                 else {
                     qWarning() << "CasaImageLoader plugin:"
                                << "Don't know how to convert casa direction"
-                               << casa::MDirection::showType( dirc.directionType() ).c_str();
+                               << casacore::MDirection::showType( dirc.directionType() ).c_str();
                 }
             }
-            else if ( subcs.type() == casa::Coordinate::Type::SPECTRAL ) {
-                const casa::SpectralCoordinate & specc = m_casaCS-> spectralCoordinate();
-                if( specc.nativeType() == casa::SpectralCoordinate::SpecType::FREQ) {
+            else if ( subcs.type() == casacore::Coordinate::Type::SPECTRAL ) {
+                const casacore::SpectralCoordinate & specc = m_casaCS-> spectralCoordinate();
+                if( specc.nativeType() == casacore::SpectralCoordinate::SpecType::FREQ) {
                     m_dstCS.setAxis( i,
                                      Carta::Lib::Regions::BasicCoordinateSystemInfo::frequency() );
 
                 } else {
-                    casa::String cstring = "???";
-                    casa::SpectralCoordinate::specTypetoString( cstring, specc.nativeType());
+                    casacore::String cstring = "???";
+                    casacore::SpectralCoordinate::specTypetoString( cstring, specc.nativeType());
                     qWarning() << "CasaImageLoader plugin: "
                                << "Don't know how to convert casa spectral"
                                << cstring.c_str();
                 }
             }
-            else if ( subcs.type() == casa::Coordinate::Type::STOKES ) {
-                const casa::StokesCoordinate & stokesc = m_casaCS-> stokesCoordinate();
+            else if ( subcs.type() == casacore::Coordinate::Type::STOKES ) {
+                const casacore::StokesCoordinate & stokesc = m_casaCS-> stokesCoordinate();
                 auto s = stokesc.stokes().tovector();
                 qDebug() << "stokesv=" << s;
                 m_dstCS.setAxis( i,
@@ -203,7 +203,7 @@ public:
 
 private:
 
-    std::shared_ptr < casa::CoordinateSystem > m_casaCS;
+    std::shared_ptr < casacore::CoordinateSystem > m_casaCS;
     Carta::Lib::Regions::CompositeCoordinateSystem m_srcCS, m_dstCS;
 };
 

--- a/carta/cpp/plugins/CasaImageLoader/CCMetaDataInterface.h
+++ b/carta/cpp/plugins/CasaImageLoader/CCMetaDataInterface.h
@@ -15,7 +15,7 @@ class CCMetaDataInterface
 
 public:
 
-    CCMetaDataInterface( QString htmlTitle, std::shared_ptr < casa::CoordinateSystem > casaCS );
+    CCMetaDataInterface( QString htmlTitle, std::shared_ptr < casacore::CoordinateSystem > casaCS );
 
     virtual Carta::Lib::Image::MetaDataInterface *
     clone() override;
@@ -25,7 +25,7 @@ public:
 
 //    virtual CoordinateGridPlotterInterface::SharedPtr
 //    coordinateGridPlotter() override;
-    std::shared_ptr<casa::CoordinateSystem> getCoordinateSystem() const;
+    std::shared_ptr<casacore::CoordinateSystem> getCoordinateSystem() const;
 
     ///Return the rest frequency and units
     virtual std::pair<double,QString> getRestFrequency() const override;
@@ -44,5 +44,5 @@ public:
 protected:
 
     Carta::Lib::HtmlString m_title;
-    std::shared_ptr < casa::CoordinateSystem > m_casaCS;
+    std::shared_ptr < casacore::CoordinateSystem > m_casaCS;
 };

--- a/carta/cpp/plugins/CasaImageLoader/CCRawView.h
+++ b/carta/cpp/plugins/CasaImageLoader/CCRawView.h
@@ -195,7 +195,7 @@ CCRawView < PType >::get( const Carta::Lib::NdArray::RawViewInterface::VI & pos 
                        + p * m_appliedSlice.dims()[i].step;
     }
 
-    // casa::ImageInterface::operator() returns the result by value
+    // casacore::ImageInterface::operator() returns the result by value
     // so in order to return reference (to satisfy our API) we need to store this
     // in a buffer first...
     m_buff = m_ccimage-> m_casaII->
@@ -225,8 +225,8 @@ CCRawView < PType >::forEach(
     /// \todo the shape of the subsection... e.g. [3:7:2,5:6] only needs a cursor
     /// of size 2x1(x1x1x1....x1) regardless of the image size...
     auto cursorShape = imageShape;
-    casa::LatticeStepper stepper( imageShape, cursorShape, casa::LatticeStepper::RESIZE );
-    casa::IPosition blc( imgDims, 0 );
+    casacore::LatticeStepper stepper( imageShape, cursorShape, casacore::LatticeStepper::RESIZE );
+    casacore::IPosition blc( imgDims, 0 );
     auto trc = blc;
     auto inc = blc;
     for ( size_t i = 0 ; i < imgDims ; i++ ) {
@@ -236,7 +236,7 @@ CCRawView < PType >::forEach(
         inc( i ) = slice1d.step;
     }
     stepper.subSection( blc, trc, inc );
-    casa::RO_LatticeIterator < PType > iterator( * casaII, stepper );
+    casacore::RO_LatticeIterator < PType > iterator( * casaII, stepper );
 
     bool first = true;
     for ( iterator.reset() ; ! iterator.atEnd() ; iterator++ ) {

--- a/carta/cpp/plugins/CasaImageLoader/CasaImageLoader.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CasaImageLoader.cpp
@@ -28,8 +28,8 @@ bool CasaImageLoader::handleHook(BaseHook & hookData)
     qDebug() << "CasaImageLoader plugin is handling hook #" << hookData.hookId();
     if( hookData.is<Carta::Lib::Hooks::Initialize>()) {
         // Register FITS and Miriad image types
-        casa::FITSImage::registerOpenFunction();
-        casa::MIRIADImage::registerOpenFunction();
+        casacore::FITSImage::registerOpenFunction();
+        casacore::MIRIADImage::registerOpenFunction();
         return true;
     }
 
@@ -55,9 +55,9 @@ std::vector<HookId> CasaImageLoader::getInitialHookList()
 }
 
 template <typename T>
-static CCImageBase::SharedPtr tryCast( casa::LatticeBase * lat)
+static CCImageBase::SharedPtr tryCast( casacore::LatticeBase * lat)
 {
-    typedef casa::ImageInterface<T> CCIT;
+    typedef casacore::ImageInterface<T> CCIT;
     CCIT * cii = dynamic_cast<CCIT *>(lat);
     typename CCImage<T>::SharedPtr res = nullptr;
     if( cii) {
@@ -78,23 +78,23 @@ Carta::Lib::Image::ImageInterface::SharedPtr CasaImageLoader::loadImage( const Q
     qDebug() << "CasaImageLoader plugin trying to load image: " << fname;
 
     // get the image type
-    casa::ImageOpener::ImageTypes filetype = casacore::ImageOpener::imageType(fname.toStdString());
+    casacore::ImageOpener::ImageTypes filetype = casacore::ImageOpener::imageType(fname.toStdString());
 
     // load image
-    casa::LatticeBase * lat = nullptr;
-    if(filetype == casa::ImageOpener::ImageTypes::AIPSPP)
+    casacore::LatticeBase * lat = nullptr;
+    if(filetype == casacore::ImageOpener::ImageTypes::AIPSPP)
     {
-        lat = casa::ImageOpener::openPagedImage ( fname.toStdString());
+        lat = casacore::ImageOpener::openPagedImage ( fname.toStdString());
         qDebug() << "\t-opened as paged image";
     }
-    else if(filetype != casa::ImageOpener::ImageTypes::UNKNOWN)
+    else if(filetype != casacore::ImageOpener::ImageTypes::UNKNOWN)
     {
-        lat = casa::ImageOpener::openImage ( fname.toStdString());
-        if(filetype == casa::ImageOpener::ImageTypes::FITS)
+        lat = casacore::ImageOpener::openImage ( fname.toStdString());
+        if(filetype == casacore::ImageOpener::ImageTypes::FITS)
         {
             qDebug() << "\t-opened as FITS image";
         }
-        else if(filetype == casa::ImageOpener::ImageTypes::MIRIAD )
+        else if(filetype == casacore::ImageOpener::ImageTypes::MIRIAD )
         {
             qDebug() << "\t-opened as MIRIAD image";
         }
@@ -122,19 +122,19 @@ Carta::Lib::Image::ImageInterface::SharedPtr CasaImageLoader::loadImage( const Q
     auto shapes = shape.asStdVector();
     qDebug() << "lat.shape = " << std::string( lat->shape().toString()).c_str();
     qDebug() << "lat.dataType = " << lat->dataType();
-    qDebug() << "Float type is " << casa::TpFloat;
+    qDebug() << "Float type is " << casacore::TpFloat;
 
     CCImageBase::SharedPtr res;
     res = tryCast<float>(lat);
     // Please note that the following code will not be reached
     // even if the FITS file is defined in 64 bit
     // and FitsHeaderExtractor::_CasaFitsConverter assumes that
-    // image is load in casa::ImageInterface < casa::Float > format
+    // image is load in casacore::ImageInterface < casacore::Float > format
     if( ! res) res = tryCast<double>(lat);
     if( ! res) res = tryCast<u_int8_t>(lat);
     if( ! res) res = tryCast<int16_t>(lat);
     if( ! res) res = tryCast<int32_t>(lat);
-    if( ! res) res = tryCast<casa::Int>(lat);
+    if( ! res) res = tryCast<casacore::Int>(lat);
     //Certain image related functions are defined only for Int, there is no
     //long long in the image class right now.  TempImage<int32_t> fails to
     //compile, for example.
@@ -148,13 +148,13 @@ Carta::Lib::Image::ImageInterface::SharedPtr CasaImageLoader::loadImage( const Q
 
     // if the initial conversion attempt failed, try a LEL expression
 /*
-    casa::ImageInterface<casa::Float> * img = 0;
+    casacore::ImageInterface<casacore::Float> * img = 0;
     try {
         qDebug() << "Trying LEL conversion";
         std::string expr = "float('" + fname.toStdString() + "')";
         qDebug() << "Espression is " << expr.c_str();
-        casa::LatticeExpr<casa::Float> le ( casa::ImageExprParse::command( expr ));
-        img = new casa::ImageExpr<casa::Float> ( le, expr );
+        casacore::LatticeExpr<casacore::Float> le ( casacore::ImageExprParse::command( expr ));
+        img = new casacore::ImageExpr<casacore::Float> ( le, expr );
         qDebug() << "\t-LEL conversion successful";
         return CCImage<float>::create( img);
     } catch ( ... ) {} 

--- a/carta/cpp/plugins/ConversionIntensity/ConverterIntensity.cpp
+++ b/carta/cpp/plugins/ConversionIntensity/ConverterIntensity.cpp
@@ -323,8 +323,8 @@ double ConverterIntensity::convertQuantity( double yValue, double frequencyValue
         const QString& oldUnits, const QString& newUnits, double beamSolidAngle,
         double beamArea ) {
 
-    casa::String oldUnitStr = oldUnits.toStdString();
-    casa::String newUnitStr = newUnits.toStdString();
+    casacore::String oldUnitStr = oldUnits.toStdString();
+    casacore::String newUnitStr = newUnits.toStdString();
 
     double convertedYValue = yValue;
     if ( oldUnits != KELVIN && newUnits != KELVIN ) {

--- a/carta/cpp/plugins/ConversionIntensity/IntensityConversionPlugin.cpp
+++ b/carta/cpp/plugins/ConversionIntensity/IntensityConversionPlugin.cpp
@@ -10,10 +10,10 @@ IntensityConversionPlugin::IntensityConversionPlugin( QObject * parent ) :
 { }
 
 
-void IntensityConversionPlugin::_getBeamInfo( casa::ImageInfo& information,
-        casa::Double& beamAngle, casa::Double& beamArea) const {
+void IntensityConversionPlugin::_getBeamInfo( casacore::ImageInfo& information,
+        casacore::Double& beamAngle, casacore::Double& beamArea) const {
     //Get the major and minor axis beam widths.
-    casa::GaussianBeam beam;
+    casacore::GaussianBeam beam;
     bool multipleBeams = information.hasMultipleBeams();
     if ( !multipleBeams ){
         beam = information.restoringBeam();
@@ -21,8 +21,8 @@ void IntensityConversionPlugin::_getBeamInfo( casa::ImageInfo& information,
     else {
         beam = information.restoringBeam( 0, -1 );
     }
-    casa::Quantity majorQuantity = beam.getMajor();
-    casa::Quantity minorQuantity = beam.getMinor();
+    casacore::Quantity majorQuantity = beam.getMajor();
+    casacore::Quantity minorQuantity = beam.getMinor();
     double arcsecArea = beam.getArea( "arcsec2");
     beamArea = arcsecArea;
 
@@ -57,9 +57,9 @@ IntensityConversionPlugin::handleHook( BaseHook & hookData ){
             }
             CCImageBase * base = dynamic_cast<CCImageBase*>( image.get() );
             if ( base ){
-                casa::ImageInfo information = base->getImageInfo();
-                casa::Double beamAngle;
-                casa::Double beamArea;
+                casacore::ImageInfo information = base->getImageInfo();
+                casacore::Double beamAngle;
+                casacore::Double beamArea;
                 _getBeamInfo( information, beamAngle, beamArea );
                 std::vector<double> valsX = hook.paramsPtr->m_inputListX;
                 std::vector<double> valsY = hook.paramsPtr->m_inputListY;

--- a/carta/cpp/plugins/ConversionIntensity/IntensityConversionPlugin.h
+++ b/carta/cpp/plugins/ConversionIntensity/IntensityConversionPlugin.h
@@ -27,8 +27,8 @@ public:
     virtual ~IntensityConversionPlugin();
 
 private:
-    void _getBeamInfo( casa::ImageInfo& information,
-            casa::Double& beamAngle, casa::Double& beamArea) const;
+    void _getBeamInfo( casacore::ImageInfo& information,
+            casacore::Double& beamAngle, casacore::Double& beamArea) const;
 
 
 };

--- a/carta/cpp/plugins/ConversionSpectral/Converter.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/Converter.cpp
@@ -77,16 +77,16 @@ Converter::Converter( const QString& oldUnitsStr, const QString& newUnitsStr):
 }
 
 
-double Converter::convert ( double oldValue, casa::SpectralCoordinate spectralCoordinate ) {
+double Converter::convert ( double oldValue, casacore::SpectralCoordinate spectralCoordinate ) {
     std::vector<double> sourceValues( 1 );
     sourceValues[0] = oldValue;
-    casa::Vector<double> destValues = convert( sourceValues, spectralCoordinate );
+    casacore::Vector<double> destValues = convert( sourceValues, spectralCoordinate );
     double result = destValues[0];
     return result;
 }
 
-void Converter::convert( casa::Vector<double> &resultValues, int sourceIndex,
-        int destIndex, casa::SpectralCoordinate /*spectralCoordinate*/) {
+void Converter::convert( casacore::Vector<double> &resultValues, int sourceIndex,
+        int destIndex, casacore::SpectralCoordinate /*spectralCoordinate*/) {
     if ( sourceIndex >= 0 && destIndex >= 0 ) {
         int diff = qAbs( destIndex - sourceIndex );
         float power = pow( 10, diff );

--- a/carta/cpp/plugins/ConversionSpectral/Converter.h
+++ b/carta/cpp/plugins/ConversionSpectral/Converter.h
@@ -14,15 +14,15 @@ public:
     static Converter* getConverter( const QString& oldUnits,const QString& newUnits );
 
     //Converts units withen a unit type (for example frequency MHz -> GHz
-    static void convert( casa::Vector<double> &resultValues, int sourceIndex,
-            int destIndex, casa::SpectralCoordinate coordinate);
+    static void convert( casacore::Vector<double> &resultValues, int sourceIndex,
+            int destIndex, casacore::SpectralCoordinate coordinate);
 
 
     //Abstract methods to be implemented by subclasses.
-    virtual double toPixel( double value, casa::SpectralCoordinate coordinate ) = 0;
-    virtual casa::Vector<double> convert( const casa::Vector<double>& oldValues,
-            casa::SpectralCoordinate coordinate) = 0;
-    virtual double convert ( double oldValue, casa::SpectralCoordinate coordinate);
+    virtual double toPixel( double value, casacore::SpectralCoordinate coordinate ) = 0;
+    virtual casacore::Vector<double> convert( const casacore::Vector<double>& oldValues,
+            casacore::SpectralCoordinate coordinate) = 0;
+    virtual double convert ( double oldValue, casacore::SpectralCoordinate coordinate);
     virtual ~Converter();
 
     typedef enum {FREQUENCY_UNIT, VELOCITY_UNIT, WAVELENGTH_UNIT, CHANNEL_UNIT, UNRECOGNIZED } UnitType;

--- a/carta/cpp/plugins/ConversionSpectral/ConverterChannel.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterChannel.cpp
@@ -10,20 +10,20 @@ Converter( oldUnits, newUnits) {
 }
 
 
-double ConverterChannel::toPixel( double value, casa::SpectralCoordinate spectralCoordinate ) {
-    casa::Double pixelValue;
+double ConverterChannel::toPixel( double value, casacore::SpectralCoordinate spectralCoordinate ) {
+    casacore::Double pixelValue;
     spectralCoordinate.toPixel( pixelValue, value );
     return pixelValue;
 }
 
-casa::Vector<double> ConverterChannel::convert( const casa::Vector<double>& oldValues,
-        casa::SpectralCoordinate spectralCoordinate ) {
+casacore::Vector<double> ConverterChannel::convert( const casacore::Vector<double>& oldValues,
+        casacore::SpectralCoordinate spectralCoordinate ) {
     std::vector<double> resultValues( oldValues.size());
     for ( int i = 0; i < static_cast<int>(resultValues.size()); i++ ) {
         double result;
         bool correct = spectralCoordinate.toWorld( result, oldValues[i]);
         if ( correct ) {
-            casa::Vector<casa::String> worldUnitsVector = spectralCoordinate.worldAxisUnits();
+            casacore::Vector<casacore::String> worldUnitsVector = spectralCoordinate.worldAxisUnits();
             QString worldUnit(worldUnitsVector[0].c_str());
             if ( worldUnit == newUnits ) {
                 resultValues[i] = result;
@@ -46,10 +46,10 @@ casa::Vector<double> ConverterChannel::convert( const casa::Vector<double>& oldV
     return resultValues;
 }
 
-double ConverterChannel::convert ( double oldValue, casa::SpectralCoordinate spectralCoordinate ) {
+double ConverterChannel::convert ( double oldValue, casacore::SpectralCoordinate spectralCoordinate ) {
     std::vector<double> oldValues(1);
     oldValues[0] = oldValue;
-    casa::Vector<double> newValues = convert( oldValues, spectralCoordinate );
+    casacore::Vector<double> newValues = convert( oldValues, spectralCoordinate );
     return newValues[0];
 }
 

--- a/carta/cpp/plugins/ConversionSpectral/ConverterChannel.h
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterChannel.h
@@ -8,9 +8,9 @@ class ConverterChannel : public Converter {
 public:
     ConverterChannel( const QString& oldUnits, const QString& newUnits );
 
-    virtual double toPixel( double value, casa::SpectralCoordinate spectralCoordinate );
-    virtual casa::Vector<double> convert( const casa::Vector<double>& oldValues,
-            casa::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
-    virtual double convert ( double oldValue, casa::SpectralCoordinate spectralCoordinate );
+    virtual double toPixel( double value, casacore::SpectralCoordinate spectralCoordinate );
+    virtual casacore::Vector<double> convert( const casacore::Vector<double>& oldValues,
+            casacore::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
+    virtual double convert ( double oldValue, casacore::SpectralCoordinate spectralCoordinate );
     virtual ~ConverterChannel();
 };

--- a/carta/cpp/plugins/ConversionSpectral/ConverterFrequency.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterFrequency.cpp
@@ -5,13 +5,13 @@ ConverterFrequency::ConverterFrequency(const QString& oldUnits, const QString& n
 Converter( oldUnits, newUnits ) {
 }
 
-double ConverterFrequency::toPixel( double value, casa::SpectralCoordinate spectralCoordinate) {
-    casa::Double pixelValue;
-    casa::Vector<casa::String> spectralUnits = spectralCoordinate.worldAxisUnits();
-    casa::String spectralUnit = spectralUnits[0];
+double ConverterFrequency::toPixel( double value, casacore::SpectralCoordinate spectralCoordinate) {
+    casacore::Double pixelValue;
+    casacore::Vector<casacore::String> spectralUnits = spectralCoordinate.worldAxisUnits();
+    casacore::String spectralUnit = spectralUnits[0];
     QString spectralUnitStr( spectralUnit.c_str());
     if ( spectralUnitStr != oldUnits ) {
-        casa::Vector<double> freqValues(1);
+        casacore::Vector<double> freqValues(1);
         freqValues[0] = value;
         convertFrequency( freqValues, oldUnits, spectralUnitStr, spectralCoordinate );
         value = freqValues[0];
@@ -20,17 +20,17 @@ double ConverterFrequency::toPixel( double value, casa::SpectralCoordinate spect
     return pixelValue;
 }
 
-casa::Vector<double> ConverterFrequency::convert( const casa::Vector<double>& oldValues,
-        casa::SpectralCoordinate spectralCoordinate) {
-    casa::Vector<double> resultValues( oldValues.size() );
+casacore::Vector<double> ConverterFrequency::convert( const casacore::Vector<double>& oldValues,
+        casacore::SpectralCoordinate spectralCoordinate) {
+    casacore::Vector<double> resultValues( oldValues.size() );
     resultValues = oldValues;
     convertFrequency( resultValues, oldUnits, newUnits, spectralCoordinate );
     return resultValues;
 }
 
-void ConverterFrequency::convertFrequency( casa::Vector<double> &resultValues,
+void ConverterFrequency::convertFrequency( casacore::Vector<double> &resultValues,
         QString& frequencySourceUnits, QString& frequencyDestUnits,
-        casa::SpectralCoordinate& coord ) {
+        casacore::SpectralCoordinate& coord ) {
     int sourceIndex = Converter::FREQUENCY_UNITS.indexOf( frequencySourceUnits );
     int destIndex = Converter::FREQUENCY_UNITS.indexOf( frequencyDestUnits );
     Converter::convert( resultValues, sourceIndex, destIndex, coord );

--- a/carta/cpp/plugins/ConversionSpectral/ConverterFrequency.h
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterFrequency.h
@@ -5,11 +5,11 @@
 class ConverterFrequency : public Converter {
 public:
     ConverterFrequency(const QString& oldUnits, const QString& newUnits);
-    static void convertFrequency( casa::Vector<double> &resultValues,
+    static void convertFrequency( casacore::Vector<double> &resultValues,
             QString& frequencySourceUnits, QString& frequencyDestUnits,
-            casa::SpectralCoordinate& spectralCoordinate );
-    virtual double toPixel( double value, casa::SpectralCoordinate spectralCoordinate);
-    virtual casa::Vector<double> convert( const casa::Vector<double>& oldValues,
-            casa::SpectralCoordinate spectralCoordinate)  Q_DECL_OVERRIDE;
+            casacore::SpectralCoordinate& spectralCoordinate );
+    virtual double toPixel( double value, casacore::SpectralCoordinate spectralCoordinate);
+    virtual casacore::Vector<double> convert( const casacore::Vector<double>& oldValues,
+            casacore::SpectralCoordinate spectralCoordinate)  Q_DECL_OVERRIDE;
     virtual ~ConverterFrequency();
 };

--- a/carta/cpp/plugins/ConversionSpectral/ConverterFrequencyVelocity.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterFrequencyVelocity.cpp
@@ -8,16 +8,16 @@ ConverterFrequencyVelocity::ConverterFrequencyVelocity(const QString& oldUnits,
 }
 
 
-casa::Vector<double> ConverterFrequencyVelocity::convert( const casa::Vector<double>& oldValues,
-        casa::SpectralCoordinate spectralCoordinate ) {
-    casa::Vector<double> frequencyValues(oldValues.size());
+casacore::Vector<double> ConverterFrequencyVelocity::convert( const casacore::Vector<double>& oldValues,
+        casacore::SpectralCoordinate spectralCoordinate ) {
+    casacore::Vector<double> frequencyValues(oldValues.size());
     frequencyValues = oldValues;
 
     //Find out the frequency units the spectral coordinate is using and
     //compare them to the frequency units we are using.  Transform the
     //data if necessary to the units used by the spectral coordinate.
-    casa::Vector<casa::String> spectralUnits = spectralCoordinate.worldAxisUnits();
-    casa::String spectralUnit = spectralUnits[0];
+    casacore::Vector<casacore::String> spectralUnits = spectralCoordinate.worldAxisUnits();
+    casacore::String spectralUnit = spectralUnits[0];
     QString spectralUnitStr( spectralUnit.c_str() );
     if ( spectralUnitStr != oldUnits ) {
         ConverterFrequency::convertFrequency( frequencyValues, oldUnits, spectralUnitStr, spectralCoordinate );
@@ -25,7 +25,7 @@ casa::Vector<double> ConverterFrequencyVelocity::convert( const casa::Vector<dou
     bool unitsUnderstood = spectralCoordinate.setVelocity( newUnits.toStdString() );
     bool successfulConversion = false;
     int dataCount = oldValues.size();
-    casa::Vector<double> resultValues( dataCount );
+    casacore::Vector<double> resultValues( dataCount );
     if ( unitsUnderstood ) {
         successfulConversion = spectralCoordinate.frequencyToVelocity( resultValues, frequencyValues );
     }

--- a/carta/cpp/plugins/ConversionSpectral/ConverterFrequencyVelocity.h
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterFrequencyVelocity.h
@@ -5,7 +5,7 @@
 class ConverterFrequencyVelocity : public ConverterFrequency {
 public:
     ConverterFrequencyVelocity(const QString& oldUnits, const QString& newUnits);
-    virtual casa::Vector<double> convert( const casa::Vector<double>& oldValues,
-            casa::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
+    virtual casacore::Vector<double> convert( const casacore::Vector<double>& oldValues,
+            casacore::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
     virtual ~ConverterFrequencyVelocity();
 };

--- a/carta/cpp/plugins/ConversionSpectral/ConverterFrequencyWavelength.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterFrequencyWavelength.cpp
@@ -7,10 +7,10 @@ ConverterFrequencyWavelength::ConverterFrequencyWavelength(const QString& oldUni
 
 }
 
-casa::Vector<double> ConverterFrequencyWavelength::convert( const casa::Vector<double>& oldValues,
-        casa::SpectralCoordinate spectralCoordinate ) {
+casacore::Vector<double> ConverterFrequencyWavelength::convert( const casacore::Vector<double>& oldValues,
+        casacore::SpectralCoordinate spectralCoordinate ) {
 
-    casa::Vector<double> resultValues(oldValues.size());
+    casacore::Vector<double> resultValues(oldValues.size());
     resultValues = oldValues;
 
     bool unitsUnderstood = spectralCoordinate.setWavelengthUnit( newUnits.toStdString() );
@@ -20,8 +20,8 @@ casa::Vector<double> ConverterFrequencyWavelength::convert( const casa::Vector<d
         successfulConversion = spectralCoordinate.frequencyToWavelength( resultValues, oldValues );
 
         if ( successfulConversion ) {
-            casa::Vector<casa::String> spectralUnits = spectralCoordinate.worldAxisUnits();
-            casa::String spectralUnit = spectralUnits[0];
+            casacore::Vector<casacore::String> spectralUnits = spectralCoordinate.worldAxisUnits();
+            casacore::String spectralUnit = spectralUnits[0];
             QString spectralUnitStr( spectralUnit.c_str() );
             if ( spectralUnitStr != oldUnits ) {
                 ConverterFrequency::convertFrequency( resultValues, spectralUnitStr,

--- a/carta/cpp/plugins/ConversionSpectral/ConverterFrequencyWavelength.h
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterFrequencyWavelength.h
@@ -6,7 +6,7 @@ class ConverterFrequencyWavelength : public ConverterFrequency {
 public:
     ConverterFrequencyWavelength(const QString& oldUnits,
             const QString& newUnits);
-    virtual casa::Vector<double> convert( const casa::Vector<double>& oldValues,
-            casa::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
+    virtual casacore::Vector<double> convert( const casacore::Vector<double>& oldValues,
+            casacore::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
     virtual ~ConverterFrequencyWavelength();
 };

--- a/carta/cpp/plugins/ConversionSpectral/ConverterVelocity.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterVelocity.cpp
@@ -6,23 +6,23 @@ Converter( oldUnits, newUnits) {
 
 }
 
-double ConverterVelocity::toPixel( double value, casa::SpectralCoordinate spectralCoordinate ) {
+double ConverterVelocity::toPixel( double value, casacore::SpectralCoordinate spectralCoordinate ) {
     double pixelVal;
     spectralCoordinate.setVelocity( oldUnits.toStdString() );
     spectralCoordinate.velocityToPixel( pixelVal, value );
     return pixelVal;
 }
 
-casa::Vector<double> ConverterVelocity::convert( const casa::Vector<double>& oldValues,
-        casa::SpectralCoordinate spectralCoordinate ) {
-    casa::Vector<double> resultValues( oldValues.size() );
+casacore::Vector<double> ConverterVelocity::convert( const casacore::Vector<double>& oldValues,
+        casacore::SpectralCoordinate spectralCoordinate ) {
+    casacore::Vector<double> resultValues( oldValues.size() );
     resultValues = oldValues;
     convertVelocity( resultValues, oldUnits, newUnits, spectralCoordinate );
     return resultValues;
 }
 
-void ConverterVelocity::convertVelocity( casa::Vector<double> &resultValues,
-        QString& sourceUnits, QString& destUnits, casa::SpectralCoordinate& coord ) {
+void ConverterVelocity::convertVelocity( casacore::Vector<double> &resultValues,
+        QString& sourceUnits, QString& destUnits, casacore::SpectralCoordinate& coord ) {
     int sourceIndex = Converter::VELOCITY_UNITS.indexOf( sourceUnits );
     int destIndex = Converter::VELOCITY_UNITS.indexOf( destUnits );
     Converter::convert( resultValues, sourceIndex, destIndex, coord );

--- a/carta/cpp/plugins/ConversionSpectral/ConverterVelocity.h
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterVelocity.h
@@ -5,10 +5,10 @@
 class ConverterVelocity : public Converter {
 public:
     ConverterVelocity(const QString& oldUnits,const QString& newUnits);
-    virtual double toPixel( double value, casa::SpectralCoordinate spectralCoordinate);
-    static void convertVelocity( casa::Vector<double> &resultValues,
-            QString& sourceUnits, QString& destUnits, casa::SpectralCoordinate& coord);
-    virtual casa::Vector<double> convert( const casa::Vector<double>& oldValues,
-            casa::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
+    virtual double toPixel( double value, casacore::SpectralCoordinate spectralCoordinate);
+    static void convertVelocity( casacore::Vector<double> &resultValues,
+            QString& sourceUnits, QString& destUnits, casacore::SpectralCoordinate& coord);
+    virtual casacore::Vector<double> convert( const casacore::Vector<double>& oldValues,
+            casacore::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
     virtual ~ConverterVelocity();
 };

--- a/carta/cpp/plugins/ConversionSpectral/ConverterVelocityFrequency.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterVelocityFrequency.cpp
@@ -7,26 +7,26 @@ ConverterVelocity( oldUnits, newUnits) {
 }
 
 
-void ConverterVelocityFrequency::convertFrequency( casa::Vector<double> &resultValues,
-        QString& frequencySourceUnits, casa::SpectralCoordinate& coord ) {
+void ConverterVelocityFrequency::convertFrequency( casacore::Vector<double> &resultValues,
+        QString& frequencySourceUnits, casacore::SpectralCoordinate& coord ) {
     //Decide on the multiplier
     int sourceUnitIndex = FREQUENCY_UNITS.indexOf( frequencySourceUnits );
     int destUnitIndex = FREQUENCY_UNITS.indexOf( newUnits );
     Converter::convert( resultValues, sourceUnitIndex, destUnitIndex, coord );
 }
 
-casa::Vector<double> ConverterVelocityFrequency::convert( const casa::Vector<double>& oldValues,
-        casa::SpectralCoordinate spectralCoordinate ) {
+casacore::Vector<double> ConverterVelocityFrequency::convert( const casacore::Vector<double>& oldValues,
+        casacore::SpectralCoordinate spectralCoordinate ) {
     bool unitsUnderstood = spectralCoordinate.setVelocity( oldUnits.toStdString() );
-    casa::Vector<double> resultValues(oldValues.size());
+    casacore::Vector<double> resultValues(oldValues.size());
     bool successfulConversion = false;
     if ( unitsUnderstood ) {
         successfulConversion = spectralCoordinate.velocityToFrequency( resultValues, oldValues );
         if ( successfulConversion ) {
             //The frequency unit will be whatever the spectralCoordinate is currently using.
-            casa::Vector<casa::String> frequencyUnits = spectralCoordinate.worldAxisUnits();
+            casacore::Vector<casacore::String> frequencyUnits = spectralCoordinate.worldAxisUnits();
             assert (frequencyUnits.size() == 1);
-            casa::String frequencyUnit = frequencyUnits[0];
+            casacore::String frequencyUnit = frequencyUnits[0];
             QString freqUnitStr( frequencyUnit.c_str());
             //Now we convert it to appropriate units;
             convertFrequency( resultValues, freqUnitStr, spectralCoordinate );

--- a/carta/cpp/plugins/ConversionSpectral/ConverterVelocityFrequency.h
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterVelocityFrequency.h
@@ -5,11 +5,11 @@
 class ConverterVelocityFrequency : public ConverterVelocity {
 public:
     ConverterVelocityFrequency(const QString& oldUnits,const QString& newUnits);
-    virtual casa::Vector<double> convert( const casa::Vector<double>& oldValues,
-            casa::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
+    virtual casacore::Vector<double> convert( const casacore::Vector<double>& oldValues,
+            casacore::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
     virtual ~ConverterVelocityFrequency();
 
 private:
-    void convertFrequency( casa::Vector<double> &resultValues, QString& frequencyUnits,
-            casa::SpectralCoordinate& coord);
+    void convertFrequency( casacore::Vector<double> &resultValues, QString& frequencyUnits,
+            casacore::SpectralCoordinate& coord);
 };

--- a/carta/cpp/plugins/ConversionSpectral/ConverterVelocityWavelength.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterVelocityWavelength.cpp
@@ -6,14 +6,14 @@ ConverterVelocityWavelength::ConverterVelocityWavelength(const QString& oldUnits
 ConverterVelocity( oldUnits, newUnits ) {
 }
 
-casa::Vector<double> ConverterVelocityWavelength::convert( const casa::Vector<double>& oldValues,
-        casa::SpectralCoordinate spectralCoordinate ) {
-    casa::Vector<double> resultValues( oldValues.size());
+casacore::Vector<double> ConverterVelocityWavelength::convert( const casacore::Vector<double>& oldValues,
+        casacore::SpectralCoordinate spectralCoordinate ) {
+    casacore::Vector<double> resultValues( oldValues.size());
     bool velocitySet = spectralCoordinate.setVelocity( oldUnits.toStdString() );
     bool wavelengthSet = spectralCoordinate.setWavelengthUnit( newUnits.toStdString() );
     bool successfulConversion = false;
     if ( velocitySet && wavelengthSet ) {
-        casa::Vector<double> frequencyValues( oldValues.size());
+        casacore::Vector<double> frequencyValues( oldValues.size());
         successfulConversion = spectralCoordinate.velocityToFrequency( frequencyValues, oldValues );
         if ( successfulConversion ) {
             successfulConversion = spectralCoordinate.frequencyToWavelength( resultValues , frequencyValues );

--- a/carta/cpp/plugins/ConversionSpectral/ConverterVelocityWavelength.h
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterVelocityWavelength.h
@@ -6,8 +6,8 @@ class ConverterVelocityWavelength : public ConverterVelocity {
 public:
     ConverterVelocityWavelength(const QString& oldUnits,
             const QString& newUnits );
-    virtual casa::Vector<double> convert( const casa::Vector<double>& oldValues,
-            casa::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
+    virtual casacore::Vector<double> convert( const casacore::Vector<double>& oldValues,
+            casacore::SpectralCoordinate spectralCoordinate )  Q_DECL_OVERRIDE;
     virtual ~ConverterVelocityWavelength();
 };
 

--- a/carta/cpp/plugins/ConversionSpectral/ConverterWavelength.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterWavelength.cpp
@@ -6,27 +6,27 @@ Converter( oldUnits, newUnits ) {
 
 }
 
-double ConverterWavelength::toPixel( double value, casa::SpectralCoordinate spectralCoordinate) {
+double ConverterWavelength::toPixel( double value, casacore::SpectralCoordinate spectralCoordinate) {
     spectralCoordinate.setWavelengthUnit( oldUnits.toStdString() );
-    casa::Vector<casa::Double> frequencyVector(1);
-    casa::Vector<casa::Double> wavelengthVector(1);
+    casacore::Vector<casacore::Double> frequencyVector(1);
+    casacore::Vector<casacore::Double> wavelengthVector(1);
     wavelengthVector[0] = value;
     spectralCoordinate.wavelengthToFrequency(frequencyVector, wavelengthVector );
-    casa::Double pixelValue;
+    casacore::Double pixelValue;
     spectralCoordinate.toPixel( pixelValue, frequencyVector[0]);
     return pixelValue;
 }
 
-casa::Vector<double> ConverterWavelength::convert( const casa::Vector<double>& oldValues,
-        casa::SpectralCoordinate spectralCoordinate) {
-    casa::Vector<double> resultValues( oldValues.size() );
+casacore::Vector<double> ConverterWavelength::convert( const casacore::Vector<double>& oldValues,
+        casacore::SpectralCoordinate spectralCoordinate) {
+    casacore::Vector<double> resultValues( oldValues.size() );
     resultValues = oldValues;
     convertWavelength( resultValues, oldUnits, newUnits, spectralCoordinate );
     return resultValues;
 }
 
-void ConverterWavelength::convertWavelength( casa::Vector<double> &resultValues,
-        QString& sourceUnits, QString& destUnits, casa::SpectralCoordinate& coord) {
+void ConverterWavelength::convertWavelength( casacore::Vector<double> &resultValues,
+        QString& sourceUnits, QString& destUnits, casacore::SpectralCoordinate& coord) {
     int sourceIndex = Converter::WAVELENGTH_UNITS.indexOf( sourceUnits );
     int destIndex = Converter::WAVELENGTH_UNITS.indexOf( destUnits );
     Converter::convert( resultValues, sourceIndex, destIndex, coord );

--- a/carta/cpp/plugins/ConversionSpectral/ConverterWavelength.h
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterWavelength.h
@@ -5,11 +5,11 @@
 class ConverterWavelength : public Converter {
 public:
     ConverterWavelength(const QString& oldUnits,const QString& newUnits);
-    virtual double toPixel( double value, casa::SpectralCoordinate spectralCoordinate );
-    static void convertWavelength( casa::Vector<double> &resultValues,
-            QString& sourceUnits, QString& destUnits, casa::SpectralCoordinate& coord);
-    virtual casa::Vector<double> convert( const casa::Vector<double>& oldValues,
-            casa::SpectralCoordinate spectralCoordinate)  Q_DECL_OVERRIDE;
+    virtual double toPixel( double value, casacore::SpectralCoordinate spectralCoordinate );
+    static void convertWavelength( casacore::Vector<double> &resultValues,
+            QString& sourceUnits, QString& destUnits, casacore::SpectralCoordinate& coord);
+    virtual casacore::Vector<double> convert( const casacore::Vector<double>& oldValues,
+            casacore::SpectralCoordinate spectralCoordinate)  Q_DECL_OVERRIDE;
     virtual ~ConverterWavelength();
 };
 

--- a/carta/cpp/plugins/ConversionSpectral/ConverterWavelengthFrequency.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterWavelengthFrequency.cpp
@@ -7,17 +7,17 @@ ConverterWavelengthFrequency::ConverterWavelengthFrequency(const QString& oldUni
 ConverterWavelength( oldUnits, newUnits ) {
 }
 
-casa::Vector<double> ConverterWavelengthFrequency::convert( const casa::Vector<double>& oldValues,
-        casa::SpectralCoordinate spectralCoordinate ) {
-    casa::Vector<double> resultValues( oldValues.size());
+casacore::Vector<double> ConverterWavelengthFrequency::convert( const casacore::Vector<double>& oldValues,
+        casacore::SpectralCoordinate spectralCoordinate ) {
+    casacore::Vector<double> resultValues( oldValues.size());
     bool wavelengthRecognized = spectralCoordinate.setWavelengthUnit( oldUnits.toStdString() );
     bool successfulConversion = false;
     if ( wavelengthRecognized ) {
         successfulConversion = spectralCoordinate.wavelengthToFrequency( resultValues, oldValues );
         if ( successfulConversion ) {
-            casa::Vector<casa::String> coordUnits = spectralCoordinate.worldAxisUnits();
+            casacore::Vector<casacore::String> coordUnits = spectralCoordinate.worldAxisUnits();
             assert ( coordUnits.size() == 1 );
-            casa::String coordUnit = coordUnits[0];
+            casacore::String coordUnit = coordUnits[0];
             QString coordUnitStr( coordUnit.c_str());
             ConverterFrequency::convertFrequency( resultValues, coordUnitStr, newUnits, spectralCoordinate );
         }

--- a/carta/cpp/plugins/ConversionSpectral/ConverterWavelengthFrequency.h
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterWavelengthFrequency.h
@@ -6,8 +6,8 @@ class ConverterWavelengthFrequency : public ConverterWavelength {
 public:
     ConverterWavelengthFrequency(const QString& oldUnits,
             const QString& newUnits );
-    virtual casa::Vector<double> convert( const casa::Vector<double>& oldValues,
-            casa::SpectralCoordinate spectralCoordinate)  Q_DECL_OVERRIDE;
+    virtual casacore::Vector<double> convert( const casacore::Vector<double>& oldValues,
+            casacore::SpectralCoordinate spectralCoordinate)  Q_DECL_OVERRIDE;
     virtual ~ConverterWavelengthFrequency();
 };
 

--- a/carta/cpp/plugins/ConversionSpectral/ConverterWavelengthVelocity.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterWavelengthVelocity.cpp
@@ -6,16 +6,16 @@ ConverterWavelengthVelocity::ConverterWavelengthVelocity(const QString& oldUnits
         ConverterWavelength( oldUnits, newUnits) {
 }
 
-casa::Vector<double> ConverterWavelengthVelocity::convert( const casa::Vector<double>& oldValues,
-        casa::SpectralCoordinate spectralCoordinate ) {
-    casa::Vector<double> resultValues( oldValues.size());
+casacore::Vector<double> ConverterWavelengthVelocity::convert( const casacore::Vector<double>& oldValues,
+        casacore::SpectralCoordinate spectralCoordinate ) {
+    casacore::Vector<double> resultValues( oldValues.size());
 
     bool validWavelength = spectralCoordinate.setWavelengthUnit( oldUnits.toStdString() );
     bool validVelocity = spectralCoordinate.setVelocity( newUnits.toStdString() );
 
     bool successfulConversion = false;
     if ( validWavelength && validVelocity ) {
-        casa::Vector<double> frequencyValues( oldValues.size());
+        casacore::Vector<double> frequencyValues( oldValues.size());
         successfulConversion = spectralCoordinate.wavelengthToFrequency( frequencyValues,oldValues);
         if ( successfulConversion ) {
             successfulConversion = spectralCoordinate.frequencyToVelocity( resultValues, frequencyValues);

--- a/carta/cpp/plugins/ConversionSpectral/ConverterWavelengthVelocity.h
+++ b/carta/cpp/plugins/ConversionSpectral/ConverterWavelengthVelocity.h
@@ -5,8 +5,8 @@
 class ConverterWavelengthVelocity : public ConverterWavelength {
 public:
     ConverterWavelengthVelocity(const QString& oldUnits,const QString& newUnits);
-    virtual casa::Vector<double> convert( const casa::Vector<double>& oldValues,
-            casa::SpectralCoordinate spectralCoordinate ) Q_DECL_OVERRIDE;
+    virtual casacore::Vector<double> convert( const casacore::Vector<double>& oldValues,
+            casacore::SpectralCoordinate spectralCoordinate ) Q_DECL_OVERRIDE;
     virtual ~ConverterWavelengthVelocity();
 };
 

--- a/carta/cpp/plugins/ConversionSpectral/SpectralConversionPlugin.cpp
+++ b/carta/cpp/plugins/ConversionSpectral/SpectralConversionPlugin.cpp
@@ -36,19 +36,19 @@ SpectralConversionPlugin::handleHook( BaseHook & hookData ){
                     Carta::Lib::Image::MetaDataInterface::SharedPtr metaPtr = base->metaData();
                     CCMetaDataInterface* metaData = dynamic_cast<CCMetaDataInterface*>(metaPtr.get());
                     if ( metaData ){
-                        std::shared_ptr<casa::CoordinateSystem> cs = metaData->getCoordinateSystem();
-                        int spectralIndex = cs->findCoordinate(casa::Coordinate::SPECTRAL,  -1);
+                        std::shared_ptr<casacore::CoordinateSystem> cs = metaData->getCoordinateSystem();
+                        int spectralIndex = cs->findCoordinate(casacore::Coordinate::SPECTRAL,  -1);
                         if ( spectralIndex >= 0 ){
-                            casa::SpectralCoordinate sc = cs->spectralCoordinate( spectralIndex );
+                            casacore::SpectralCoordinate sc = cs->spectralCoordinate( spectralIndex );
                             std::vector<double> inputValues = hook.paramsPtr->m_inputList;
                             int dataCount = inputValues.size();
-                            casa::Vector<double> inputs( dataCount );
+                            casacore::Vector<double> inputs( dataCount );
                             for ( int i = 0; i < dataCount; i++ ){
                                 inputs[i] = inputValues[i];
                             }
                             std::vector<double> resultValues;
                             if ( !newUnits.isEmpty() ){
-                                casa::Vector<double> outputs = converter->convert( inputs, sc );
+                                casacore::Vector<double> outputs = converter->convert( inputs, sc );
                                 resultValues = outputs.tovector();
                             }
                             else {

--- a/carta/cpp/plugins/Histogram/Histogram1.cpp
+++ b/carta/cpp/plugins/Histogram/Histogram1.cpp
@@ -35,7 +35,7 @@ Carta::Lib::Hooks::HistogramResult Histogram1::_computeHistogram( ){
 } // _computeHistogram
 
 std::pair < int, int >
-Histogram1::_getChannelBounds( casa::ImageInterface<casa::Float>* casaImage,
+Histogram1::_getChannelBounds( casacore::ImageInterface<casacore::Float>* casaImage,
         double freqMin, double freqMax, const QString & unitStr ) const{
     std::pair < int, int > bounds( - 1, - 1 );
     if ( ! casaImage ) {
@@ -43,8 +43,8 @@ Histogram1::_getChannelBounds( casa::ImageInterface<casa::Float>* casaImage,
         return bounds;
     }
 
-    casa::CoordinateSystem cSys = casaImage->coordinates();
-    casa::Int specAx = cSys.findCoordinate( casa::Coordinate::SPECTRAL );
+    casacore::CoordinateSystem cSys = casaImage->coordinates();
+    casacore::Int specAx = cSys.findCoordinate( casacore::Coordinate::SPECTRAL );
     if ( specAx < 0 ) {
         //qWarning() << "Image did not have a spectral coordinate";
         /// \todo Does this mean we can only compute histograms on spectral coordinates!?!?!?!
@@ -55,20 +55,20 @@ Histogram1::_getChannelBounds( casa::ImageInterface<casa::Float>* casaImage,
     int channelHigh = - 1;
     std::string units = unitStr.toStdString();
 
-    casa::IPosition imgShape = casaImage->shape();
+    casacore::IPosition imgShape = casaImage->shape();
     int maxChannel = imgShape[specAx] - 1;
-    casa::SpectralCoordinate specCoord = cSys.spectralCoordinate( specAx );
+    casacore::SpectralCoordinate specCoord = cSys.spectralCoordinate( specAx );
 
     //Minimum frequency
-    casa::MVFrequency minMV( casa::Quantity( 0, units ) );
+    casacore::MVFrequency minMV( casacore::Quantity( 0, units ) );
     specCoord.toWorld( minMV, 0 );
-    casa::Quantity minQuantity = minMV.get( units );
+    casacore::Quantity minQuantity = minMV.get( units );
     double lowBound = minQuantity.getValue();
 
     //Maximum frequency
-    casa::MVFrequency maxMV( casa::Quantity( 0, units ) );
+    casacore::MVFrequency maxMV( casacore::Quantity( 0, units ) );
     specCoord.toWorld( maxMV, maxChannel );
-    casa::Quantity maxQuantity = maxMV.get( units );
+    casacore::Quantity maxQuantity = maxMV.get( units );
     double highBound = maxQuantity.getValue();
     if ( highBound < lowBound ) {
         std::swap( highBound, lowBound);
@@ -83,9 +83,9 @@ Histogram1::_getChannelBounds( casa::ImageInterface<casa::Float>* casaImage,
     }
 
     //Lower bound
-    casa::Quantity freqQuantity( frequencyMin, units );
-    casa::MVFrequency mvFreq( freqQuantity );
-    casa::Double pixel = - 1;
+    casacore::Quantity freqQuantity( frequencyMin, units );
+    casacore::MVFrequency mvFreq( freqQuantity );
+    casacore::Double pixel = - 1;
     if ( specCoord.toPixel( pixel, mvFreq ) ) {
         channelLow = qRound( pixel );
         if ( channelLow > maxChannel ) {
@@ -93,9 +93,9 @@ Histogram1::_getChannelBounds( casa::ImageInterface<casa::Float>* casaImage,
         }
     }
 
-    casa::Quantity freqQuantityMax( frequencyMax, units );
-    casa::MVFrequency mvFreqMax( freqQuantityMax );
-    casa::Double pixelMax = - 1;
+    casacore::Quantity freqQuantityMax( frequencyMax, units );
+    casacore::MVFrequency mvFreqMax( freqQuantityMax );
+    casacore::Double pixelMax = - 1;
     if ( specCoord.toPixel( pixelMax, mvFreqMax ) ) {
         channelHigh = qRound( pixelMax );
         if ( channelHigh > maxChannel ) {
@@ -109,7 +109,7 @@ Histogram1::_getChannelBounds( casa::ImageInterface<casa::Float>* casaImage,
 } // _getChannelBounds
 
 std::pair < double, double >
-Histogram1::_getFrequencyBounds( casa::ImageInterface<casa::Float>* casaImage,
+Histogram1::_getFrequencyBounds( casacore::ImageInterface<casacore::Float>* casaImage,
         int channelMin, int channelMax, const QString & unitStr ) const{
     std::pair < double, double > bounds( - 1, - 1 );
     if ( ! casaImage ) {
@@ -117,29 +117,29 @@ Histogram1::_getFrequencyBounds( casa::ImageInterface<casa::Float>* casaImage,
         return bounds;
     }
 
-    casa::CoordinateSystem cSys = casaImage->coordinates();
-    casa::Int specAx = cSys.findCoordinate( casa::Coordinate::SPECTRAL );
+    casacore::CoordinateSystem cSys = casaImage->coordinates();
+    casacore::Int specAx = cSys.findCoordinate( casacore::Coordinate::SPECTRAL );
     if ( specAx < 0 ) {
         //qWarning() << "Image did not have a spectral coordinate";
         return bounds;
     }
 
-    casa::IPosition imgShape = casaImage->shape();
+    casacore::IPosition imgShape = casaImage->shape();
     int chanMin = std::max( 0, channelMin);
     int chanMax = std::min( int(imgShape[specAx]) - 1, channelMax);
 
-    casa::SpectralCoordinate specCoord = cSys.spectralCoordinate( specAx );
+    casacore::SpectralCoordinate specCoord = cSys.spectralCoordinate( specAx );
     std::string units = unitStr.toStdString();
 
     // Lower bound
     double freqLow = - 1;
-    casa::MVFrequency mvFreq( casa::Quantity( 0, units));
+    casacore::MVFrequency mvFreq( casacore::Quantity( 0, units));
     if ( specCoord.toWorld( mvFreq, chanMin ) ) {
         freqLow = mvFreq.get( units ).getValue();
     }
 
     double freqHigh = - 1;
-    casa::MVFrequency mvFreqMax( casa::Quantity( 0, units ) );
+    casacore::MVFrequency mvFreqMax( casacore::Quantity( 0, units ) );
     if ( specCoord.toWorld( mvFreqMax, chanMax ) ) {
         freqHigh = mvFreqMax.get( units ).getValue();
     }
@@ -167,17 +167,17 @@ Histogram1::handleHook( BaseHook & hookData )
             return false;
         }
 
-        casa::ImageInterface<casa::Float> * casaImage = cartaII2casaII_float( image );
+        casacore::ImageInterface<casacore::Float> * casaImage = cartaII2casaII_float( image );
         if( ! casaImage) {
             qWarning() << "Histogram plugin: not an image created by casaimageloader...";
             return false;
         }
         if ( !m_histogram ){
-            m_histogram.reset(new ImageHistogram < casa::Float >());
+            m_histogram.reset(new ImageHistogram < casacore::Float >());
         }
         std::shared_ptr<Carta::Lib::Regions::RegionBase> regionBase = hook.paramsPtr->region;
         QString regionId = hook.paramsPtr->regionId;
-        casa::ImageRegion* imageRegion = nullptr;
+        casacore::ImageRegion* imageRegion = nullptr;
         if ( regionBase ){
         	imageRegion = ImageRegionGenerator::makeRegion( casaImage, regionBase );
         }
@@ -190,8 +190,8 @@ Histogram1::handleHook( BaseHook & hookData )
         int minChannel = - 1;
         int maxChannel = - 1;
         if ( frequencyMin < 0 || frequencyMax < 0 ) {
-            casa::CoordinateSystem cSys = casaImage->coordinates();
-            casa::Int specAx = cSys.findCoordinate( casa::Coordinate::SPECTRAL );
+            casacore::CoordinateSystem cSys = casaImage->coordinates();
+            casacore::Int specAx = cSys.findCoordinate( casacore::Coordinate::SPECTRAL );
             if ( specAx >= 0 ) {
                 minChannel = hook.paramsPtr->minChannel;
                 maxChannel = hook.paramsPtr->maxChannel;

--- a/carta/cpp/plugins/Histogram/Histogram1.h
+++ b/carta/cpp/plugins/Histogram/Histogram1.h
@@ -39,17 +39,17 @@ private:
     /**
      * Returns channel range for the given frequency bounds.
      */
-    std::pair<int,int> _getChannelBounds( casa::ImageInterface<casa::Float>* casaImage,
+    std::pair<int,int> _getChannelBounds( casacore::ImageInterface<casacore::Float>* casaImage,
             double freq1, double freq2,
             const QString& unitStr ) const;
 
     /**
      * Returns frequency bounds corresponding to the given channel range.
      */
-    std::pair<double,double> _getFrequencyBounds( casa::ImageInterface<casa::Float>* casaImage,
+    std::pair<double,double> _getFrequencyBounds( casacore::ImageInterface<casacore::Float>* casaImage,
             int channelMin, int channelMax, const QString& unitStr ) const;
 
     /// Histogram implementation.
-    std::unique_ptr<ImageHistogram<casa::Float>> m_histogram = nullptr;
+    std::unique_ptr<ImageHistogram<casacore::Float>> m_histogram = nullptr;
 
 };

--- a/carta/cpp/plugins/Histogram/ImageHistogram.cpp
+++ b/carta/cpp/plugins/Histogram/ImageHistogram.cpp
@@ -82,7 +82,7 @@ bool ImageHistogram<T>::compute( ){
 		m_histogramMaker->setNBins( m_binCount );
 
 		//Set the intensity range.
-		casa::Vector<T> includeRange;
+		casacore::Vector<T> includeRange;
 		if ( m_intensityMin != ALL_INTENSITIES && m_intensityMax != ALL_INTENSITIES ){
 			includeRange.resize(2);
 			includeRange[0] = m_intensityMin;
@@ -92,8 +92,8 @@ bool ImageHistogram<T>::compute( ){
 		try {
 
 			//Calculate the histogram
-			casa::Array<T> values;
-			casa::Array<T> counts;
+			casacore::Array<T> values;
+			casacore::Array<T> counts;
 			success = m_histogramMaker->getHistograms( values, counts );
 			if ( success ){
 				//Store the data
@@ -103,7 +103,7 @@ bool ImageHistogram<T>::compute( ){
 				counts.tovector( m_yValues );
 			}
 		}
-		catch( casa::AipsError& error ){
+		catch( casacore::AipsError& error ){
 			success = false;
 			qDebug() << "Exception: "<<error.what();
 		}
@@ -115,10 +115,10 @@ bool ImageHistogram<T>::compute( ){
 }
 
 template <class T>
-void ImageHistogram<T>::_filterByChannels( const casa::ImageInterface<T>* image ){
+void ImageHistogram<T>::_filterByChannels( const casacore::ImageInterface<T>* image ){
 	if ( m_channelMin != ALL_CHANNELS && m_channelMax != ALL_CHANNELS ){
 		//Create a slicer from the image
-		casa::CoordinateSystem cSys = image->coordinates();
+		casacore::CoordinateSystem cSys = image->coordinates();
 		if ( cSys.hasSpectralAxis() ){
 			//We use the preset spectral coordinate, if it
 			//exists because images can be rotated when they
@@ -126,12 +126,12 @@ void ImageHistogram<T>::_filterByChannels( const casa::ImageInterface<T>* image 
 			//take rotation into account.
 			int spectralIndex = cSys.spectralAxisNumber();
 			if ( spectralIndex >= 0 ){
-                casa::IPosition imShape = image->shape();
+                casacore::IPosition imShape = image->shape();
 
                 int shapeCount = imShape.nelements();
-                casa::IPosition startPos( shapeCount, 0);
-                casa::IPosition endPos(imShape - 1);
-                casa::IPosition stride( shapeCount, 1);
+                casacore::IPosition startPos( shapeCount, 0);
+                casacore::IPosition endPos(imShape - 1);
+                casacore::IPosition stride( shapeCount, 1);
 
                 int endIndex = m_channelMax;
                 if ( m_channelMax >= imShape(spectralIndex) && m_channelMin < imShape(spectralIndex)){
@@ -141,21 +141,21 @@ void ImageHistogram<T>::_filterByChannels( const casa::ImageInterface<T>* image 
                 startPos[spectralIndex] = m_channelMin;
                 endPos[spectralIndex] = endIndex;
 
-                casa::Slicer channelSlicer( startPos, endPos, stride, casa::Slicer::endIsLast );
-                casa::ImageInterface<T>* img = new casa::SubImage<T>( *(image), channelSlicer );
+                casacore::Slicer channelSlicer( startPos, endPos, stride, casacore::Slicer::endIsLast );
+                casacore::ImageInterface<T>* img = new casacore::SubImage<T>( *(image), channelSlicer );
                 delete m_histogramMaker;
-                m_histogramMaker = new casa::LatticeHistograms<casa::Float>( *img );
+                m_histogramMaker = new casacore::LatticeHistograms<casacore::Float>( *img );
 			}
 		}
 	}
 	else {
 	    delete m_histogramMaker;
-	    m_histogramMaker = new casa::LatticeHistograms<casa::Float>( *image );
+	    m_histogramMaker = new casacore::LatticeHistograms<casacore::Float>( *image );
 	}
 }
 
 template <class T>
-void ImageHistogram<T>::setImage( const casa::ImageInterface<T>*  val ){
+void ImageHistogram<T>::setImage( const casacore::ImageInterface<T>*  val ){
     if ( val != nullptr ){
         if ( m_image == nullptr || m_image->name(true) != val->name(true) ){
             m_image = val;
@@ -165,7 +165,7 @@ void ImageHistogram<T>::setImage( const casa::ImageInterface<T>*  val ){
 }
 
 template <class T>
-void ImageHistogram<T>::setRegion( casa::ImageRegion* region, const QString& id ){
+void ImageHistogram<T>::setRegion( casacore::ImageRegion* region, const QString& id ){
 	if ( m_region == nullptr || m_regionId != id ){
 		delete m_region;
 		m_region = region;
@@ -178,7 +178,7 @@ bool ImageHistogram<T>::_reset(){
 	bool success = true;
 	if ( m_image != nullptr ){
 	    if ( !m_histogramMaker ){
-	        m_histogramMaker = new casa::LatticeHistograms<T>( *(m_image) );
+	        m_histogramMaker = new casacore::LatticeHistograms<T>( *(m_image) );
 	    }
 		try {
 			if ( m_region == NULL ){
@@ -187,7 +187,7 @@ bool ImageHistogram<T>::_reset(){
 			}
 			else {
 				//Make the histogram based on the region
-				casa::SubImage<T>* subImage = new casa::SubImage<T>( *m_image, *m_region );
+				casacore::SubImage<T>* subImage = new casacore::SubImage<T>( *m_image, *m_region );
 				 _filterByChannels( subImage );
 				//Filter will make a new image based on this one so we can delete this sub
 				//image once filter is done.
@@ -195,7 +195,7 @@ bool ImageHistogram<T>::_reset(){
 			}
 			success = compute();
 		}
-		catch( casa::AipsError& error ){
+		catch( casacore::AipsError& error ){
 			success = false;
 			qDebug() << "Error making histogram: "<<error.getMesg().c_str();
 		}
@@ -320,7 +320,7 @@ std::vector< std::pair<double,double> > ImageHistogram<T>::getData() const {
 
 template <class T>
 QString ImageHistogram<T>::getName() const {
-    casa::String strname = ImageHistogram::m_image->name(true);
+    casacore::String strname = ImageHistogram::m_image->name(true);
     QString qname(strname.c_str());
     qname = qname + m_regionId;
 
@@ -334,7 +334,7 @@ QString ImageHistogram<T>::getUnitsX() const {
 
 template<class T>
 QString ImageHistogram<T>::getUnitsY() const {
-    const casa::Unit pixelUnit = ImageHistogram::m_image->units();
+    const casacore::Unit pixelUnit = ImageHistogram::m_image->units();
     return pixelUnit.getName().c_str();
 }
 
@@ -365,7 +365,7 @@ template <class T>
 void ImageHistogram<T>::toAscii( QTextStream& out ) const {
 	const QString LINE_END( "\n");
 	QString centerStr( "#Bin Center(");
-	casa::Unit unit = ImageHistogram::m_image->units();
+	casacore::Unit unit = ImageHistogram::m_image->units();
 	QString unitStr( unit.getName().c_str());
 	centerStr.append( unitStr + ")");
 	out << centerStr << "Count";

--- a/carta/cpp/plugins/Histogram/ImageHistogram.h
+++ b/carta/cpp/plugins/Histogram/ImageHistogram.h
@@ -7,7 +7,7 @@
 
 #include <memory>
 
-namespace casa {
+namespace casacore {
     template <class T> class ImageInterface;
     template <class T> class LatticeHistograms;
     template <class T> class SubImage;
@@ -30,7 +30,7 @@ public:
     virtual bool compute() Q_DECL_OVERRIDE;
 
 	int getDataCount() const;
-	void setRegion(casa::ImageRegion* region, const QString& id );
+	void setRegion(casacore::ImageRegion* region, const QString& id );
 	void defineLine( int index, QVector<double>& xVals, QVector<double>& yVals,
 			bool useLogY ) const;
 	void defineStepHorizontal( int index, QVector<double>& xVals, QVector<double>& yVals,
@@ -53,7 +53,7 @@ public:
 
 	void setIntensityRange( double minimumIntensity, double maximumIntensity )  Q_DECL_OVERRIDE;
 
-	void setImage(const casa::ImageInterface<T>*  val);
+	void setImage(const casacore::ImageInterface<T>*  val);
 	static double computeYValue( double value, bool useLog );
 
 
@@ -64,15 +64,15 @@ private:
 	ImageHistogram operator=( const ImageHistogram<T>& other );
 	//Completely reset the histogram if the image, region, or channels change
 	bool _reset();
-	void _filterByChannels( const casa::ImageInterface<T>*  image );
+	void _filterByChannels( const casacore::ImageInterface<T>*  image );
 
 	vector<T> m_xValues;
 	vector<T> m_yValues;
-	casa::LatticeHistograms<T>* m_histogramMaker;
-	casa::ImageRegion* m_region;
+	casacore::LatticeHistograms<T>* m_histogramMaker;
+	casacore::ImageRegion* m_region;
 	const int ALL_CHANNELS;
 	const int ALL_INTENSITIES;
-    const casa::ImageInterface<T>*  m_image; //Use
+    const casacore::ImageInterface<T>*  m_image; //Use
 	int m_channelMin;
 	int m_channelMax;
 	double m_intensityMin;

--- a/carta/cpp/plugins/Histogram/ImageRegionGenerator.cpp
+++ b/carta/cpp/plugins/Histogram/ImageRegionGenerator.cpp
@@ -19,35 +19,35 @@
 
 const QString ImageRegionGenerator::RAD_UNITS = "rad";
 
-std::pair<casa::Vector<casa::Quantity>,casa::Vector<casa::Quantity> > ImageRegionGenerator::_getEllipsePositionRadii(
-		Carta::Lib::Regions::Ellipse* ellipse, const casa::CoordinateSystem &cs ){
+std::pair<casacore::Vector<casacore::Quantity>,casacore::Vector<casacore::Quantity> > ImageRegionGenerator::_getEllipsePositionRadii(
+		Carta::Lib::Regions::Ellipse* ellipse, const casacore::CoordinateSystem &cs ){
 
 
 	QRectF outlineBox = ellipse->outlineBox();
 	QPointF topLeftPt = outlineBox.topLeft();
 	QPointF centerPt = outlineBox.center();
 	bool validCenter = false;
-	casa::Vector<casa::Double> centerWorld = _toWorld( cs, centerPt.x(), centerPt.y(), &validCenter );
+	casacore::Vector<casacore::Double> centerWorld = _toWorld( cs, centerPt.x(), centerPt.y(), &validCenter );
 	bool validTopLeft = false;
-	casa::Vector<casa::Double> topLeft = _toWorld( cs, topLeftPt.x(), topLeftPt.y(), &validTopLeft );
+	casacore::Vector<casacore::Double> topLeft = _toWorld( cs, topLeftPt.x(), topLeftPt.y(), &validTopLeft );
 
-	casa::Vector<casa::Quantum<casa::Double> > qcenter, qtlc;
-	casa::Vector<casa::Quantity> radii_(2);
+	casacore::Vector<casacore::Quantum<casacore::Double> > qcenter, qtlc;
+	casacore::Vector<casacore::Quantity> radii_(2);
 
 	if ( validCenter && validTopLeft ){
 		qcenter.resize(2);
 		qtlc.resize(2);
 
-		casa::String units( RAD_UNITS.toStdString().c_str() );
+		casacore::String units( RAD_UNITS.toStdString().c_str() );
 
-		qcenter[0] = casa::Quantum<casa::Double>(centerWorld[0], units);
-		qcenter[1] = casa::Quantum<casa::Double>(centerWorld[1], units);
+		qcenter[0] = casacore::Quantum<casacore::Double>(centerWorld[0], units);
+		qcenter[1] = casacore::Quantum<casacore::Double>(centerWorld[1], units);
 
-		qtlc[0] = casa::Quantum<casa::Double>(topLeft[0], units);
-		qtlc[1] = casa::Quantum<casa::Double>(topLeft[1], units);
+		qtlc[0] = casacore::Quantum<casacore::Double>(topLeft[0], units);
+		qtlc[1] = casacore::Quantum<casacore::Double>(topLeft[1], units);
 
 		int directionIndex = cs.directionCoordinateNumber();
-		casa::MDirection::Types cccs = casa::MDirection::N_Types;
+		casacore::MDirection::Types cccs = casacore::MDirection::N_Types;
 		if ( directionIndex < 0 ){
 			// no direction coordinate was found...
 			double c0 = qcenter[0].getValue();
@@ -61,34 +61,34 @@ std::pair<casa::Vector<casa::Quantity>,casa::Vector<casa::Quantity> > ImageRegio
 			cccs = cs.directionCoordinate( directionIndex).directionType( true );
 			// a direction coordinate was found...
 
-			casa::Vector<casa::Double> center_rad(2);
+			casacore::Vector<casacore::Double> center_rad(2);
 			center_rad[0] = qcenter[0].getValue( units );
 			center_rad[1] = qcenter[1].getValue( units );
-			casa::MDirection mdcenter( casa::Quantum<casa::Vector<casa::Double> > (center_rad,units), cccs  );
+			casacore::MDirection mdcenter( casacore::Quantum<casacore::Vector<casacore::Double> > (center_rad,units), cccs  );
 
-			casa::Vector<casa::Double> tlc_rad_x(2);
+			casacore::Vector<casacore::Double> tlc_rad_x(2);
 			tlc_rad_x[0] = qtlc[0].getValue( units);
 			tlc_rad_x[1] = qcenter[1].getValue( units );
-			casa::MDirection mdtlc_x( casa::Quantum<casa::Vector<casa::Double> >(tlc_rad_x,units),cccs );
+			casacore::MDirection mdtlc_x( casacore::Quantum<casacore::Vector<casacore::Double> >(tlc_rad_x,units),cccs );
 
-			casa::Vector<casa::Double> tlc_rad_y(2);
+			casacore::Vector<casacore::Double> tlc_rad_y(2);
 			tlc_rad_y[0] = qcenter[0].getValue(units);
 			tlc_rad_y[1] = qtlc[1].getValue(units);
-			casa::MDirection mdtlc_y( casa::Quantum<casa::Vector<casa::Double> >(tlc_rad_y,units),cccs );
+			casacore::MDirection mdtlc_y( casacore::Quantum<casacore::Vector<casacore::Double> >(tlc_rad_y,units),cccs );
 
 			double xdistance = mdcenter.getValue( ).separation(mdtlc_x.getValue( ));
 			double ydistance = mdcenter.getValue( ).separation(mdtlc_y.getValue( ));
-			radii_[0] = casa::Quantity(xdistance, units);
-			radii_[1] = casa::Quantity(ydistance, units);
+			radii_[0] = casacore::Quantity(xdistance, units);
+			radii_[1] = casacore::Quantity(ydistance, units);
 		}
 	}
 	return std::make_pair(qcenter,radii_);
 }
 
 
-casa::ImageRegion* ImageRegionGenerator::makeRegion( casa::ImageInterface<casa::Float> * casaImage,
+casacore::ImageRegion* ImageRegionGenerator::makeRegion( casacore::ImageInterface<casacore::Float> * casaImage,
 		std::shared_ptr<Carta::Lib::Regions::RegionBase> region ){
-	casa::ImageRegion* imageRegion = nullptr;
+	casacore::ImageRegion* imageRegion = nullptr;
 	if ( region ){
 		QString regionType = region->typeName();
 		if ( regionType == "rectangle" ){
@@ -121,38 +121,38 @@ casa::ImageRegion* ImageRegionGenerator::makeRegion( casa::ImageInterface<casa::
 	return imageRegion;
 }
 
-casa::ImageRegion* ImageRegionGenerator::_makeRegionRectangle( casa::ImageInterface<casa::Float> * image,
+casacore::ImageRegion* ImageRegionGenerator::_makeRegionRectangle( casacore::ImageInterface<casacore::Float> * image,
 		const QRectF& outlineBox){
-	casa::ImageRegion* imageRegion = nullptr;
+	casacore::ImageRegion* imageRegion = nullptr;
 	if ( image ){
-		casa::Vector<casa::Int> dispAxes(2);
-		const casa::CoordinateSystem &cs = image->coordinates( );
-		int directionIndex = cs.findCoordinate( casa::Coordinate::DIRECTION );
+		casacore::Vector<casacore::Int> dispAxes(2);
+		const casacore::CoordinateSystem &cs = image->coordinates( );
+		int directionIndex = cs.findCoordinate( casacore::Coordinate::DIRECTION );
 		if ( directionIndex >= 0 ){
-			casa::Vector<casa::Int> dirPixelAxis = cs.pixelAxes(directionIndex);
+			casacore::Vector<casacore::Int> dirPixelAxis = cs.pixelAxes(directionIndex);
 			dispAxes(0) = dirPixelAxis[0];
 			dispAxes(1) = dirPixelAxis[1];
 
-			casa::Vector<casa::Quantum<casa::Double> > qbrc(2);
-			casa::Vector<casa::Quantum<casa::Double> > qtlc(2);
+			casacore::Vector<casacore::Quantum<casacore::Double> > qbrc(2);
+			casacore::Vector<casacore::Quantum<casacore::Double> > qtlc(2);
 
 			QPointF tlc = outlineBox.topLeft();
 			QPointF brc = outlineBox.bottomRight();
 			bool blcValid = false;
-			casa::Vector<casa::Double> brcWorld = _toWorld( cs, brc.x(), brc.y(), &blcValid );
+			casacore::Vector<casacore::Double> brcWorld = _toWorld( cs, brc.x(), brc.y(), &blcValid );
 			bool trcValid = false;
-			casa::Vector<casa::Double> tlcWorld = _toWorld( cs, tlc.x(), tlc.y(), &trcValid );
+			casacore::Vector<casacore::Double> tlcWorld = _toWorld( cs, tlc.x(), tlc.y(), &trcValid );
 			if ( blcValid && trcValid ){
-				casa::String unitStr( RAD_UNITS.toStdString().c_str() );
-				qtlc[0] = casa::Quantum<casa::Double>( tlcWorld[0], unitStr );
-				qtlc[1] = casa::Quantum<casa::Double>( tlcWorld[1], unitStr );
-				qbrc[0] = casa::Quantum<casa::Double>( brcWorld[0], unitStr );
-				qbrc[1] = casa::Quantum<casa::Double>( brcWorld[1], unitStr );
+				casacore::String unitStr( RAD_UNITS.toStdString().c_str() );
+				qtlc[0] = casacore::Quantum<casacore::Double>( tlcWorld[0], unitStr );
+				qtlc[1] = casacore::Quantum<casacore::Double>( tlcWorld[1], unitStr );
+				qbrc[0] = casacore::Quantum<casacore::Double>( brcWorld[0], unitStr );
+				qbrc[1] = casacore::Quantum<casacore::Double>( brcWorld[1], unitStr );
 				try {
-					casa::WCBox box( qtlc, qbrc, casa::IPosition(dispAxes), cs, casa::Vector<casa::Int>() );
-					imageRegion = new casa::ImageRegion(box);
+					casacore::WCBox box( qtlc, qbrc, casacore::IPosition(dispAxes), cs, casacore::Vector<casacore::Int>() );
+					imageRegion = new casacore::ImageRegion(box);
 				}
-				catch( const casa::AipsError& error ) {
+				catch( const casacore::AipsError& error ) {
 					qDebug() << "Could not make image region error="<<error.getMesg().c_str();
 				}
 			}
@@ -161,26 +161,26 @@ casa::ImageRegion* ImageRegionGenerator::_makeRegionRectangle( casa::ImageInterf
 	return imageRegion;
 }
 
-casa::ImageRegion* ImageRegionGenerator::_makeRegionEllipse( casa::ImageInterface<casa::Float> * image,
+casacore::ImageRegion* ImageRegionGenerator::_makeRegionEllipse( casacore::ImageInterface<casacore::Float> * image,
 		Carta::Lib::Regions::Ellipse* ellipse){
-	casa::ImageRegion* imageRegion = nullptr;
+	casacore::ImageRegion* imageRegion = nullptr;
 	if ( image ){
-		casa::Vector<casa::Int> dispAxes(2);
-		const casa::CoordinateSystem &cs = image->coordinates( );
-		int directionIndex = cs.findCoordinate( casa::Coordinate::DIRECTION );
+		casacore::Vector<casacore::Int> dispAxes(2);
+		const casacore::CoordinateSystem &cs = image->coordinates( );
+		int directionIndex = cs.findCoordinate( casacore::Coordinate::DIRECTION );
 		if ( directionIndex >= 0 ){
-			casa::Vector<casa::Int> dirPixelAxis = cs.pixelAxes(directionIndex);
+			casacore::Vector<casacore::Int> dirPixelAxis = cs.pixelAxes(directionIndex);
 			dispAxes(0) = dirPixelAxis[0];
 			dispAxes(1) = dirPixelAxis[1];
-			std::pair<casa::Vector<casa::Quantity>,casa::Vector<casa::Quantity> > positionRadii =
+			std::pair<casacore::Vector<casacore::Quantity>,casacore::Vector<casacore::Quantity> > positionRadii =
 					_getEllipsePositionRadii( ellipse, cs );
 			if ( positionRadii.second.size( ) == 2 ) {
 				try {
-					casa::WCEllipsoid ellipse( positionRadii.first, positionRadii.second,
-							casa::IPosition(dispAxes), cs );
-					imageRegion = new casa::ImageRegion(ellipse);
+					casacore::WCEllipsoid ellipse( positionRadii.first, positionRadii.second,
+							casacore::IPosition(dispAxes), cs );
+					imageRegion = new casacore::ImageRegion(ellipse);
 				}
-				catch( const casa::AipsError& error ) {
+				catch( const casacore::AipsError& error ) {
 					qDebug() << "Could not calculate ellipse position and radii: "<<error.getMesg().c_str();
 				}
 			}
@@ -189,19 +189,19 @@ casa::ImageRegion* ImageRegionGenerator::_makeRegionEllipse( casa::ImageInterfac
 	return imageRegion;
 }
 
-casa::ImageRegion* ImageRegionGenerator::_makeRegionPolygon( casa::ImageInterface<casa::Float> * image,
+casacore::ImageRegion* ImageRegionGenerator::_makeRegionPolygon( casacore::ImageInterface<casacore::Float> * image,
 		Carta::Lib::Regions::Polygon* polygon ){
-	casa::ImageRegion* imageRegion = nullptr;
+	casacore::ImageRegion* imageRegion = nullptr;
 	if ( image && polygon ){
 		QPolygonF poly = polygon->qpolyf();
 		int cornerPointCount = poly.count();
-		casa::Vector<casa::Double> x( cornerPointCount );
-		casa::Vector<casa::Double> y( cornerPointCount );
-		const casa::CoordinateSystem &cs = image->coordinates( );
+		casacore::Vector<casacore::Double> x( cornerPointCount );
+		casacore::Vector<casacore::Double> y( cornerPointCount );
+		const casacore::CoordinateSystem &cs = image->coordinates( );
 		bool successful = true;
 		for ( int i = 0; i < cornerPointCount; ++i ) {
 			QPointF polyPt = poly.value( i );
-			casa::Vector<casa::Double> worldPt = _toWorld( cs, polyPt.x(), polyPt.y(), &successful );
+			casacore::Vector<casacore::Double> worldPt = _toWorld( cs, polyPt.x(), polyPt.y(), &successful );
 			if ( successful ){
 				x[i] = worldPt[0];
 				y[i] = worldPt[1];
@@ -213,21 +213,21 @@ casa::ImageRegion* ImageRegionGenerator::_makeRegionPolygon( casa::ImageInterfac
 		}
 
 		if ( successful ){
-			casa::Vector<casa::Int> dispAxes(2);
-			const casa::CoordinateSystem &cs = image->coordinates( );
-			int directionIndex = cs.findCoordinate( casa::Coordinate::DIRECTION );
+			casacore::Vector<casacore::Int> dispAxes(2);
+			const casacore::CoordinateSystem &cs = image->coordinates( );
+			int directionIndex = cs.findCoordinate( casacore::Coordinate::DIRECTION );
 			if ( directionIndex >= 0 ){
-				casa::Vector<casa::Int> dirPixelAxis = cs.pixelAxes(directionIndex);
+				casacore::Vector<casacore::Int> dirPixelAxis = cs.pixelAxes(directionIndex);
 				dispAxes(0) = dirPixelAxis[0];
 				dispAxes(1) = dirPixelAxis[1];
-				const casa::String units( RAD_UNITS.toStdString().c_str() );
+				const casacore::String units( RAD_UNITS.toStdString().c_str() );
 				try {
-					casa::Quantum<casa::Vector<casa::Double> > qx( x, units );
-					casa::Quantum<casa::Vector<casa::Double> > qy( y, units );
-					casa::WCPolygon poly(qx, qy, casa::IPosition(dispAxes), cs);
-					imageRegion = new casa::ImageRegion(poly);
+					casacore::Quantum<casacore::Vector<casacore::Double> > qx( x, units );
+					casacore::Quantum<casacore::Vector<casacore::Double> > qy( y, units );
+					casacore::WCPolygon poly(qx, qy, casacore::IPosition(dispAxes), cs);
+					imageRegion = new casacore::ImageRegion(poly);
 				}
-				catch( casa::AipsError& error ) {
+				catch( casacore::AipsError& error ) {
 					qDebug() << "Error making image region: "<<error.getMesg().c_str();
 				}
 			}
@@ -236,11 +236,11 @@ casa::ImageRegion* ImageRegionGenerator::_makeRegionPolygon( casa::ImageInterfac
 	return imageRegion;
 }
 
-casa::Vector<casa::Double> ImageRegionGenerator::_toWorld( const casa::CoordinateSystem& cSys,
+casacore::Vector<casacore::Double> ImageRegionGenerator::_toWorld( const casacore::CoordinateSystem& cSys,
 		double x, double y, bool* successful ){
 	int pixelCount = cSys.nPixelAxes();
-	casa::Vector<casa::Double> pixelPt( pixelCount, 0 );
-	casa::Vector<casa::Double> worldPt;
+	casacore::Vector<casacore::Double> pixelPt( pixelCount, 0 );
+	casacore::Vector<casacore::Double> worldPt;
 	if ( pixelCount >= 2 ){
 		pixelPt[0] = x;
 		pixelPt[1] = y;
@@ -248,7 +248,7 @@ casa::Vector<casa::Double> ImageRegionGenerator::_toWorld( const casa::Coordinat
 			worldPt = cSys.toWorld( pixelPt );
 			*successful = true;
 		}
-		catch( const casa::AipsError& error ){
+		catch( const casacore::AipsError& error ){
 			qDebug() << error.getMesg().c_str();
 			*successful = false;
 		}

--- a/carta/cpp/plugins/Histogram/ImageRegionGenerator.h
+++ b/carta/cpp/plugins/Histogram/ImageRegionGenerator.h
@@ -9,7 +9,7 @@
 #include <QString>
 #include <QRectF>
 
-namespace casa {
+namespace casacore {
     class ImageRegion;
     template <class T> class ImageInterface;
 }
@@ -32,22 +32,22 @@ public:
 	 * @param casaImage - an image.
 	 * @param region - a region in the image.
 	 */
-	static casa::ImageRegion* makeRegion( casa::ImageInterface<casa::Float> * casaImage,
+	static casacore::ImageRegion* makeRegion( casacore::ImageInterface<casacore::Float> * casaImage,
 			std::shared_ptr<Carta::Lib::Regions::RegionBase> region );
 
 	virtual ~ImageRegionGenerator();
 
 private:
 
-	static std::pair<casa::Vector<casa::Quantity>,casa::Vector<casa::Quantity> > _getEllipsePositionRadii(
-			Carta::Lib::Regions::Ellipse* ellipse, const casa::CoordinateSystem &cs );
-	static casa::ImageRegion* _makeRegionRectangle( casa::ImageInterface<casa::Float> * casaImage,
+	static std::pair<casacore::Vector<casacore::Quantity>,casacore::Vector<casacore::Quantity> > _getEllipsePositionRadii(
+			Carta::Lib::Regions::Ellipse* ellipse, const casacore::CoordinateSystem &cs );
+	static casacore::ImageRegion* _makeRegionRectangle( casacore::ImageInterface<casacore::Float> * casaImage,
 			const QRectF& outlineBox);
-	static casa::ImageRegion* _makeRegionEllipse( casa::ImageInterface<casa::Float> * casaImage,
+	static casacore::ImageRegion* _makeRegionEllipse( casacore::ImageInterface<casacore::Float> * casaImage,
 			Carta::Lib::Regions::Ellipse* ellipse);
-	static casa::ImageRegion* _makeRegionPolygon( casa::ImageInterface<casa::Float> * casaImage,
+	static casacore::ImageRegion* _makeRegionPolygon( casacore::ImageInterface<casacore::Float> * casaImage,
 			Carta::Lib::Regions::Polygon* polygon );
-	static casa::Vector<casa::Double> _toWorld( const casa::CoordinateSystem& cSys,
+	static casacore::Vector<casacore::Double> _toWorld( const casacore::CoordinateSystem& cSys,
 			double x, double y, bool* successful );
 	const static QString RAD_UNITS;
 	ImageRegionGenerator();

--- a/carta/cpp/plugins/ImageStatistics/RegionRecordFactory.cpp
+++ b/carta/cpp/plugins/ImageStatistics/RegionRecordFactory.cpp
@@ -20,55 +20,55 @@ RegionRecordFactory::RegionRecordFactory( ){
 }
 
 
-casa::ImageRegion*
+casacore::ImageRegion*
 RegionRecordFactory::_getEllipsoid(
-        const casa::CoordinateSystem& cSys,
-        const casa::Vector<casa::Double>& corner1,
-        const casa::Vector<casa::Double>& corner2 ){
+        const casacore::CoordinateSystem& cSys,
+        const casacore::Vector<casacore::Double>& corner1,
+        const casacore::Vector<casacore::Double>& corner2 ){
     int imageDims = 2;
-    casa::Vector<casa::Quantity> center(imageDims);
-    casa::Vector<casa::Quantity> radius(imageDims);
-    casa::ImageRegion* imageRegion = NULL;
-    int directionIndex = cSys.findCoordinate( casa::Coordinate::DIRECTION );
+    casacore::Vector<casacore::Quantity> center(imageDims);
+    casacore::Vector<casacore::Quantity> radius(imageDims);
+    casacore::ImageRegion* imageRegion = NULL;
+    int directionIndex = cSys.findCoordinate( casacore::Coordinate::DIRECTION );
     if ( directionIndex >= 0 ){
-        const casa::String radUnits( "rad");
-        casa::Vector<casa::String> axisUnits = cSys.worldAxisUnits();
+        const casacore::String radUnits( "rad");
+        casacore::Vector<casacore::String> axisUnits = cSys.worldAxisUnits();
         for ( int i = 0; i < imageDims; i++ ){
-            center[i] = casa::Quantity( (corner1[i] +corner2[i]) / 2, axisUnits[i]);
+            center[i] = casacore::Quantity( (corner1[i] +corner2[i]) / 2, axisUnits[i]);
         }
 
-        casa::uInt dirIndex = static_cast<casa::uInt>(directionIndex);
-        casa::MDirection::Types type = cSys.directionCoordinate(dirIndex).directionType(true);
+        casacore::uInt dirIndex = static_cast<casacore::uInt>(directionIndex);
+        casacore::MDirection::Types type = cSys.directionCoordinate(dirIndex).directionType(true);
 
 
-        casa::Vector<casa::Double> qCenter(imageDims);
-        casa::Vector<casa::Int> dirPixelAxis = cSys.pixelAxes(directionIndex);
+        casacore::Vector<casacore::Double> qCenter(imageDims);
+        casacore::Vector<casacore::Int> dirPixelAxis = cSys.pixelAxes(directionIndex);
         qCenter[0] = center[0].getValue();
         qCenter[1] = center[1].getValue();
-        casa::MDirection mdcenter( casa::Quantum<casa::Vector<casa::Double> >(qCenter,radUnits), type );
+        casacore::MDirection mdcenter( casacore::Quantum<casacore::Vector<casacore::Double> >(qCenter,radUnits), type );
 
-        casa::Vector<casa::Double> blc_rad_x(imageDims);
+        casacore::Vector<casacore::Double> blc_rad_x(imageDims);
         blc_rad_x[0] = corner1[0];
         blc_rad_x[1] = center[1].getValue();
-        casa::MDirection mdblc_x( casa::Quantum<casa::Vector<casa::Double> >(blc_rad_x,radUnits),type );
+        casacore::MDirection mdblc_x( casacore::Quantum<casacore::Vector<casacore::Double> >(blc_rad_x,radUnits),type );
 
-        casa::Vector<casa::Double> blc_rad_y(imageDims);
+        casacore::Vector<casacore::Double> blc_rad_y(imageDims);
         blc_rad_y[0] = center[0].getValue();
         blc_rad_y[1] = corner1[1];
-        casa::MDirection mdblc_y( casa::Quantum<casa::Vector<casa::Double> >(blc_rad_y,radUnits),type );
+        casacore::MDirection mdblc_y( casacore::Quantum<casacore::Vector<casacore::Double> >(blc_rad_y,radUnits),type );
 
         double xdistance = mdcenter.getValue( ).separation(mdblc_x.getValue( ));
         double ydistance = mdcenter.getValue( ).separation(mdblc_y.getValue( ));
         const float ERR = 0;
         if ( xdistance > ERR && ydistance > ERR ){
-            radius[0] = casa::Quantity( xdistance, axisUnits[0]);
-            radius[1] = casa::Quantity( ydistance, axisUnits[1]);
+            radius[0] = casacore::Quantity( xdistance, axisUnits[0]);
+            radius[1] = casacore::Quantity( ydistance, axisUnits[1]);
 
-            casa::Vector<casa::Int> pixax(imageDims);
+            casacore::Vector<casacore::Int> pixax(imageDims);
             pixax[0] = dirPixelAxis[0];
             pixax[1] = dirPixelAxis[1];
-            casa::WCEllipsoid ellipsoid( center, radius, pixax, cSys);
-            imageRegion = new casa::ImageRegion( ellipsoid );
+            casacore::WCEllipsoid ellipsoid( center, radius, pixax, cSys);
+            imageRegion = new casacore::ImageRegion( ellipsoid );
         }
     }
     else {
@@ -111,55 +111,55 @@ RegionRecordFactory::_getMinMaxCorners( const QPolygonF & corners,
 }
 
 
-casa::ImageRegion*
-RegionRecordFactory::_getPolygon( casa::ImageInterface<casa::Float>* casaImage,
+casacore::ImageRegion*
+RegionRecordFactory::_getPolygon( casacore::ImageInterface<casacore::Float>* casaImage,
         const QPolygonF& corners, const std::vector<int>& slice ){
-    casa::ImageRegion* imageRegion = NULL;
+    casacore::ImageRegion* imageRegion = NULL;
 
-    casa::CoordinateSystem cSys = casaImage->coordinates();
-    casa::Vector<casa::String> axisUnits = cSys.worldAxisUnits();
+    casacore::CoordinateSystem cSys = casaImage->coordinates();
+    casacore::Vector<casacore::String> axisUnits = cSys.worldAxisUnits();
     int imageDim = casaImage->shape().nelements();
     int cornerCount = corners.size();
-    casa::Vector<casa::Quantity> worldVertexX(cornerCount);
-    casa::Vector<casa::Quantity> worldVertexY(cornerCount);
-    int directionIndex = cSys.findCoordinate( casa::Coordinate::DIRECTION );
+    casacore::Vector<casacore::Quantity> worldVertexX(cornerCount);
+    casacore::Vector<casacore::Quantity> worldVertexY(cornerCount);
+    int directionIndex = cSys.findCoordinate( casacore::Coordinate::DIRECTION );
     if ( directionIndex >= 0 ){
         for ( int i = 0; i < cornerCount; i++ ){
-            casa::Vector<casa::Double> worldVertex(imageDim);
+            casacore::Vector<casacore::Double> worldVertex(imageDim);
             QPointF corner = corners.value( i );
             bool validVertex = _getWorldVertex( corner.x(), corner.y(), cSys,
                 slice, worldVertex );
             if ( validVertex ){
-                worldVertexX[i] = casa::Quantity( worldVertex[0], axisUnits[0] );
-                worldVertexY[i] = casa::Quantity( worldVertex[1], axisUnits[1] );
+                worldVertexX[i] = casacore::Quantity( worldVertex[0], axisUnits[0] );
+                worldVertexY[i] = casacore::Quantity( worldVertex[1], axisUnits[1] );
             }
             else {
                 qWarning() << "Could not convert vertex: ("<<corner.x()<< ", "<<corner.y()<<")";
             }
         }
-        casa::Vector<casa::Int> dirPixelAxis = cSys.pixelAxes( directionIndex );
-        casa::Vector<casa::Int> pixAx(2);
+        casacore::Vector<casacore::Int> dirPixelAxis = cSys.pixelAxes( directionIndex );
+        casacore::Vector<casacore::Int> pixAx(2);
         pixAx[0] = dirPixelAxis[0];
         pixAx[1] = dirPixelAxis[1];
-        casa::RegionManager regMan;
+        casacore::RegionManager regMan;
         imageRegion = regMan.wpolygon( worldVertexX, worldVertexY,  pixAx, cSys, "abs");
     }
     return imageRegion;
 }
 
 
-casa::ImageRegion*
-RegionRecordFactory::_getRectangle( casa::ImageInterface<casa::Float>* casaImage,
+casacore::ImageRegion*
+RegionRecordFactory::_getRectangle( casacore::ImageInterface<casacore::Float>* casaImage,
         const QPolygonF& corners, const std::vector<int>& slice ){
-    casa::ImageRegion* imageRegion = NULL;
+    casacore::ImageRegion* imageRegion = NULL;
 
     std::pair<double,double> minCorners;
     std::pair<double,double> maxCorners;
     _getMinMaxCorners( corners, minCorners, maxCorners );
-    casa::CoordinateSystem cSys = casaImage->coordinates();
+    casacore::CoordinateSystem cSys = casaImage->coordinates();
     int imageDim = casaImage->shape().nelements();
-    casa::Vector<casa::Double> worldVerticesBLC( imageDim );
-    casa::Vector<casa::Double> worldVerticesTRC( imageDim );
+    casacore::Vector<casacore::Double> worldVerticesBLC( imageDim );
+    casacore::Vector<casacore::Double> worldVerticesTRC( imageDim );
 
     bool blcValid = _getWorldVertex( minCorners.first, minCorners.second, cSys,
             slice, worldVerticesBLC );
@@ -167,28 +167,28 @@ RegionRecordFactory::_getRectangle( casa::ImageInterface<casa::Float>* casaImage
             slice, worldVerticesTRC );
 
     if ( blcValid && trcValid ){
-        casa::Vector<casa::String> axisUnits = cSys.worldAxisUnits();
-        casa::Vector<casa::Quantity> blc(imageDim);
-        casa::Vector<casa::Quantity> trc(imageDim);
+        casacore::Vector<casacore::String> axisUnits = cSys.worldAxisUnits();
+        casacore::Vector<casacore::Quantity> blc(imageDim);
+        casacore::Vector<casacore::Quantity> trc(imageDim);
         for ( int ax = 0; ax < imageDim; ax++) {
-            blc[ax] = casa::Quantity( worldVerticesBLC[ax], axisUnits[ax] );
-            trc[ax] = casa::Quantity( worldVerticesTRC[ax], axisUnits[ax] );
+            blc[ax] = casacore::Quantity( worldVerticesBLC[ax], axisUnits[ax] );
+            trc[ax] = casacore::Quantity( worldVerticesTRC[ax], axisUnits[ax] );
         }
-        casa::WCBox box(blc, trc, cSys, casa::Vector<casa::Int>());
-        imageRegion = new casa::ImageRegion(box);
+        casacore::WCBox box(blc, trc, cSys, casacore::Vector<casacore::Int>());
+        imageRegion = new casacore::ImageRegion(box);
     }
     return imageRegion;
 }
 
 
-casa::Record RegionRecordFactory::getRegionRecord(
-        casa::ImageInterface<casa::Float>* casaImage,
+casacore::Record RegionRecordFactory::getRegionRecord(
+        casacore::ImageInterface<casacore::Float>* casaImage,
         std::shared_ptr<Carta::Lib::Regions::RegionBase> region,
     const std::vector<int>& slice,
     QString& typeStr ){
-    casa::Record regionRecord;
+    casacore::Record regionRecord;
     //Do a quick check to make sure the slice is actually in the image.
-    casa::IPosition imageShape = casaImage->shape();
+    casacore::IPosition imageShape = casaImage->shape();
     if ( imageShape.nelements() != slice.size() ){
         //Slice does not match image shape.
         return regionRecord;
@@ -223,11 +223,11 @@ casa::Record RegionRecordFactory::getRegionRecord(
 }
 
 
-casa::Record RegionRecordFactory::_getRegionRecordEllipse(
-        casa::ImageInterface<casa::Float>* casaImage,
+casacore::Record RegionRecordFactory::_getRegionRecordEllipse(
+        casacore::ImageInterface<casacore::Float>* casaImage,
         std::shared_ptr<Carta::Lib::Regions::RegionBase> region,
         const std::vector<int>& slice){
-    casa::Record regionRecord;
+    casacore::Record regionRecord;
     if ( region ){
         QRectF boundingRect = region->outlineBox();
         QPointF topLeftCorner = boundingRect.topLeft();
@@ -236,16 +236,16 @@ casa::Record RegionRecordFactory::_getRegionRecordEllipse(
         std::pair<double,double> maxCorner( bottomRightCorner.x(), bottomRightCorner.y());
 
         //Get the bounding box corners for the ellipse in world coordinates.
-        casa::CoordinateSystem cSys = casaImage->coordinates();
-        casa::Vector<casa::Double> worldVertex1;
+        casacore::CoordinateSystem cSys = casaImage->coordinates();
+        casacore::Vector<casacore::Double> worldVertex1;
         bool valid1 = _getWorldVertex( minCorner.first, minCorner.second, cSys,
                 slice, worldVertex1 );
-        casa::Vector<casa::Double> worldVertex2;
+        casacore::Vector<casacore::Double> worldVertex2;
         bool valid2 = _getWorldVertex( maxCorner.first, maxCorner.second, cSys,
                 slice, worldVertex2 );
         if ( valid1 && valid2 ){
             //Make an elliptical region based on the corners.
-            casa::ImageRegion* ellipsoid = _getEllipsoid( cSys, worldVertex1, worldVertex2 );
+            casacore::ImageRegion* ellipsoid = _getEllipsoid( cSys, worldVertex1, worldVertex2 );
             if ( ellipsoid != NULL ){
                 regionRecord = ellipsoid->toRecord("");
                 delete ellipsoid;
@@ -258,17 +258,17 @@ casa::Record RegionRecordFactory::_getRegionRecordEllipse(
     return regionRecord;
 }
 
-casa::Record RegionRecordFactory::_getRegionRecordPolygon(
-        casa::ImageInterface<casa::Float>* casaImage,
+casacore::Record RegionRecordFactory::_getRegionRecordPolygon(
+        casacore::ImageInterface<casacore::Float>* casaImage,
         std::shared_ptr<Carta::Lib::Regions::RegionBase> region,
         const std::vector<int>& slice, QString& typeStr ){
-    casa::Record regionRecord;
+    casacore::Record regionRecord;
     if ( region ){
         Carta::Lib::Regions::Polygon* polygonRegion = dynamic_cast<Carta::Lib::Regions::Polygon*>( region.get());
         QPolygonF polygon = polygonRegion->qpolyf();
         int cornerCount = polygon.size();
 
-        casa::ImageRegion* region = nullptr;
+        casacore::ImageRegion* region = nullptr;
         //Polygonal region
         if ( cornerCount >= 3 ){
             typeStr = "Polygon";
@@ -285,18 +285,18 @@ casa::Record RegionRecordFactory::_getRegionRecordPolygon(
     return regionRecord;
 }
 
-casa::Record RegionRecordFactory::_getRegionRecordPoint(
-        casa::ImageInterface<casa::Float>* casaImage,
+casacore::Record RegionRecordFactory::_getRegionRecordPoint(
+        casacore::ImageInterface<casacore::Float>* casaImage,
         std::shared_ptr<Carta::Lib::Regions::RegionBase> region,
         const std::vector<int>& slice, QString& typeStr ){
-    casa::Record regionRecord;
+    casacore::Record regionRecord;
     if ( region ){
     	Carta::Lib::Regions::Point* pointRegion = dynamic_cast<Carta::Lib::Regions::Point*>( region.get());
     	QRectF polygon = pointRegion->outlineBox();
     	QPointF centerVal = polygon.center();
     	QRectF pointRect( centerVal.x(), centerVal.y(), centerVal.x(), centerVal.y() );
     	typeStr = "Point";
-    	casa::ImageRegion* region = _getRectangle( casaImage, pointRect, slice );
+    	casacore::ImageRegion* region = _getRectangle( casaImage, pointRect, slice );
     	if ( region != nullptr ){
     		regionRecord = region->toRecord("");
     		delete region;
@@ -306,18 +306,18 @@ casa::Record RegionRecordFactory::_getRegionRecordPoint(
 }
 
 
-casa::Record RegionRecordFactory::_getRegionRecordRectangle(
-        casa::ImageInterface<casa::Float>* casaImage,
+casacore::Record RegionRecordFactory::_getRegionRecordRectangle(
+        casacore::ImageInterface<casacore::Float>* casaImage,
         std::shared_ptr<Carta::Lib::Regions::RegionBase> region,
         const std::vector<int>& slice, QString& typeStr ){
-    casa::Record regionRecord;
+    casacore::Record regionRecord;
     if ( region ){
     	Carta::Lib::Regions::Rectangle* rectRegion = dynamic_cast<Carta::Lib::Regions::Rectangle*>( region.get());
     	QRectF polygon = rectRegion->outlineBox();
     	int width = polygon.width();
     	int height = polygon.height();
 
-    	casa::ImageRegion* region = nullptr;
+    	casacore::ImageRegion* region = nullptr;
     	//Rectangular region or point
     	if ( width > 0 || height > 0 ){
     		typeStr = "Rectangle";
@@ -332,14 +332,14 @@ casa::Record RegionRecordFactory::_getRegionRecordRectangle(
 }
 
 
-bool RegionRecordFactory::_getWorldVertex( int pixelX, int pixelY, const casa::CoordinateSystem& cSys,
-        const std::vector<int>& slice, casa::Vector<casa::Double>& worldVertices ){
+bool RegionRecordFactory::_getWorldVertex( int pixelX, int pixelY, const casacore::CoordinateSystem& cSys,
+        const std::vector<int>& slice, casacore::Vector<casacore::Double>& worldVertices ){
     int imageDim = slice.size();
     bool worldFilled = false;
-    casa::Vector<casa::Double> pixelVertices( imageDim );
-    casa::Int directionIndex = cSys.findCoordinate(casa::Coordinate::DIRECTION);
+    casacore::Vector<casacore::Double> pixelVertices( imageDim );
+    casacore::Int directionIndex = cSys.findCoordinate(casacore::Coordinate::DIRECTION);
     if ( directionIndex >= 0 ){
-        casa::Vector<casa::Int> dirPixelAxis = cSys.pixelAxes(directionIndex);
+        casacore::Vector<casacore::Int> dirPixelAxis = cSys.pixelAxes(directionIndex);
         for ( int ax = 0; ax < imageDim; ax++) {
             if ( ax == dirPixelAxis[0] ) {
                 pixelVertices[ax] = pixelX;

--- a/carta/cpp/plugins/ImageStatistics/RegionRecordFactory.h
+++ b/carta/cpp/plugins/ImageStatistics/RegionRecordFactory.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include "CartaLib/Regions/IRegion.h"
 
-namespace casa {
+namespace casacore {
     class ImageRegion;
 }
 
@@ -24,8 +24,8 @@ public:
      * @param typeStr - an identifier for the type of region (return value).
      * @return - a record representation of the region.
      */
-	static casa::Record getRegionRecord(
-	        casa::ImageInterface<casa::Float>* casaImage,
+	static casacore::Record getRegionRecord(
+	        casacore::ImageInterface<casacore::Float>* casaImage,
 	        std::shared_ptr<Carta::Lib::Regions::RegionBase> region,
 	        const std::vector<int>& slice, QString& typeStr );
 
@@ -36,42 +36,42 @@ private:
 	RegionRecordFactory( const RegionRecordFactory& other );
 	RegionRecordFactory operator=( const RegionRecordFactory& other );
 
-	static casa::ImageRegion*
-	_getEllipsoid(const casa::CoordinateSystem& cSys,
-	            const casa::Vector<casa::Double>& x, const casa::Vector<casa::Double>& y);
+	static casacore::ImageRegion*
+	_getEllipsoid(const casacore::CoordinateSystem& cSys,
+	            const casacore::Vector<casacore::Double>& x, const casacore::Vector<casacore::Double>& y);
 
 	static void _getMinMaxCorners( const QPolygonF & corners,
 	        std::pair<double,double>& minCorner, std::pair<double,double>& maxCorner);
 
-	static casa::ImageRegion*
-	_getPolygon( casa::ImageInterface<casa::Float>* casaImage,
+	static casacore::ImageRegion*
+	_getPolygon( casacore::ImageInterface<casacore::Float>* casaImage,
 	        const QPolygonF& corners, const std::vector<int>& slice );
 
-	static casa::ImageRegion*
-	_getRectangle( casa::ImageInterface<casa::Float>* casaImage,
+	static casacore::ImageRegion*
+	_getRectangle( casacore::ImageInterface<casacore::Float>* casaImage,
 	        const QPolygonF& corners,
 	        const std::vector<int>& slice );
 
-	static casa::Record _getRegionRecordEllipse(
-	        casa::ImageInterface<casa::Float>* casaImage,
+	static casacore::Record _getRegionRecordEllipse(
+	        casacore::ImageInterface<casacore::Float>* casaImage,
 	        std::shared_ptr<Carta::Lib::Regions::RegionBase> region,
 	        const std::vector<int>& slice);
 
-	static casa::Record _getRegionRecordPoint(
-	        casa::ImageInterface<casa::Float>* casaImage,
+	static casacore::Record _getRegionRecordPoint(
+	        casacore::ImageInterface<casacore::Float>* casaImage,
 	        std::shared_ptr<Carta::Lib::Regions::RegionBase> region,
 	        const std::vector<int>& slice, QString& typeStr );
 
-	static casa::Record _getRegionRecordPolygon(
-	        casa::ImageInterface<casa::Float>* casaImage,
+	static casacore::Record _getRegionRecordPolygon(
+	        casacore::ImageInterface<casacore::Float>* casaImage,
 	        std::shared_ptr<Carta::Lib::Regions::RegionBase> region,
 	        const std::vector<int>& slice, QString& typeStr );
 
-	static casa::Record _getRegionRecordRectangle(
-	        casa::ImageInterface<casa::Float>* casaImage,
+	static casacore::Record _getRegionRecordRectangle(
+	        casacore::ImageInterface<casacore::Float>* casaImage,
 	        std::shared_ptr<Carta::Lib::Regions::RegionBase> region,
 	        const std::vector<int>& slice, QString& typeStr );
 
-	static bool _getWorldVertex( int pixelX, int pixelY, const casa::CoordinateSystem& cSys,
-	        const std::vector<int>& slice, casa::Vector<casa::Double>& worldVertices );
+	static bool _getWorldVertex( int pixelX, int pixelY, const casacore::CoordinateSystem& cSys,
+	        const std::vector<int>& slice, casacore::Vector<casacore::Double>& worldVertices );
 };

--- a/carta/cpp/plugins/ImageStatistics/StatisticsCASA.cpp
+++ b/carta/cpp/plugins/ImageStatistics/StatisticsCASA.cpp
@@ -37,7 +37,7 @@ StatisticsCASA::handleHook( BaseHook & hookData ){
                 qWarning() << "Missing image for statistics";
                 continue;
             }
-            casa::ImageInterface<casa::Float>* casaImage = cartaII2casaII_float( image );
+            casacore::ImageInterface<casacore::Float>* casaImage = cartaII2casaII_float( image );
             if( ! casaImage) {
                 qWarning() << "Image statistics plugin: not an image created by casaimageloader...";
                 return false;

--- a/carta/cpp/plugins/ImageStatistics/StatisticsCASAImage.cpp
+++ b/carta/cpp/plugins/ImageStatistics/StatisticsCASAImage.cpp
@@ -13,7 +13,7 @@ StatisticsCASAImage::StatisticsCASAImage() {
 }
 
 
-std::vector<QString> StatisticsCASAImage::_beamAsStringVector( const casa::GaussianBeam &beam ){
+std::vector<QString> StatisticsCASAImage::_beamAsStringVector( const casacore::GaussianBeam &beam ){
     std::vector<QString> result;
     if (! beam.isNull()) {
         char buf[512];
@@ -23,9 +23,9 @@ std::vector<QString> StatisticsCASAImage::_beamAsStringVector( const casa::Gauss
             result.push_back(QString(buf));
             sprintf( buf,"%.2f\"", beam.getMinor("arcsec") );
             result.push_back(QString(buf));
-            //sprintf( buf,"%.2f%s", beam.getPA("deg", casa::True), "\u00B0" );
+            //sprintf( buf,"%.2f%s", beam.getPA("deg", casacore::True), "\u00B0" );
             //temporary solution to correctly display 'degree' char
-            sprintf( buf,"%.2fdeg", beam.getPA("deg", casa::True) );
+            sprintf( buf,"%.2fdeg", beam.getPA("deg", casacore::True) );
             result.push_back(QString(buf));
         }
         if (beam.getMinor("arcsec") <= 0.1){
@@ -33,9 +33,9 @@ std::vector<QString> StatisticsCASAImage::_beamAsStringVector( const casa::Gauss
             result.push_back(QString(buf));
             sprintf( buf,"%.3f\"", beam.getMinor("arcsec") );
             result.push_back(QString(buf));
-            //sprintf( buf,"%.2f%s", beam.getPA("deg", casa::True), "\u00B0" );
+            //sprintf( buf,"%.2f%s", beam.getPA("deg", casacore::True), "\u00B0" );
             //temporary solution to correctly display 'degree' char
-            sprintf( buf,"%.2fdeg", beam.getPA("deg", casa::True) );
+            sprintf( buf,"%.2fdeg", beam.getPA("deg", casacore::True) );
             result.push_back(QString(buf));
         }
         if (beam.getMinor("arcsec") <= 0.01){
@@ -43,9 +43,9 @@ std::vector<QString> StatisticsCASAImage::_beamAsStringVector( const casa::Gauss
             result.push_back(QString(buf));
             sprintf( buf,"%.4f\"", beam.getMinor("arcsec") );
             result.push_back(QString(buf));
-            //sprintf( buf,"%.2f%s", beam.getPA("deg", casa::True), "\u00B0" );
+            //sprintf( buf,"%.2f%s", beam.getPA("deg", casacore::True), "\u00B0" );
             //temporary solution to correctly display 'degree' char
-            sprintf( buf,"%.2fdeg", beam.getPA("deg", casa::True) );
+            sprintf( buf,"%.2fdeg", beam.getPA("deg", casacore::True) );
             result.push_back(QString(buf));
         }
         if (beam.getMinor("arcsec") >= 60.0){
@@ -53,9 +53,9 @@ std::vector<QString> StatisticsCASAImage::_beamAsStringVector( const casa::Gauss
             result.push_back(QString(buf));
             sprintf( buf,"%.2f\'", beam.getMinor("arcmin") );
             result.push_back(QString(buf));
-            //sprintf( buf,"%.2f%s", beam.getPA("deg", casa::True), "\u00B0" );
+            //sprintf( buf,"%.2f%s", beam.getPA("deg", casacore::True), "\u00B0" );
             //temporary solution to correctly display 'degree' char
-            sprintf( buf,"%.2fdeg", beam.getPA("deg", casa::True) );
+            sprintf( buf,"%.2fdeg", beam.getPA("deg", casacore::True) );
             result.push_back(QString(buf));
         }
     }
@@ -63,21 +63,21 @@ std::vector<QString> StatisticsCASAImage::_beamAsStringVector( const casa::Gauss
 }
 
 
-bool StatisticsCASAImage::_beamCompare( const casa::GaussianBeam &a, const casa::GaussianBeam &b ) {
+bool StatisticsCASAImage::_beamCompare( const casacore::GaussianBeam &a, const casacore::GaussianBeam &b ) {
     return a.getArea("rad2") < b.getArea("rad2");
 }
 
 
-void StatisticsCASAImage::_computeStats(const casa::ImageInterface<casa::Float>* image,
+void StatisticsCASAImage::_computeStats(const casacore::ImageInterface<casacore::Float>* image,
         QList<Carta::Lib::StatInfo>& stats ){
-    casa::Vector<casa::Int> shapeVector = image->shape().asVector();
+    casacore::Vector<casacore::Int> shapeVector = image->shape().asVector();
     int dimCount = shapeVector.nelements();
     if (dimCount <= 0 ){
         return;
     }
     _insertShape( shapeVector, stats );
 
-    const casa::CoordinateSystem cs = image->coordinates();
+    const casacore::CoordinateSystem cs = image->coordinates();
     _insertRaDec( cs, shapeVector, stats );
 
     _insertSpectral( cs, shapeVector, stats );
@@ -86,7 +86,7 @@ void StatisticsCASAImage::_computeStats(const casa::ImageInterface<casa::Float>*
 }
 
 
-void StatisticsCASAImage::_getStatsPlanar( const casa::ImageInterface<casa::Float>* image,
+void StatisticsCASAImage::_getStatsPlanar( const casacore::ImageInterface<casacore::Float>* image,
         QList<Carta::Lib::StatInfo>& statsMap, int zIndex, int hIndex ) {
 
     try {
@@ -95,14 +95,14 @@ void StatisticsCASAImage::_getStatsPlanar( const casa::ImageInterface<casa::Floa
             return;
         }
 
-        const casa::CoordinateSystem cs = image->coordinates();
+        const casacore::CoordinateSystem cs = image->coordinates();
 
         int zAxis = -1;
         if ( cs.hasSpectralAxis() ){
             zAxis = cs.spectralAxisNumber();
         }
         else {
-            int tabIndex = cs.findCoordinate( casa::Coordinate::TABULAR );
+            int tabIndex = cs.findCoordinate( casacore::Coordinate::TABULAR );
             if ( tabIndex >= 0 ){
                 zAxis = tabIndex;
             }
@@ -115,33 +115,33 @@ void StatisticsCASAImage::_getStatsPlanar( const casa::ImageInterface<casa::Floa
         }
 
         //Get the axis names
-        casa::Vector<casa::String> axesNames = cs.worldAxisNames();
+        casacore::Vector<casacore::String> axesNames = cs.worldAxisNames();
         int nameCount = axesNames.size();
-        casa::String zAxisName("");
+        casacore::String zAxisName("");
         if ( zAxis >= 0 && zAxis < nameCount ){
             zAxisName = axesNames[zAxis];
         }
-        casa::String hAxisName("");
+        casacore::String hAxisName("");
         if ( hAxis >= 0 && hAxis < nameCount ){
             hAxisName = axesNames[hAxis ];
         }
 
-        casa::String zUnit, zspKey, zspVal;
+        casacore::String zUnit, zspKey, zspVal;
 
-        casa::String unit =  image->units().getName();
+        casacore::String unit =  image->units().getName();
 
         //Region Spectral Plane
-        casa::Vector<casa::Double> tWrld;
+        casacore::Vector<casacore::Double> tWrld;
 
-        casa::String tStr;
-        casa::Vector<casa::Double>tPix = cs.referencePixel();
+        casacore::String tStr;
+        casacore::Vector<casacore::Double>tPix = cs.referencePixel();
         int tPixSize = tPix.nelements();
         if (zIndex > -1 && zAxis >= 0 && zAxis < tPixSize ) {
             tPix(zAxis) = zIndex;
             if ( cs.toWorld( tWrld, tPix)){
-                casa::String zLabel = cs.format(tStr, casa::Coordinate::DEFAULT, tWrld(zAxis), zAxis,
+                casacore::String zLabel = cs.format(tStr, casacore::Coordinate::DEFAULT, tWrld(zAxis), zAxis,
                         true, true, -1, false);
-                casa::String valueStr( zLabel + tStr );
+                casacore::String valueStr( zLabel + tStr );
                 Carta::Lib::StatInfo info( Carta::Lib::StatInfo::StatType::Frequency );
                 info.setValue( valueStr.c_str() );
                 statsMap.append( info );
@@ -152,7 +152,7 @@ void StatisticsCASAImage::_getStatsPlanar( const casa::ImageInterface<casa::Floa
         if (hAxis > -1) {
             tPix(hAxis) = hIndex;
             if ( cs.toWorld( tWrld, tPix) ){
-                casa::String hLabel = cs.format(tStr, casa::Coordinate::DEFAULT, tWrld(hAxis), hAxis,
+                casacore::String hLabel = cs.format(tStr, casacore::Coordinate::DEFAULT, tWrld(hAxis), hAxis,
                         true, true, -1, false );
                 if ( hLabel != "" ){
                     Carta::Lib::StatInfo info( Carta::Lib::StatInfo::StatType::Stokes );
@@ -163,13 +163,13 @@ void StatisticsCASAImage::_getStatsPlanar( const casa::ImageInterface<casa::Floa
         }
 
         //Frequency & Velocity
-        casa::Int spInd = cs.findCoordinate(casa::Coordinate::SPECTRAL);
-        casa::SpectralCoordinate spCoord;
+        casacore::Int spInd = cs.findCoordinate(casacore::Coordinate::SPECTRAL);
+        casacore::SpectralCoordinate spCoord;
         if ( spInd>=0 ) {
             spCoord=cs.spectralCoordinate(spInd);
             spCoord.setVelocity();
-            casa::Double vel;
-            casa::Double restFreq = spCoord.restFrequency();
+            casacore::Double vel;
+            casacore::Double restFreq = spCoord.restFrequency();
             if (downcase(zAxisName).contains("freq")) {
                 Carta::Lib::StatInfo info( Carta::Lib::StatInfo::StatType::Velocity );
                 if (restFreq >0 && spCoord.pixelToVelocity(vel, zIndex)) {
@@ -192,20 +192,20 @@ void StatisticsCASAImage::_getStatsPlanar( const casa::ImageInterface<casa::Floa
         info.setValue( unitval.c_str() );
         statsMap.append( info );
 
-        casa::Double beamArea = 0;
-        casa::ImageInfo ii = image->imageInfo();
-        casa::GaussianBeam beam = ii.restoringBeam(zIndex);
+        casacore::Double beamArea = 0;
+        casacore::ImageInfo ii = image->imageInfo();
+        casacore::GaussianBeam beam = ii.restoringBeam(zIndex);
         std::string imageUnits = image->units().getName();
         std::transform( imageUnits.begin(), imageUnits.end(), imageUnits.begin(), ::toupper );
 
-        casa::Int afterCoord = -1;
-        casa::Int dC = cs.findCoordinate(casa::Coordinate::DIRECTION, afterCoord);
+        casacore::Int afterCoord = -1;
+        casacore::Int dC = cs.findCoordinate(casacore::Coordinate::DIRECTION, afterCoord);
         if ( ! beam.isNull() && dC!=-1 && imageUnits.find("JY/BEAM") != std::string::npos ) {
-            casa::DirectionCoordinate dCoord = cs.directionCoordinate(dC);
-            casa::Vector<casa::String> units(2);
+            casacore::DirectionCoordinate dCoord = cs.directionCoordinate(dC);
+            casacore::Vector<casacore::String> units(2);
             units(0) = units(1) = "rad";
             dCoord.setWorldAxisUnits(units);
-            casa::Vector<casa::Double> deltas = dCoord.increment();
+            casacore::Vector<casacore::Double> deltas = dCoord.increment();
             double divisor = qAbs( deltas(0)* deltas(1));
             beamArea = beam.getArea("rad2") / divisor;
         }
@@ -216,14 +216,14 @@ void StatisticsCASAImage::_getStatsPlanar( const casa::ImageInterface<casa::Floa
             statsMap.append( info );
         }
     }
-    catch (const casa::AipsError& err) {
+    catch (const casacore::AipsError& err) {
         std::string errMsg_ = err.getMesg();
         qDebug() << "Error: "<<errMsg_.c_str();
     }
 }
 
 QList<Carta::Lib::StatInfo>
-StatisticsCASAImage::getStats( const casa::ImageInterface<casa::Float>* image ){
+StatisticsCASAImage::getStats( const casacore::ImageInterface<casacore::Float>* image ){
     QList<Carta::Lib::StatInfo> stats;
     if ( image ){
         Carta::Lib::StatInfo info( Carta::Lib::StatInfo::StatType::Name );
@@ -242,34 +242,34 @@ StatisticsCASAImage::getStats( const casa::ImageInterface<casa::Float>* image ){
 }
 
 
-void StatisticsCASAImage::_insertRaDec( const casa::CoordinateSystem& cs,
-        casa::Vector<casa::Int>& shapeVector,
+void StatisticsCASAImage::_insertRaDec( const casacore::CoordinateSystem& cs,
+        casacore::Vector<casacore::Int>& shapeVector,
         QList<Carta::Lib::StatInfo> & stats ){
     if ( cs.hasDirectionCoordinate( ) ) {
-        const casa::DirectionCoordinate &direction = cs.directionCoordinate( );
-        casa::String directionType = casa::MDirection::showType(direction.directionType( ));
-        casa::Vector<double> refval = direction.referenceValue( );
+        const casacore::DirectionCoordinate &direction = cs.directionCoordinate( );
+        casacore::String directionType = casacore::MDirection::showType(direction.directionType( ));
+        casacore::Vector<double> refval = direction.referenceValue( );
         if ( refval.size( ) == 2 ) {
-            casa::Vector<int> direction_axes = cs.directionAxesNumbers( );
-            casa::Vector<double> pix(direction_axes.size( ));
+            casacore::Vector<int> direction_axes = cs.directionAxesNumbers( );
+            casacore::Vector<double> pix(direction_axes.size( ));
             for ( unsigned int x=0; x < pix.size( ); ++x ){
                 pix[x] = 0;
             }
-            casa::Vector<double> world (pix.size( ));
+            casacore::Vector<double> world (pix.size( ));
             direction.toWorld(world,pix);
 
-            casa::String units;
+            casacore::String units;
             std::vector<QString> raStr;
-            raStr.push_back(direction.format( units, casa::Coordinate::DEFAULT, world[0], 0, true, true ).c_str());
+            raStr.push_back(direction.format( units, casacore::Coordinate::DEFAULT, world[0], 0, true, true ).c_str());
             std::vector<QString> decStr;
-            decStr.push_back(direction.format( units, casa::Coordinate::DEFAULT, world[1], 1, true, true ).c_str());
+            decStr.push_back(direction.format( units, casacore::Coordinate::DEFAULT, world[1], 1, true, true ).c_str());
 
             for ( unsigned int x=0; x < pix.size( ); ++x ){
                 pix[x] = shapeVector[direction_axes[x]];
             }
             direction.toWorld(world,pix);
-            raStr.push_back(direction.format( units, casa::Coordinate::DEFAULT, world[0], 0, true, true ).c_str());
-            decStr.push_back(direction.format( units, casa::Coordinate::DEFAULT, world[1], 1, true, true ).c_str());
+            raStr.push_back(direction.format( units, casacore::Coordinate::DEFAULT, world[0], 0, true, true ).c_str());
+            decStr.push_back(direction.format( units, casacore::Coordinate::DEFAULT, world[1], 1, true, true ).c_str());
 
             QString raRange = raStr[0] + ", " + raStr[1];
             QString decRange = decStr[0] + ", " + decStr[1];
@@ -288,10 +288,10 @@ void StatisticsCASAImage::_insertRaDec( const casa::CoordinateSystem& cs,
     }
 }
 
-void StatisticsCASAImage::_insertRestoringBeam( const casa::ImageInterface<casa::Float>* image,
+void StatisticsCASAImage::_insertRestoringBeam( const casacore::ImageInterface<casacore::Float>* image,
         QList<Carta::Lib::StatInfo>& stats ){
-    casa::ImageInfo imageInfo = image->imageInfo();
-   std::vector<casa::GaussianBeam> restoringBeams;
+    casacore::ImageInfo imageInfo = image->imageInfo();
+   std::vector<casacore::GaussianBeam> restoringBeams;
    Carta::Lib::StatInfo::StatType beamType = Carta::Lib::StatInfo::StatType::MedianRestoringBeam;
    if ( imageInfo.hasBeam( ) ) {
        if ( imageInfo.hasMultipleBeams( ) ) {
@@ -313,7 +313,7 @@ void StatisticsCASAImage::_insertRestoringBeam( const casa::ImageInterface<casa:
    }
 }
 
-void StatisticsCASAImage::_insertShape( const casa::Vector<casa::Int>& shapeVector,
+void StatisticsCASAImage::_insertShape( const casacore::Vector<casacore::Int>& shapeVector,
         QList<Carta::Lib::StatInfo>& stats ){
     QString shapeStr( "[");
     int dimCount = shapeVector.nelements();
@@ -329,11 +329,11 @@ void StatisticsCASAImage::_insertShape( const casa::Vector<casa::Int>& shapeVect
     stats.append( info );
 }
 
-void StatisticsCASAImage::_insertSpectral( const casa::CoordinateSystem& cs,
-        casa::Vector<casa::Int>& shapeVector, QList<Carta::Lib::StatInfo>& stats ){
+void StatisticsCASAImage::_insertSpectral( const casacore::CoordinateSystem& cs,
+        casacore::Vector<casacore::Int>& shapeVector, QList<Carta::Lib::StatInfo>& stats ){
     if ( cs.hasSpectralAxis( ) && shapeVector[cs.spectralAxisNumber( )] > 1 ) {
-        casa::SpectralCoordinate spec = cs.spectralCoordinate( );
-        casa::Vector<casa::String> specUnitVec = spec.worldAxisUnits( );
+        casacore::SpectralCoordinate spec = cs.spectralCoordinate( );
+        casacore::Vector<casacore::String> specUnitVec = spec.worldAxisUnits( );
         if ( specUnitVec(0) == "Hz" ){
             specUnitVec(0) = "GHz";
         }
@@ -384,13 +384,13 @@ void StatisticsCASAImage::_insertSpectral( const casa::CoordinateSystem& cs,
 
 
 std::vector<QString>
-StatisticsCASAImage::_medianRestoringBeamAsStr( std::vector<casa::GaussianBeam> beams){
+StatisticsCASAImage::_medianRestoringBeamAsStr( std::vector<casacore::GaussianBeam> beams){
     std::vector<QString> result;
     if ( beams.size( ) == 1 ){
         result = _beamAsStringVector(beams[0]);
     }
     else if ( beams.size( ) > 1 ) {
-        std::vector<casa::GaussianBeam> beamcopy(beams);
+        std::vector<casacore::GaussianBeam> beamcopy(beams);
         size_t n = beamcopy.size( ) / 2;
         std::nth_element( beamcopy.begin( ), beamcopy.begin( )+n, beamcopy.end( ),
                 StatisticsCASAImage::_beamCompare );

--- a/carta/cpp/plugins/ImageStatistics/StatisticsCASAImage.h
+++ b/carta/cpp/plugins/ImageStatistics/StatisticsCASAImage.h
@@ -18,32 +18,32 @@ public:
      * @param image - a pointer to an image.
      * @return - a map of (key,value) pairs representing the image's statistics.
      */
-    static QList<Carta::Lib::StatInfo> getStats( const casa::ImageInterface<casa::Float>* image );
+    static QList<Carta::Lib::StatInfo> getStats( const casacore::ImageInterface<casacore::Float>* image );
 private:
-    static bool _beamCompare( const casa::GaussianBeam &a, const casa::GaussianBeam &b );
+    static bool _beamCompare( const casacore::GaussianBeam &a, const casacore::GaussianBeam &b );
 
-    static std::vector<QString> _beamAsStringVector( const casa::GaussianBeam &beam );
+    static std::vector<QString> _beamAsStringVector( const casacore::GaussianBeam &beam );
 
-    static void _computeStats( const casa::ImageInterface<casa::Float>* image,
+    static void _computeStats( const casacore::ImageInterface<casacore::Float>* image,
             QList<Carta::Lib::StatInfo>& stats );
 
-    static void _getStatsPlanar( const casa::ImageInterface<casa::Float>* image,
+    static void _getStatsPlanar( const casacore::ImageInterface<casacore::Float>* image,
                 QList<Carta::Lib::StatInfo>& stats, int zIndex, int hIndex  );
 
-    static void _insertRaDec( const casa::CoordinateSystem& cs, casa::Vector<casa::Int>& shapeVector,
+    static void _insertRaDec( const casacore::CoordinateSystem& cs, casacore::Vector<casacore::Int>& shapeVector,
             QList<Carta::Lib::StatInfo> & stats );
 
-    static void _insertRestoringBeam( const casa::ImageInterface<casa::Float>* image,
+    static void _insertRestoringBeam( const casacore::ImageInterface<casacore::Float>* image,
             QList<Carta::Lib::StatInfo>& stats );
 
-    static void _insertShape( const casa::Vector<casa::Int>& shapeVector,
+    static void _insertShape( const casacore::Vector<casacore::Int>& shapeVector,
             QList<Carta::Lib::StatInfo>& stats );
 
-    static void _insertSpectral( const casa::CoordinateSystem& cs,
-            casa::Vector<casa::Int>& shapeVector, QList<Carta::Lib::StatInfo>& stats );
+    static void _insertSpectral( const casacore::CoordinateSystem& cs,
+            casacore::Vector<casacore::Int>& shapeVector, QList<Carta::Lib::StatInfo>& stats );
 
 
-    static std::vector<QString> _medianRestoringBeamAsStr( std::vector<casa::GaussianBeam> beams);
+    static std::vector<QString> _medianRestoringBeamAsStr( std::vector<casacore::GaussianBeam> beams);
     StatisticsCASAImage();
 
     virtual ~StatisticsCASAImage();

--- a/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.cpp
+++ b/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.cpp
@@ -11,35 +11,35 @@ StatisticsCASARegion::StatisticsCASARegion() {
 
 QList<Carta::Lib::StatInfo>
 StatisticsCASARegion::getStats(
-        casa::ImageInterface<casa::Float>* image,
+        casacore::ImageInterface<casacore::Float>* image,
         std::shared_ptr<Carta::Lib::Regions::RegionBase> regionInfo,
         const std::vector<int>& slice ){
     QList<Carta::Lib::StatInfo> stats;
     QString regionTypeStr;
-    casa::Record regionRecord = RegionRecordFactory:: getRegionRecord(
+    casacore::Record regionRecord = RegionRecordFactory:: getRegionRecord(
             image, regionInfo, slice, regionTypeStr );
     _getStatsFromCalculator( image, regionRecord, slice, stats, regionTypeStr );
     return stats;
 }
 
 
-void StatisticsCASARegion::_getStatsFromCalculator( casa::ImageInterface<casa::Float>* image,
-       const casa::Record& region, const std::vector<int>& slice,
+void StatisticsCASARegion::_getStatsFromCalculator( casacore::ImageInterface<casacore::Float>* image,
+       const casacore::Record& region, const std::vector<int>& slice,
        QList<Carta::Lib::StatInfo>& stats, const QString& regionType ){
     //If the region record is empty, there are not stats - just return.
     int fieldCount = region.nfields();
     if ( fieldCount == 0 ){
         return;
     }
-    std::shared_ptr<const casa::ImageInterface<casa::Float> > imagePtr( image->cloneII() );
+    std::shared_ptr<const casacore::ImageInterface<casacore::Float> > imagePtr( image->cloneII() );
 
-    casa::CoordinateSystem cs = image->coordinates();
-    casa::Vector<casa::Int> displayAxes = cs.directionAxesNumbers();
-    casa::Quantum<casa::Double> pix0( 0, "pix");
-    casa::IPosition shape = image->shape();
+    casacore::CoordinateSystem cs = image->coordinates();
+    casacore::Vector<casacore::Int> displayAxes = cs.directionAxesNumbers();
+    casacore::Quantum<casacore::Double> pix0( 0, "pix");
+    casacore::IPosition shape = image->shape();
     int nAxes = shape.nelements();
-    casa::Vector<casa::Quantum<casa::Double> > blcq( nAxes, pix0);
-    casa::Vector<casa::Quantum<casa::Double> > trcq( nAxes, pix0);
+    casacore::Vector<casacore::Quantum<casacore::Double> > blcq( nAxes, pix0);
+    casacore::Vector<casacore::Quantum<casacore::Double> > trcq( nAxes, pix0);
     for ( int i = 0; i < nAxes; i++ ){
         if ( i == displayAxes[0] || i == displayAxes[1]){
             trcq[i].setValue( shape[i] );
@@ -50,15 +50,15 @@ void StatisticsCASARegion::_getStatsFromCalculator( casa::ImageInterface<casa::F
         }
     }
 
-    casa::WCBox box( blcq, trcq, cs, casa::Vector<casa::Int>());
-    casa::ImageRegion* imgBox = new casa::ImageRegion( box );
-    std::shared_ptr<casa::SubImage<casa::Float> > boxImage( new casa::SubImage<Float>(*image, *imgBox ) );
+    casacore::WCBox box( blcq, trcq, cs, casacore::Vector<casacore::Int>());
+    casacore::ImageRegion* imgBox = new casacore::ImageRegion( box );
+    std::shared_ptr<casacore::SubImage<casacore::Float> > boxImage( new casacore::SubImage<Float>(*image, *imgBox ) );
 
-    ImageStatsCalculator calc( boxImage, &region, "", true);
+    casa::ImageStatsCalculator calc( boxImage, &region, "", true);
     calc.setList(False);
     Record result = calc.calculate();
-    const casa::String blcKey( "blc");
-    const casa::String trcKey( "trc");
+    const casacore::String blcKey( "blc");
+    const casacore::String trcKey( "trc");
     _insertScalar( result, "npts", Carta::Lib::StatInfo::StatType::FrameCount, stats );
     _insertScalar( result, "sum", Carta::Lib::StatInfo::StatType::Sum, stats );
     _insertScalar( result, "sumsq", Carta::Lib::StatInfo::StatType::SumSq, stats );
@@ -79,9 +79,9 @@ void StatisticsCASARegion::_getStatsFromCalculator( casa::ImageInterface<casa::F
 
     //Put in an identifier.
     if ( result.isDefined( blcKey ) && result.isDefined( trcKey ) ){
-        casa::Vector<int> blcArray = result.asArrayInt( blcKey );
+        casacore::Vector<int> blcArray = result.asArrayInt( blcKey );
         QString blcVal = _vectorToString( blcArray );
-        casa::Vector<int> trcArray = result.asArrayInt( trcKey );
+        casacore::Vector<int> trcArray = result.asArrayInt( trcKey );
         QString trcVal = _vectorToString( trcArray );
         QString idVal = regionType + ":" + blcVal;
         if ( blcVal != trcVal ){
@@ -97,10 +97,10 @@ void StatisticsCASARegion::_getStatsFromCalculator( casa::ImageInterface<casa::F
 
 
 void
-StatisticsCASARegion::_insertList( const casa::Record& result, const casa::String& key,
+StatisticsCASARegion::_insertList( const casacore::Record& result, const casacore::String& key,
         Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats ){
     if ( result.isDefined( key) ){
-        casa::Vector<int> valArray = result.asArrayInt( key );
+        casacore::Vector<int> valArray = result.asArrayInt( key );
         QString val = _vectorToString( valArray );
         if ( !val.isEmpty()){
             Carta::Lib::StatInfo info( statType );
@@ -112,10 +112,10 @@ StatisticsCASARegion::_insertList( const casa::Record& result, const casa::Strin
 
 
 void
-StatisticsCASARegion::_insertScalar( const casa::Record& result, const casa::String& key,
+StatisticsCASARegion::_insertScalar( const casacore::Record& result, const casacore::String& key,
         Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats ){
     if ( result.isDefined( key ) ){
-        casa::Vector<double> valArray = result.asArrayDouble(key);
+        casacore::Vector<double> valArray = result.asArrayDouble(key);
         if ( valArray.nelements() > 0 ){
             Carta::Lib::StatInfo info( statType );
             info.setValue( QString::number( valArray[0] ) );
@@ -125,17 +125,17 @@ StatisticsCASARegion::_insertScalar( const casa::Record& result, const casa::Str
 }
 
 void
-StatisticsCASARegion::_insertString( const casa::Record& result, const casa::String& key,
+StatisticsCASARegion::_insertString( const casacore::Record& result, const casacore::String& key,
         Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats ){
     if ( result.isDefined( key ) ){
-        casa::String valStr = result.asString(key);
+        casacore::String valStr = result.asString(key);
         Carta::Lib::StatInfo info( statType );
         info.setValue( valStr.c_str() );
         stats.append( info );
     }
 }
 
-QString StatisticsCASARegion::_vectorToString( const casa::Vector<int>& valArray ){
+QString StatisticsCASARegion::_vectorToString( const casacore::Vector<int>& valArray ){
     int elementCount = valArray.nelements();
     QString val("[");
     for ( int i = 0; i < elementCount; i++ ){

--- a/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.h
+++ b/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.h
@@ -26,21 +26,21 @@ public:
      *      image.
      */
     static QList<Carta::Lib::StatInfo>
-    getStats( casa::ImageInterface<casa::Float>* image, std::shared_ptr<Carta::Lib::Regions::RegionBase> regionInfo,
+    getStats( casacore::ImageInterface<casacore::Float>* image, std::shared_ptr<Carta::Lib::Regions::RegionBase> regionInfo,
             const std::vector<int>& slice );
 private:
     StatisticsCASARegion();
-    static void _getStatsFromCalculator( casa::ImageInterface<casa::Float>* image,
-           const casa::Record& region, const std::vector<int>& slice,
+    static void _getStatsFromCalculator( casacore::ImageInterface<casacore::Float>* image,
+           const casacore::Record& region, const std::vector<int>& slice,
            QList<Carta::Lib::StatInfo>& stats, const QString& typeStr );
 
-    static void _insertScalar( const casa::Record& result, const casa::String& key,
+    static void _insertScalar( const casacore::Record& result, const casacore::String& key,
             Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats );
-    static void _insertList( const casa::Record& result, const casa::String& key,
+    static void _insertList( const casacore::Record& result, const casacore::String& key,
             Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats );
-    static void _insertString( const casa::Record& result, const casa::String& key,
+    static void _insertString( const casacore::Record& result, const casacore::String& key,
             Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats );
-    static QString _vectorToString( const casa::Vector<int>& valArray );
+    static QString _vectorToString( const casacore::Vector<int>& valArray );
 
     virtual ~StatisticsCASARegion();
 

--- a/carta/cpp/plugins/ProfileCASA/ProfileCASA.h
+++ b/carta/cpp/plugins/ProfileCASA/ProfileCASA.h
@@ -13,7 +13,7 @@
 #include <QObject>
 
 
-namespace casa {
+namespace casacore {
     class ImageRegion;
 }
 
@@ -36,19 +36,19 @@ public:
 
 private:
 
-    casa::MFrequency::Types _determineRefFrame(
-            std::shared_ptr<casa::ImageInterface<casa::Float> > img ) const;
-    Carta::Lib::Hooks::ProfileResult _generateProfile( casa::ImageInterface < casa::Float > * imagePtr,
+    casacore::MFrequency::Types _determineRefFrame(
+            std::shared_ptr<casacore::ImageInterface<casacore::Float> > img ) const;
+    Carta::Lib::Hooks::ProfileResult _generateProfile( casacore::ImageInterface < casacore::Float > * imagePtr,
             std::shared_ptr<Carta::Lib::Regions::RegionBase> regionInfo, Carta::Lib::ProfileInfo profileInfo ) const;
     casa::ImageCollapserData::AggregateType _getCombineMethod( Carta::Lib::ProfileInfo profileInfo ) const;
-    casa::ImageRegion* _getEllipsoid(const casa::CoordinateSystem& cSys,
-            const casa::Vector<casa::Double>& x, const casa::Vector<casa::Double>& y) const;
-    casa::ImageRegion* _getPolygon(const casa::CoordinateSystem& cSys,
-            const casa::Vector<casa::Double>& x, const casa::Vector<casa::Double>& y) const;
-    casa::Record _getRegionRecord( const QString& shape, const casa::CoordinateSystem& cSys,
-            const casa::Vector<casa::Double>& x, const casa::Vector<casa::Double>& y) const;
+    casacore::ImageRegion* _getEllipsoid(const casacore::CoordinateSystem& cSys,
+            const casacore::Vector<casacore::Double>& x, const casacore::Vector<casacore::Double>& y) const;
+    casacore::ImageRegion* _getPolygon(const casacore::CoordinateSystem& cSys,
+            const casacore::Vector<casacore::Double>& x, const casacore::Vector<casacore::Double>& y) const;
+    casacore::Record _getRegionRecord( const QString& shape, const casacore::CoordinateSystem& cSys,
+            const casacore::Vector<casacore::Double>& x, const casacore::Vector<casacore::Double>& y) const;
 
-    casa::Vector<casa::Double> _toWorld( const casa::CoordinateSystem& cSys,
+    casacore::Vector<casacore::Double> _toWorld( const casacore::CoordinateSystem& cSys,
     		double x, double y, bool* successful ) const;
     const QString PIXEL_UNIT;
     const QString RADIAN_UNIT;

--- a/carta/cpp/plugins/RegionCASA/RegionCASA.cpp
+++ b/carta/cpp/plugins/RegionCASA/RegionCASA.cpp
@@ -69,20 +69,20 @@ std::vector<HookId> RegionCASA::getInitialHookList(){
 
 std::vector<QPointF>
 RegionCASA::_getPixelVertices( const casa::AnnotationBase::Direction& corners,
-        const casa::CoordinateSystem& csys, const casa::Vector<casa::MDirection>& directions ) const {
-    std::vector<casa::Quantity> xx, xy;
+        const casacore::CoordinateSystem& csys, const casacore::Vector<casacore::MDirection>& directions ) const {
+    std::vector<casacore::Quantity> xx, xy;
     _getWorldVertices(xx, xy, csys, directions );
-    casa::Vector<casa::Double> world = csys.referenceValue();
-    const casa::IPosition dirAxes = csys.directionAxesNumbers();
-    casa::String xUnit = csys.worldAxisUnits()[dirAxes[0]];
-    casa::String yUnit = csys.worldAxisUnits()[dirAxes[1]];
+    casacore::Vector<casacore::Double> world = csys.referenceValue();
+    const casacore::IPosition dirAxes = csys.directionAxesNumbers();
+    casacore::String xUnit = csys.worldAxisUnits()[dirAxes[0]];
+    casacore::String yUnit = csys.worldAxisUnits()[dirAxes[1]];
     int cornerCount = corners.size();
 
     std::vector<QPointF> pixelVertices( cornerCount );
     for (int i=0; i<cornerCount; i++) {
         world[dirAxes[0]] = xx[i].getValue(xUnit);
         world[dirAxes[1]] = xy[i].getValue(yUnit);
-        casa::Vector<casa::Double> pixel;
+        casacore::Vector<casacore::Double> pixel;
         csys.toPixel(pixel, world);
         pixelVertices[i]= QPointF( pixel[dirAxes[0]], pixel[dirAxes[1]] );
     }
@@ -108,31 +108,31 @@ RegionCASA::_loadRegion( const QString & fname,
 		std::shared_ptr<Carta::Lib::Image::ImageInterface> imagePtr ){
 	std::vector<Carta::Lib::Regions::RegionBase*> regionInfos;
 
-	casa::String fileName( fname.toStdString().c_str() );
+	casacore::String fileName( fname.toStdString().c_str() );
 	CCImageBase * base = dynamic_cast<CCImageBase*>( imagePtr.get() );
 	if ( base ){
 		Carta::Lib::Image::MetaDataInterface::SharedPtr metaPtr = base->metaData();
 		CCMetaDataInterface* metaData = dynamic_cast<CCMetaDataInterface*>(metaPtr.get());
 		if ( metaData ){
-			std::shared_ptr<casa::CoordinateSystem> cs = metaData->getCoordinateSystem();
+			std::shared_ptr<casacore::CoordinateSystem> cs = metaData->getCoordinateSystem();
 			std::vector < int > dimensions = imagePtr->dims();
 			int dimCount = dimensions.size();
-			casa::IPosition shape(dimCount);
+			casacore::IPosition shape(dimCount);
 			for ( int i = 0; i < dimCount; i++ ){
 				shape[i] = dimensions[i];
 			}
 			casa::RegionTextList regionList( fileName, *cs.get(), shape );
-			casa::Vector<casa::AsciiAnnotationFileLine> aaregions = regionList.getLines();
+			casacore::Vector<casa::AsciiAnnotationFileLine> aaregions = regionList.getLines();
 			int regionCount = aaregions.size();
 			for ( int i = 0; i < regionCount; i++ ){
 				if ( aaregions[i].getType() != casa::AsciiAnnotationFileLine::ANNOTATION ){
 					continue;
 				}
 
-				casa::CountedPtr<const casa::AnnotationBase> ann = aaregions[i].getAnnotationBase();
+				casacore::CountedPtr<const casa::AnnotationBase> ann = aaregions[i].getAnnotationBase();
 				Carta::Lib::Regions::RegionBase* rInfo = nullptr;
 
-				casa::Vector<casa::MDirection> directions = ann->getConvertedDirections();
+				casacore::Vector<casacore::MDirection> directions = ann->getConvertedDirections();
 				casa::AnnotationBase::Direction points = ann->getDirections();
 				std::vector<QPointF> corners =
 						_getPixelVertices( points, *cs.get(), directions );
@@ -172,22 +172,22 @@ RegionCASA::_loadRegion( const QString & fname,
 					Carta::Lib::Regions::Ellipse* regionEllipse = new Carta::Lib::Regions::Ellipse();
 					rInfo = regionEllipse;
 					const casa::AnnEllipse* ellipse = dynamic_cast<const casa::AnnEllipse*>( ann.get() );
-					casa::Int directionIndex = cs->findCoordinate(casa::Coordinate::Type::DIRECTION );
+					casacore::Int directionIndex = cs->findCoordinate(casacore::Coordinate::Type::DIRECTION );
 
-					casa::MDirection::Types csType = casa::MDirection::EXTRA;
+					casacore::MDirection::Types csType = casacore::MDirection::EXTRA;
 					if ( directionIndex >= 0 ){
-						casa::DirectionCoordinate  dCoord = cs->directionCoordinate(directionIndex);
+						casacore::DirectionCoordinate  dCoord = cs->directionCoordinate(directionIndex);
 						csType = dCoord.directionType();
 					}
 
-					if ( csType == casa::MDirection::EXTRA ){
+					if ( csType == casacore::MDirection::EXTRA ){
 						qWarning( "Unable to complete elliptical region, unspecified direction type.");
 						continue;
 					}
 
 
-					casa::MDirection dir_center = casa::MDirection::Convert(ellipse->getCenter( ), csType)();
-					casa::Vector<double> center = dir_center.getAngle("rad").getValue( );
+					casacore::MDirection dir_center = casacore::MDirection::Convert(ellipse->getCenter( ), csType)();
+					casacore::Vector<double> center = dir_center.getAngle("rad").getValue( );
 					// 90 deg around 0 & 180 deg
 					const double major_radius = ellipse->getSemiMajorAxis().getValue("rad");
 					const double minor_radius = ellipse->getSemiMinorAxis().getValue("rad");
@@ -233,38 +233,38 @@ RegionCASA::_loadRegion( const QString & fname,
 }
 
 double RegionCASA::_getRadiusPixel( const QPointF& centerRadian, const QPointF& centerPixel,
-		double radius, double angleDegrees, const casa::CoordinateSystem& cSys ) const {
+		double radius, double angleDegrees, const casacore::CoordinateSystem& cSys ) const {
 	double pointX = centerRadian.x() + radius * cos( angleDegrees * ( M_PI / 180));
 	double pointY = centerRadian.y() + radius * sin ( angleDegrees * ( M_PI / 180));
 	bool successful = false;
-	casa::Vector<casa::Double> pixelPt = _toPixel( cSys, pointX, pointY, &successful );
+	casacore::Vector<casacore::Double> pixelPt = _toPixel( cSys, pointX, pointY, &successful );
 	double xDiff = pixelPt[0] - centerPixel.x();
 	double yDiff = pixelPt[1] - centerPixel.y();
 	double radiusPixel = qSqrt( xDiff * xDiff + yDiff * yDiff );
 	return radiusPixel;
 }
 
-void RegionCASA::_getWorldVertices(std::vector<casa::Quantity>& x, std::vector<casa::Quantity>& y,
-        const casa::CoordinateSystem& csys,
-        const casa::Vector<casa::MDirection>& directions ) const {
-    const casa::IPosition dirAxes = csys.directionAxesNumbers();
-    casa::String xUnit = csys.worldAxisUnits()[dirAxes[0]];
-    casa::String yUnit = csys.worldAxisUnits()[dirAxes[1]];
+void RegionCASA::_getWorldVertices(std::vector<casacore::Quantity>& x, std::vector<casacore::Quantity>& y,
+        const casacore::CoordinateSystem& csys,
+        const casacore::Vector<casacore::MDirection>& directions ) const {
+    const casacore::IPosition dirAxes = csys.directionAxesNumbers();
+    casacore::String xUnit = csys.worldAxisUnits()[dirAxes[0]];
+    casacore::String yUnit = csys.worldAxisUnits()[dirAxes[1]];
     int directionCount = directions.size();
     x.resize( directionCount );
     y.resize( directionCount );
     for (int i = 0; i < directionCount; i++) {
-        x[i] = casa::Quantity(directions[i].getAngle(xUnit).getValue(xUnit)[0], xUnit);
-        y[i] = casa::Quantity(directions[i].getAngle(yUnit).getValue(yUnit)[1], yUnit);
+        x[i] = casacore::Quantity(directions[i].getAngle(xUnit).getValue(xUnit)[0], xUnit);
+        y[i] = casacore::Quantity(directions[i].getAngle(yUnit).getValue(yUnit)[1], yUnit);
     }
 }
 
-casa::Vector<casa::Double> RegionCASA::_toPixel( const casa::CoordinateSystem& cSys,
+casacore::Vector<casacore::Double> RegionCASA::_toPixel( const casacore::CoordinateSystem& cSys,
 		double x, double y, bool* successful ) const {
 	int pixelCount = cSys.nPixelAxes();
-	casa::Vector<casa::Double> worldPt( pixelCount, 0 );
+	casacore::Vector<casacore::Double> worldPt( pixelCount, 0 );
 	worldPt = cSys.referenceValue();
-	casa::Vector<casa::Double> pixelPt( pixelCount);
+	casacore::Vector<casacore::Double> pixelPt( pixelCount);
 	pixelPt = cSys.referencePixel();
 	if ( pixelCount >= 2 ){
 		worldPt[0] = x;
@@ -273,7 +273,7 @@ casa::Vector<casa::Double> RegionCASA::_toPixel( const casa::CoordinateSystem& c
 			pixelPt = cSys.toPixel( worldPt );
 			*successful = true;
 		}
-		catch( const casa::AipsError& error ){
+		catch( const casacore::AipsError& error ){
 			qDebug() << error.getMesg().c_str()<<" x="<<x<<" y="<<y;
 			*successful = false;
 		}

--- a/carta/cpp/plugins/RegionCASA/RegionCASA.h
+++ b/carta/cpp/plugins/RegionCASA/RegionCASA.h
@@ -53,7 +53,7 @@ private:
      */
     std::vector<QPointF>
         _getPixelVertices( const casa::AnnotationBase::Direction& corners,
-            const casa::CoordinateSystem& csys, const casa::Vector<casa::MDirection>& directions ) const;
+            const casacore::CoordinateSystem& csys, const casacore::Vector<casacore::MDirection>& directions ) const;
 
     /**
      * Convert the length is world coordinates to pixel coordinates.
@@ -64,7 +64,7 @@ private:
      * @return - the corresponding length in pixel coordinates.
      */
     double _getRadiusPixel( const QPointF& centerRadian, const QPointF& centerPixel,
-       		double radius, double angleDegrees, const casa::CoordinateSystem& cSys ) const;
+       		double radius, double angleDegrees, const casacore::CoordinateSystem& cSys ) const;
 
     /**
      * Get a lists of x- and y- coordinates of the corner points of a region based on world
@@ -74,9 +74,9 @@ private:
      * @param csys - the coordinate system of the containing image.
      * @param directions - a list of MDirections for the image.
      */
-    void _getWorldVertices(std::vector<casa::Quantity>& x, std::vector<casa::Quantity>& y,
-            const casa::CoordinateSystem& csys,
-            const casa::Vector<casa::MDirection>& directions ) const;
+    void _getWorldVertices(std::vector<casacore::Quantity>& x, std::vector<casacore::Quantity>& y,
+            const casacore::CoordinateSystem& csys,
+            const casacore::Vector<casacore::MDirection>& directions ) const;
 
     /**
      * Returns true if the region is a casa region; false otherwise.
@@ -103,6 +103,6 @@ private:
      * @param successful - set to true if the point is successfully converted; otherwise set to false.
      * @return - a list of the corresponding pixel coordinates.
      */
-    casa::Vector<casa::Double> _toPixel( const casa::CoordinateSystem& cSys,
+    casacore::Vector<casacore::Double> _toPixel( const casacore::CoordinateSystem& cSys,
     		double x, double y, bool* successful ) const;
 };

--- a/carta/cpp/plugins/RegionDs9/ContextDs9.cpp
+++ b/carta/cpp/plugins/RegionDs9/ContextDs9.cpp
@@ -24,17 +24,17 @@ static inline double wrap_angle( double before, double after ) {
     return after;
 }
 
-static inline casa::Quantum<casa::Vector<double> > convert_angle( double x, const std::string &xunits, double y, const std::string &yunits,
-        casa::MDirection::Types original_coordsys, casa::MDirection::Types new_coordsys, const std::string &new_units="rad" ) {
-    casa::Quantum<double> xq(x,casa::String(xunits));
-    casa::Quantum<double> yq(y,casa::String(yunits));
-    casa::MDirection md = casa::MDirection::Convert(casa::MDirection(xq,yq,original_coordsys), new_coordsys)();
-    casa::Quantum<casa::Vector<double> > result = md.getAngle("rad");
+static inline casacore::Quantum<casacore::Vector<double> > convert_angle( double x, const std::string &xunits, double y, const std::string &yunits,
+        casacore::MDirection::Types original_coordsys, casacore::MDirection::Types new_coordsys, const std::string &new_units="rad" ) {
+    casacore::Quantum<double> xq(x,casacore::String(xunits));
+    casacore::Quantum<double> yq(y,casacore::String(yunits));
+    casacore::MDirection md = casacore::MDirection::Convert(casacore::MDirection(xq,yq,original_coordsys), new_coordsys)();
+    casacore::Quantum<casacore::Vector<double> > result = md.getAngle("rad");
     xq.convert("rad");
     yq.convert("rad");
     result.getValue( )(0) = wrap_angle(xq.getValue( ), result.getValue( )(0));
     result.getValue( )(1) = wrap_angle(yq.getValue( ), result.getValue( )(1));
-    result.convert(casa::String(new_units));
+    result.convert(casacore::String(new_units));
     return result;
 }
 

--- a/carta/cpp/plugins/RegionDs9/ContextDs9.h
+++ b/carta/cpp/plugins/RegionDs9/ContextDs9.h
@@ -40,18 +40,18 @@ enum SkyFrame {FK4, FK4_NO_E, FK5, ICRS, GALACTIC, SUPERGALACTIC,
 enum SkyDist {DEGREE, ARCMIN, ARCSEC};
 enum PointShape {CIRCLE,BOX,DIAMOND,CROSS,XPT,ARROW,BOXCIRCLE};
 
-inline casa::MDirection::Types todirection( SkyFrame frame ) {
+inline casacore::MDirection::Types todirection( SkyFrame frame ) {
     switch ( frame ) {
     case FK4:
-        return casa::MDirection::B1950;
+        return casacore::MDirection::B1950;
     case FK5:
-        return casa::MDirection::J2000;
+        return casacore::MDirection::J2000;
     case GALACTIC:
-        return casa::MDirection::GALACTIC;
+        return casacore::MDirection::GALACTIC;
     case ECLIPTIC:
-        return casa::MDirection::ECLIPTIC;
+        return casacore::MDirection::ECLIPTIC;
     default:
-        return casa::MDirection::GALACTIC;
+        return casacore::MDirection::GALACTIC;
     }
 }
 

--- a/carta/cpp/plugins/RegionDs9/RegionDs9.pro
+++ b/carta/cpp/plugins/RegionDs9/RegionDs9.pro
@@ -45,11 +45,19 @@ LIBS += -L$$OUT_PWD/../../CartaLib/ -lCartaLib
 # INCLUDEPATH += /usr/local/opt/bison/include
 # /usr/local/opt/bison/bin/bison
 
-# 3. now use macports: flex:2.6.1, bison 3.0.4, OK
+# 3. now use macports: flex:2.6.1, bison 3.0.4, not OK
 
+# FLEXANDBISONDIR=../../ThirdParty/macports
+# FLEXBIN= $${FLEXANDBISONDIR}/bin/flex
+# BISONBIN= $${FLEXANDBISONDIR}/bin/bison
+
+# FLEXINCLUDE = $${FLEXANDBISONDIR}/include
+# FLEXLIB= $${FLEXANDBISONDIR}/lib
+
+# 4. build from source code of flex, and use homebrew's bison
+
+BISONBIN=/usr/local/opt/bison/bin/bison
 FLEXBIN= $${FLEXANDBISONDIR}/bin/flex
-BISONBIN= $${FLEXANDBISONDIR}/bin/bison
-
 FLEXINCLUDE = $${FLEXANDBISONDIR}/include
 FLEXLIB= $${FLEXANDBISONDIR}/lib
 

--- a/carta/cpp/plugins/RegionDs9/RegionDs9.pro
+++ b/carta/cpp/plugins/RegionDs9/RegionDs9.pro
@@ -35,20 +35,27 @@ LIBS += -L$${CFITSIODIR}/lib -lcfitsio
 LIBS += -L$$OUT_PWD/../../core/ -lcore
 LIBS += -L$$OUT_PWD/../../CartaLib/ -lCartaLib
 
+# 1 original:
+# LIBS += -L$${FLEXANDBISONDIR}/lib -lfl -ly
+# INCLUDEPATH += $${FLEXANDBISONDIR}/include
 
-FLEXBIN= /opt/casa/02/bin/flex
-# /usr/local/opt/bison/bin/bison
-BISONBIN= /opt/casa/02/bin/bison
-
+# 2 then try homebrew, but not work
+# flex:2.6.3, bison:3.0.4
 # /usr/local/opt/flex/include
-FLEXINCLUDE = /opt/casa/02/include
-FLEXLIB= /opt/casa/02/lib
+# INCLUDEPATH += /usr/local/opt/bison/include
+# /usr/local/opt/bison/bin/bison
+
+# 3. now use macports: flex:2.6.1, bison 3.0.4, OK
+
+FLEXBIN= $${FLEXANDBISONDIR}/bin/flex
+BISONBIN= $${FLEXANDBISONDIR}/bin/bison
+
+FLEXINCLUDE = $${FLEXANDBISONDIR}/include
+FLEXLIB= $${FLEXANDBISONDIR}/lib
 
 unix:macx{
-    # use homebrew version, flex:2.6.3, bison:3.0.4
     LIBS += -L$${FLEXLIB} -lfl -ly
     INCLUDEPATH += $${FLEXINCLUDE}
-    # INCLUDEPATH += /usr/local/opt/bison/include
 } else {
     LIBS += -lfl -ly
 }

--- a/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.cpp
+++ b/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.cpp
@@ -93,7 +93,7 @@ FitsHeaderExtractor::getHeader()
     // was this created using CasaImageLoader plugin?
     CCImageBase * base = dynamic_cast < CCImageBase * > ( & * m_cartaImage );
     if ( base ) {
-        casa::LatticeBase * latticeBase = base-> getCasaImage();
+        casacore::LatticeBase * latticeBase = base-> getCasaImage();
         if ( latticeBase ) {
 
             // casacore's fits parser
@@ -118,14 +118,14 @@ FitsHeaderExtractor::getErrors()
 // tree. There are probably unused pieces of code/weird comments,etc...
 /// \todo clean up the code below
 QStringList
-FitsHeaderExtractor::_CasaFitsConverter( casa::LatticeBase * lbase )
+FitsHeaderExtractor::_CasaFitsConverter( casacore::LatticeBase * lbase )
 {
     // can we get float image interface ?
-    casa::ImageInterface < casa::Float > * fii = nullptr;
+    casacore::ImageInterface < casacore::Float > * fii = nullptr;
     #ifndef Q_OS_MAC
-        fii = dynamic_cast < casa::ImageInterface < casa::Float > * > ( lbase );
+        fii = dynamic_cast < casacore::ImageInterface < casacore::Float > * > ( lbase );
     #else
-        fii = static_cast < casa::ImageInterface < casa::Float > * > ( lbase );
+        fii = static_cast < casacore::ImageInterface < casacore::Float > * > ( lbase );
     #endif
 
     if ( ! fii ) {
@@ -135,9 +135,9 @@ FitsHeaderExtractor::_CasaFitsConverter( casa::LatticeBase * lbase )
 
     // alias image to be reference to the image, since the original code used a reference
     // rather than a pointer and I'm too lazy to convert everything to pointers :)
-    casa::ImageInterface < casa::Float > & image = * fii;
+    casacore::ImageInterface < casacore::Float > & image = * fii;
 
-    using namespace casa;
+    using namespace casacore;
 
     QStringList errors;
     bool preferVelocity = true;

--- a/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.h
+++ b/carta/cpp/plugins/WcsPlotter/FitsHeaderExtractor.h
@@ -8,7 +8,7 @@
 #include "CartaLib/IImage.h"
 #include <QStringList>
 
-namespace casa { class LatticeBase; }
+namespace casacore { class LatticeBase; }
 
 class FitsHeaderExtractor
 {
@@ -33,7 +33,7 @@ public:
 private:
 
     QString _FITSKeyWordParser(QString _raw);
-    QStringList _CasaFitsConverter( casa::LatticeBase * lbase);
+    QStringList _CasaFitsConverter( casacore::LatticeBase * lbase);
 
     Carta::Lib::Image::ImageInterface::SharedPtr m_cartaImage = nullptr;
     QStringList m_errors;

--- a/carta/html5/common/qooxdoo-3.5-sdk
+++ b/carta/html5/common/qooxdoo-3.5-sdk
@@ -1,1 +1,0 @@
-../../../Externals/ThirdParty/qooxdoo-3.5-sdk

--- a/carta/html5/common/qooxdoo-3.5.1-sdk
+++ b/carta/html5/common/qooxdoo-3.5.1-sdk
@@ -1,0 +1,1 @@
+../../../Externals/ThirdParty/qooxdoo-3.5.1-sdk

--- a/carta/html5/common/skel/Gruntfile.js
+++ b/carta/html5/common/skel/Gruntfile.js
@@ -1,7 +1,7 @@
 // global conf
 var common = {
   QOOXDOO_VERSION: '3.5',
-  QOOXDOO_PATH: '../../../../ThirdParty/qooxdoo-3.5-sdk'
+  QOOXDOO_PATH: '../../../../ThirdParty/qooxdoo-3.5.1-sdk'
 };
 
 // requires

--- a/carta/html5/common/skel/Manifest.json
+++ b/carta/html5/common/skel/Manifest.json
@@ -1,15 +1,15 @@
 {
-  "info" : 
+  "info" :
   {
     "name" : "skel",
 
     "summary" : "Custom Application",
     "description" : "This is a skeleton for a custom application with qooxdoo.",
-    
+
     "homepage" : "http://some.homepage.url/",
 
     "license" : "SomeLicense",
-    "authors" : 
+    "authors" :
     [
       {
         "name" : "First Author (uid)",
@@ -18,10 +18,10 @@
     ],
 
     "version" : "master",
-    "qooxdoo-versions": ["3.5"]
+    "qooxdoo-versions": ["3.5.1"]
   },
-  
-  "provides" : 
+
+  "provides" :
   {
     "namespace"   : "skel",
     "encoding"    : "utf-8",
@@ -31,4 +31,3 @@
     "type"        : "application"
   }
 }
-

--- a/carta/html5/common/skel/config.json
+++ b/carta/html5/common/skel/config.json
@@ -1,6 +1,6 @@
 {
 	"name"		: "skel",
-	
+
 	"include" :
 	[
 		{
@@ -45,7 +45,7 @@
 	"let" :
 	{
 		"APPLICATION"	 : "skel",
-		"QOOXDOO_PATH" : "../qooxdoo-3.5-sdk",
+		"QOOXDOO_PATH" : "../qooxdoo-3.5.1-sdk",
     //			"QOOXDOO_PATH" : "../qooxdoo-4.0.1-sdk",
 		"QXTHEME"			 : "skel.theme.Theme",
 		"API_EXCLUDE"	 : ["qx.test.*", "${APPLICATION}.theme.*", "${APPLICATION}.test.*", "${APPLICATION}.simulation.*"],
@@ -75,7 +75,7 @@
 				},
 				"paths": {
 					"app-root": "../.."
-          
+
 				},
 				"code": {
 					"decode-uris-plug": "customuris.js"
@@ -95,8 +95,8 @@
 				}
 		  }
 		},
-		
-/*    
+
+/*
 		, "build-script": {
 		  "compile-options": {
 				"code": {

--- a/carta/html5/common/skel/generate.py
+++ b/carta/html5/common/skel/generate.py
@@ -27,7 +27,7 @@ import sys, os, re, subprocess, codecs, optparse
 
 CMD_PYTHON = sys.executable
 #QOOXDOO_PATH = '../../../../ThirdParty/qooxdoo-4.0.1-sdk'
-QOOXDOO_PATH = '../../../../ThirdParty/qooxdoo-3.5-sdk'
+QOOXDOO_PATH = '../../../../ThirdParty/qooxdoo-3.5.1-sdk'
 QX_PYLIB = "tool/pylib"
 
 ##

--- a/carta/scripts/buildcasa.sh
+++ b/carta/scripts/buildcasa.sh
@@ -312,6 +312,7 @@ mkdir build && cd build
 if [ "$(uname)" == "Darwin" ]; then
     cmake -DUseCrashReporter=0 -DBoost_NO_BOOST_CMAKE=1 \
     -DUseCasacoreNamespace=1 \
+    -DCMAKE_Fortran_COMPILER=/usr/local/bin/gfortran \
     -Darch=$TARGETOS -DCMAKE_BUILD_TYPE=Release -DCXX11=1 \
     -DWCSLIB_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/wcslib \
     -DCFITSIO_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/cfitsio \

--- a/carta/scripts/buildcasa.sh
+++ b/carta/scripts/buildcasa.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-export CARTAWORKHOME=`pwd`
+
+## TODO: remove installinging
+## java/jre, pgplot, dbus, qt4.
+## qwt has been removed
+
+if [ -z ${cartawork+x} ]; then
+	export cartawork=`pwd`
+else
+fi
 
 isCentOS=true
 if grep -q CentOS /etc/os-release; then
@@ -13,11 +21,10 @@ TARGETOS=linux
 
 if [ "$(uname)" == "Darwin" ]; then
     ## should do https://github.com/CARTAvis/carta/wiki/Install-Third-Party-For-CARTA-CASA-On-Mac first
-    ## its qmake (homebrew) is in /usr/local/Cellar/qt/4.8.7_3/bin
 
     TARGETOS=darwin
 
-    ## in this path, in include "dbuspp-xml2cpp" which will affect code's cmake:DBUS_FLAVOR_dbuspp-xml2cpp_EXECUTABLE
+    ## in this path, it includes "dbuspp-xml2cpp" which will affect code's cmake:DBUS_FLAVOR_dbuspp-xml2cpp_EXECUTABLE
     ## without this, casa-code's CMakeLists' requirement becomes dbus-c++ from dbus-cpp
     export PATH=/opt/casa/02/bin:$PATH
 
@@ -29,61 +36,25 @@ name=CASA RPMs for RedHat Enterprise Linux 7 (x86_64)
 baseurl=http://svn.cv.nrao.edu/casa/repo/el7/x86_64
 gpgkey=http://svn.cv.nrao.edu/casa/RPM-GPG-KEY-casa http://www.jpackage.org/jpackage.asc http://svn.cv.nrao.edu/casa/repo/el7/RPM-GPG-KEY-redhat-release http://svn.cv.nrao.edu/casa/repo/el7/RPM-GPG-KEY-EPEL
 EOF
-
-
-    # for building Qt 4.8.5,
-    # On Grimmer's docker -centos 7.3 , only when buidling Carta by Qt-5.3.2, we need gstreamer-devel, gstreamer-plugins-base
-    # But on Chia-Jung Hsu's pc - centos 7.3, building Qt 4.8.5 needs pkgconfig(gstreamer-app-0.10) which install gstreamer-plugins-base-devel ,
-    #    also gstreamer-devel, gstreamer-plugins-base,  gstreamer
-    # Qt's QtWebkit may use gstreamer libs
-    sudo yum -y install 'pkgconfig(gstreamer-app-0.10)'
-
     ##### CentOS 7
     ## https://safe.nrao.edu/wiki/bin/view/Software/CASA/CartaBuildInstructionsForEL7
     ## To do: should spend time to minimalize them,
     ## also tell them which part is for casacore, which is for casa(code)
     ## only support CentOS 7 ??
-    # sudo yum -y install devtoolset*
+    # sudo yum -y install devtoolset* (includes devtoolset-3 gcc-4.9.2, fortran, glib, python)
 
-    #   devtoolset-3-gcc.x86_64 0:4.9.2-6.2.el7
-    #   devtoolset-3-gcc-c++.x86_64 0:4.9.2-6.2.el7
-    #   devtoolset-3-gcc-gfortran.x86_64 0:4.9.2-6.2.el7
-    ## not sure if other libs are needed or not. seems not
-    # Installed:
-    #   devtoolset-3-binutils.x86_64 0:2.24-18.el7                          devtoolset-3-dwz.x86_64 0:0.11-1.1.el7                            devtoolset-3-elfutils.x86_64 0:0.161-1.el7
-    #   devtoolset-3-elfutils-libelf.x86_64 0:0.161-1.el7                   devtoolset-3-elfutils-libs.x86_64 0:0.161-1.el7                   devtoolset-3-gcc.x86_64 0:4.9.2-6.2.el7
-    #   devtoolset-3-gcc-c++.x86_64 0:4.9.2-6.2.el7                         devtoolset-3-gcc-gfortran.x86_64 0:4.9.2-6.2.el7                  devtoolset-3-gdb.x86_64 0:7.8.2-38.el7
-    #   devtoolset-3-libquadmath-devel.x86_64 0:4.9.2-6.2.el7               devtoolset-3-libstdc++-devel.x86_64 0:4.9.2-6.2.el7               devtoolset-3-ltrace.x86_64 0:0.7.91-9.el7
-    #   devtoolset-3-memstomp.x86_64 0:0.1.5-3.el7                          devtoolset-3-runtime.x86_64 0:3.1-12.el7                          devtoolset-3-strace.x86_64 0:4.8-8.el7
-    #   devtoolset-3-toolchain.x86_64 0:3.1-12.el7
-    #
-    # Dependency Installed:
-    #   audit-libs-python.x86_64 0:2.6.5-3.el7          checkpolicy.x86_64 0:2.5-4.el7                    glibc-devel.x86_64 0:2.17-157.el7_3.1          glibc-headers.x86_64 0:2.17-157.el7_3.1
-    #   kernel-headers.x86_64 0:3.10.0-514.6.1.el7      libcgroup.x86_64 0:0.41-11.el7                    libgomp.x86_64 0:4.8.5-11.el7                  libmpc.x86_64 0:1.0.1-3.el7
-    #   libselinux-python.x86_64 0:2.5-6.el7            libselinux-utils.x86_64 0:2.5-6.el7               libsemanage-python.x86_64 0:2.5-5.1.el7_3      mpfr.x86_64 0:3.1.1-4.el7
-    #   policycoreutils.x86_64 0:2.5-11.el7_3           policycoreutils-python.x86_64 0:2.5-11.el7_3      python-IPy.noarch 0:0.75-6.el7                 scl-utils.x86_64 0:20130529-17.el7_1
-    #   setools-libs.x86_64 0:3.3.8-1.1.el7
-    #
-    # Dependency Updated:
-    #   libsemanage.x86_64 0:2.5-5.1.el7_3
-    ####
-    # Xerces-C++ is a validating XML parser
-
-    ## need to check if we really need this to install casa01-mpi4py, casa01-openmpi
+    ## TODO: need to check if we really need this to install casa01-mpi4py, casa01-openmpi
     ## https://safe.nrao.edu/wiki/bin/view/Software/CASA/CartaBuildInstructionsForEL7
 
-    ##  casa01-python-tools seems to have python-numpy, boost-python
+    ## casa01-python-tools seems to have python-numpy, boost-python
 
     sudo yum -y install python-devel boost-python
     # casa01-mpi4py.x86_64 casa01-openmpi.x86_64 \
     # casa01-python.x86_64 casa01-python-devel.x86_64, casa01-python-tools.x86_64 \ (2.7.5)
-    sudo yum -y install lapack-devel xerces-c-devel
+    sudo yum -y install lapack-devel xerces-c-devel #Xerces-C++ is a validating XML parser
 
-    # sudo yum -y install wcslib wcslib-devel
-
-    ## casacore needs. not sure if code needs or not
-    ## casacore refernece: https://github.com/casacore/casacore
-    ## the above link shows. (optional) yum -y install ncurses ncurses-devel, but it is default when building on Ubuntu?
+    ## casacore/code needs boost. casacore refernece: https://github.com/casacore/casacore
+    ## the above link shows. (optional) yum -y install ncurses ncurses-devel
     # sudo yum -y install gcc-gfortran ## 4.8.5, ast also needs this
     sudo yum -y install boost
     sudo yum -y install boost-devel
@@ -177,62 +148,55 @@ else
 
     ##### Qt 4.8.5 way1:  Build (slow)
     #wget https://download.qt.io/archive/qt/4.8/4.8.5/qt-everywhere-opensource-src-4.8.5.zip
-    #unzip -a qt-everywhere-opensource-src-4.8.5.zip # -d $CARTAWORKHOME/CARTAvis-externals/ThirdParty/Qt4.8.5
-    ## cd $CARTAWORKHOME/CARTAvis-externals/ThirdParty/Qt4.8.5/qt-everywhere-opensource-src-4.8.5
+    #unzip -a qt-everywhere-opensource-src-4.8.5.zip # -d $cartawork/CARTAvis-externals/ThirdParty/Qt4.8.5
+    ## cd $cartawork/CARTAvis-externals/ThirdParty/Qt4.8.5/qt-everywhere-opensource-src-4.8.5
     #cd qt-everywhere-opensource-src-4.8.5
     #printf 'yes\n' | ./configure -v -opensource -dbus-linked
     #make
     #make install
     #export PATH=/usr/local/Trolltech/Qt-4.8.5/bin:$PATH
     #######
-
-    # ./configure --prefix $CARTAWORKHOME/CARTAvis-externals/ThirdParty/Qt4.8.5 -> fail
+    ## ./configure --prefix $cartawork/CARTAvis-externals/ThirdParty/Qt4.8.5 -> fail, not know why
     #./configure # some interactive questioin. "o", "yes" !!
 
-    ##### TODO: way2, to install Qt 4.8.7, use qmake or qmake-qt4. Not use this way to test all.
+    ## TODO: way2, to install Qt 4.8.7, use qmake or qmake-qt4. Not use this way to test all.
     sudo apt-get install libqt4-dev
 fi
 
-# can try to use tools to answer stdin questions automatically
-# http://askubuntu.com/questions/338857/automatically-enter-input-in-command-line
-# http://stackoverflow.com/questions/14392525/passing-arguments-to-an-interactive-program-non-interactively
-# http://stackoverflow.com/questions/4857702/how-to-provide-password-to-a-command-that-prompts-for-one-in-bash
-# or use sudo yum to insatll ? qt-4.8.6-30.fc20.x86_64
+cd $cartawork/CARTAvis-externals/ThirdParty
 
-cd $CARTAWORKHOME/CARTAvis-externals/ThirdParty
+### Qwt: for casa-submodue-code, by using Qt4.8.5
+# curl -O -L http://downloads.sourceforge.net/project/qwt/qwt/6.1.0/qwt-6.1.0.tar.bz2
+# tar xvfj qwt-6.1.0.tar.bz2 && mv qwt-6.1.0 qwt-6.1.0-src
+# cd qwt-6.1.0-src # can use qwt 6.1.3 Pavol uses
+# # for unix part
+# if [ "$(uname)" == "Darwin" ]; then
+#     perl -i -pe 's/.*/ QWT_INSTALL_PREFIX    = $ENV{cartawork}\/CARTAvis-externals\/ThirdParty\/qwt-6.1.0\/ / if $.==22' qwtconfig.pri
+# else
+#     sed -i "22,22c QWT_INSTALL_PREFIX    = $cartawork/CARTAvis-externals/ThirdParty/qwt-6.1.0" qwtconfig.pri
+# fi
+# qmake qwt.pro
+# make && make install
+# # export PATH=$cartawork/CARTAvis-externals/ThirdParty/qwt-6.1.0/include:$PATH
+# # export PATH=$cartawork/CARTAvis-externals/ThirdParty/qwt-6.1.0/lib:$PATH
+# cd ..
+# if [ "$(uname)" == "Darwin" ]; then
+# 	cd qwt-6.1.0
+#     mkdir include
+# 	ln -s ../lib/qwt.framework/Versions/6/Headers include/qwt
+#     ln -s ../lib/qwt.framework/Versions/6/qwt ./lib/qwt
+# 	cd ..
+# fi
 
-## for building qwt for casa-submodue-code, by using Qt4.8.5
-curl -O -L http://downloads.sourceforge.net/project/qwt/qwt/6.1.0/qwt-6.1.0.tar.bz2
-tar xvfj qwt-6.1.0.tar.bz2 && mv qwt-6.1.0 qwt-6.1.0-src
-cd qwt-6.1.0-src # can use qwt 6.1.3 Pavol uses
-# for unix part
-if [ "$(uname)" == "Darwin" ]; then
-    perl -i -pe 's/.*/ QWT_INSTALL_PREFIX    = $ENV{CARTAWORKHOME}\/CARTAvis-externals\/ThirdParty\/qwt-6.1.0\/ / if $.==22' qwtconfig.pri
-else
-    sed -i "22,22c QWT_INSTALL_PREFIX    = $CARTAWORKHOME/CARTAvis-externals/ThirdParty/qwt-6.1.0" qwtconfig.pri
-fi
-qmake qwt.pro
-make && make install
-# export PATH=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/qwt-6.1.0/include:$PATH
-# export PATH=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/qwt-6.1.0/lib:$PATH
-cd ..
-if [ "$(uname)" == "Darwin" ]; then
-	cd qwt-6.1.0
-    mkdir include
-	ln -s ../lib/qwt.framework/Versions/6/Headers include/qwt
-    ln -s ../lib/qwt.framework/Versions/6/qwt ./lib/qwt
-	cd ..
-fi
-
-## cascore and code
+#### cascore and code
 # in the other instruction to build carta + casa, usually
 # casa
-# cartabuild(CARTAWORKHOME) / CARTAvis(carta, git root folder)
-# but we put casa inside $CARTAWORKHOME/CARTAvis-externals/ThirdParty
+# cartabuild(cartawork) / CARTAvis(carta, git root folder)
+# but we put casa inside $cartawork/CARTAvis-externals/ThirdParty
 mkdir casa
 cd casa
 
-### old svn way
+### old svn way:
 # it seems that its svn external link, casa submodule - casacore will checkout its latest one
 # svn co --ignore-externals -r 38314 https://svn.cv.nrao.edu/svn/casa/trunk
 # cd trunk
@@ -242,9 +206,7 @@ cd casa
 # # no need to rename for git way
 # svn co -r 105507 https://github.com/casacore/casacore/trunk
 # mv trunk casacore
-###
-
-### new total git way + only clone casacore without asap part
+### new git way: total git way + only clone casacore without asap part
 git clone https://open-bitbucket.nrao.edu/scm/casa/casa.git trunk
 cd trunk
 git checkout 77a3c0170c895142883dc1b69c4996f430c9e8ec ## = 5.0.0-mas-193, 20170506
@@ -256,19 +218,16 @@ git submodule update --init casacore
 cd casacore
 mkdir build && cd build
 
-# https://sites.google.com/a/asiaa.sinica.edu.tw/acdc/bui/centos7-2,
-# maybe this is due to the above reason, required by latest versoin of casacore
-# export PATH=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/cfitsio/include:$PATH \
-# export PATH=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/cfitsio/lib:$PATH
-
 ###  two more official build refernece
 # https://github.com/casacore/casacore
 # https://github.com/casacore/casacore/wiki/CmakeInstructions
+# https://safe.nrao.edu/wiki/bin/view/Software/CASA/CasaCMakeFlagsOSX1010
+# https://safe.nrao.edu/wiki/bin/view/Software/CASA/CartaBuildInstructionsForUbuntu
 ###
 
 ## it is better to rm -rf * in build folder if rebuild manually + dependency changes
 ## can use your own compiler and gfortan here
-## use $CARTAWORKHOME may be better for -DCMAKE_INSTALL_PREFIX=../../linux
+## use $cartawork may be better for -DCMAKE_INSTALL_PREFIX=../../linux
 ## After checking, /usr/lib64/casa/01 does not exist but build OK
 
 if [ "$(uname)" == "Darwin" ]; then
@@ -276,8 +235,8 @@ if [ "$(uname)" == "Darwin" ]; then
     -DUseCasacoreNamespace=1 \
     -DCMAKE_Fortran_COMPILER=/usr/local/Cellar/gcc/6.3.0_1/bin/gfortran-6 \
     -DPYTHON_LIBRARY=/System/Library/Frameworks/Python.framework/Versions/2.7/Python \
-    -DWCSLIB_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/wcslib \
-    -DCFITSIO_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/cfitsio \
+    -DWCSLIB_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/wcslib \
+    -DCFITSIO_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/cfitsio \
     -DBOOST_ROOT=/usr/local/Cellar/boost/1.63.0 \
     -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
     -DCMAKE_C_COMPILER=/usr/bin/clang \
@@ -289,8 +248,8 @@ elif [ "$isCentOS" = true ] ; then
     -DCMAKE_INSTALL_PREFIX=../../$TARGETOS -DBUILD_PYTHON=1 \
     -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 \
     -DPYTHON_LIBRARY=/usr/lib64/libpython2.7.so \
-    -DWCSLIB_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/wcslib \
-    -DCFITSIO_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/cfitsio \
+    -DWCSLIB_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/wcslib \
+    -DCFITSIO_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/cfitsio \
     -DCMAKE_BUILD_TYPE=Release \
     -DCXX11=1 ..
     # -DPYTHON_LIBRARY=/opt/casa/01/lib/libpython2.7.so \ ??
@@ -307,26 +266,15 @@ else
     -DCMAKE_BUILD_TYPE=Release -DCXX11=1 ..
 fi
 
-### Mac part:
-# -DCMAKE_Fortran_COMPILER=/opt/casa/02/bin/gfortran-mp-5 \ ?
-# -DPYTHON_LIBRARY=/opt/casa/02/lib/libpython2.7.dylib \ ?
-## DUseCrashReporter seems to be not used by casacore
-# cmake -DBoost_NO_BOOST_CMAKE=1 -DCASA_BUILD=1 \
-# -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
-# -DCMAKE_C_COMPILER=/usr/bin/clang \
-# -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF \
-# -DCMAKE_INSTALL_PREFIX=../../darwin -DBUILD_PYTHON=1 -DCXX11=1 ..
-###
-
-# it may build fail due to no official parallel build support of casa
+# it may build fail due to no official parallel build support of casa, switch to use "make" when fail
 make -j2
 make install
 
 ############################ casa-submodule: code/imageanalysis
+
 cd ../../code
 
-
-### old
+### old:
 # # Apply https://safe.nrao.edu/wiki/pub/Software/CASA/CartaBuildInstructionsForUbuntu/imageanalysisonubuntu.diff
 # # to Code to build imageanalysis only. Reduce build time a lot !!!!!
 # curl -O http://www.asiaa.sinica.edu.tw/~tckang/casa/casacodereduce1.diff
@@ -351,16 +299,14 @@ cd ../../code
 #   sed -i 's/.*casa_add_module( parallel/#&/' CMakeLists.txt
 #   sed -i 's/.*casa_add_module( casadbus/#&/' CMakeLists.txt
 # fi
-###
-
-### new for new git way/repo, will improve later. 201705
-curl -O http://www.asiaa.sinica.edu.tw/~tckang/casa/casacodereduce2.diff
-git apply casacodereduce2.diff
+### new:  for new git way/repo, will improve later. 201705
+curl -O https://raw.githubusercontent.com/grimmer0125/tmp/master/casacodereduce3.diff
+git apply casacodereduce3.diff
 ###
 
 mkdir build && cd build
 
-# -DEXTRA_C_FLAGS=-DPG_PPU -I/opt/casa/02/include/wcslib
+# TODO: check what this means? -DEXTRA_C_FLAGS=-DPG_PPU -I/opt/casa/02/include/wcslib
 
 ## it is better to rm -rf * in build folder if rebuild manually + dependency changes
 ## DSKIP_PGPLOT is used by display, qtviewer/guitools?, or some imageanalysis/test
@@ -368,8 +314,8 @@ if [ "$(uname)" == "Darwin" ]; then
     cmake -DUseCrashReporter=0 -DBoost_NO_BOOST_CMAKE=1 \
     -DUseCasacoreNamespace=1 \
     -Darch=$TARGETOS -DCMAKE_BUILD_TYPE=Release -DCXX11=1 \
-    -DWCSLIB_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/wcslib \
-    -DCFITSIO_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/cfitsio \
+    -DWCSLIB_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/wcslib \
+    -DCFITSIO_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/cfitsio \
     -DREADLINE_ROOT_DIR=/usr/local/opt/readline \
     -DPGPLOT_ROOT_DIR=/usr/local/opt/pgplot \
     -DBOOST_ROOT=/usr/local/Cellar/boost/1.63.0 \
@@ -377,9 +323,9 @@ if [ "$(uname)" == "Darwin" ]; then
     -DPGPLOT_LIBRARIES=/usr/local/opt/pgplot/lib \
     -DSKIP_PGPLOT=1 \
     -DLIBXML2_ROOT_DIR=/usr/local/opt/libxml2 \
-    -DQWT_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/qwt-6.1.0 \
+    -DQWT_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/qwt-6.1.0 \
     -DXERCES_ROOT_DIR=/usr/local/opt/xerces-c \
-    -DRPFITS_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/rpfits \
+    -DRPFITS_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/rpfits \
     -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
     -DCMAKE_C_COMPILER=/usr/bin/clang \
     -DLLVMCOMPILER=1 \
@@ -387,9 +333,9 @@ if [ "$(uname)" == "Darwin" ]; then
 elif [ "$isCentOS" = true ] ; then
     cmake -DUseCrashReporter=0 -DBoost_NO_BOOST_CMAKE=1 -DEXTRA_C_FLAGS=-DPG_PPU \
     -DUseCasacoreNamespace=1 \
-    -DWCSLIB_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/wcslib \
-    -DCFITSIO_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/cfitsio \
-    -DQWT_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/qwt-6.1.0 \
+    -DWCSLIB_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/wcslib \
+    -DCFITSIO_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/cfitsio \
+    -DQWT_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/qwt-6.1.0 \
     -DLIBSAKURA_ROOT_DIR=/opt/casa/01/lib/libsakura/default/ \
     -Darch=$TARGETOS -DCMAKE_BUILD_TYPE=Release ..
     ## -DCXX11=1
@@ -400,47 +346,26 @@ else
     # -DWCSLIB_ROOT_DIR=/media/workdrive/CARTA/CARTAvis-externals/ThirdParty/wcslib
     cmake -DUseCrashReporter=0 -DBoost_NO_BOOST_CMAKE=1 '-DEXTRA_C_FLAGS=-DPG_PPU' \
     -DUseCasacoreNamespace=1 \
-    -DWCSLIB_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/wcslib \
-    -DCFITSIO_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/cfitsio \
-    -DQWT_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/qwt-6.1.0 \
+    -DWCSLIB_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/wcslib \
+    -DCFITSIO_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/cfitsio \
+    -DQWT_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/qwt-6.1.0 \
     -DLIBSAKURA_ROOT_DIR=/opt/casa/01/lib/libsakura/default/ \
     -Darch=$TARGETOS -DCMAKE_BUILD_TYPE=Release ..
 fi
 
-# -DCMAKE_Fortran_COMPILER=/opt/casa/02/bin/gfortran-mp-5 \
-### Mac part
-# cmake -DUseCrashReporter=0 -DBoost_NO_BOOST_CMAKE=1 \
-# -Darch=darwin -DCMAKE_BUILD_TYPE=Release -DCXX11=1 \
-# -DWCSLIB_ROOT_DIR=/usr/local/Cellar/wcslib/5.16_1 \
-# -DREADLINE_ROOT_DIR=/usr/local/opt/readline \
-# -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
-# -DCMAKE_C_COMPILER=/usr/bin/clang \
-# -DLLVMCOMPILER=1 \
-# -DINTERACTIVE_ITERATION=1 -Dpgplot_ext=_nox ..
-# # -DCMAKE_INSTALL_PREFIX=../../darwin
-###
-
-# https://safe.nrao.edu/wiki/bin/view/Software/CASA/CartaBuildInstructionsForUbuntu
-# cmake -DUseCrashReporter=0 -DBoost_NO_BOOST_CMAKE=1 '-DEXTRA_C_FLAGS=-DPG_PPU' \
-# -Darch=linux -DCMAKE_BUILD_TYPE=Release \
-# -DCXX11=1 -DWCSLIB_ROOT_DIR=$CARTAWORKHOME/CARTAvis-externals/ThirdParty/wcslib ..
-
 # it may build fail due to no official parallel build support of casa
 make -j2
 
-# Ville said code does not need make install
-# make install
+mkdir -p $cartawork/CARTAvis-externals/ThirdParty/casacore
+mkdir -p $cartawork/CARTAvis-externals/ThirdParty/imageanalysis
 
-mkdir -p $CARTAWORKHOME/CARTAvis-externals/ThirdParty/casacore
-mkdir -p $CARTAWORKHOME/CARTAvis-externals/ThirdParty/imageanalysis
-
-cd $CARTAWORKHOME/CARTAvis-externals/ThirdParty/imageanalysis
-ln -s $CARTAWORKHOME/CARTAvis-externals/ThirdParty/casa/trunk/$TARGETOS/include/casacode/ include
-ln -s $CARTAWORKHOME/CARTAvis-externals/ThirdParty/casa/trunk/$TARGETOS/lib lib
+cd $cartawork/CARTAvis-externals/ThirdParty/imageanalysis
+ln -s $cartawork/CARTAvis-externals/ThirdParty/casa/trunk/$TARGETOS/include/casacode/ include
+ln -s $cartawork/CARTAvis-externals/ThirdParty/casa/trunk/$TARGETOS/lib lib
 
 cd ../casacore
-ln -s $CARTAWORKHOME/CARTAvis-externals/ThirdParty/casa/trunk/$TARGETOS/include/ include
-ln -s $CARTAWORKHOME/CARTAvis-externals/ThirdParty/casa/trunk/$TARGETOS/lib lib
+ln -s $cartawork/CARTAvis-externals/ThirdParty/casa/trunk/$TARGETOS/include/ include
+ln -s $cartawork/CARTAvis-externals/ThirdParty/casa/trunk/$TARGETOS/lib lib
 
 if [ "$isCentOS" = true ] ; then
     unalias qmake

--- a/carta/scripts/buildcasa.sh
+++ b/carta/scripts/buildcasa.sh
@@ -236,7 +236,7 @@ if [ "$(uname)" == "Darwin" ]; then
     -DPYTHON_LIBRARY=/System/Library/Frameworks/Python.framework/Versions/2.7/Python \
     -DWCSLIB_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/wcslib \
     -DCFITSIO_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/cfitsio \
-    -DBOOST_ROOT=/usr/local/Cellar/boost/1.63.0 \
+    -DBOOST_ROOT=/usr/local/opt/boost \
     -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
     -DCMAKE_C_COMPILER=/usr/bin/clang \
     -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF \
@@ -318,7 +318,7 @@ if [ "$(uname)" == "Darwin" ]; then
     -DCFITSIO_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/cfitsio \
     -DREADLINE_ROOT_DIR=/usr/local/opt/readline \
     -DPGPLOT_ROOT_DIR=/usr/local/opt/pgplot \
-    -DBOOST_ROOT=/usr/local/Cellar/boost/1.63.0 \
+    -DBOOST_ROOT=/usr/local/opt/boost \
     -DPGPLOT_INCLUDE_DIRS=/usr/local/opt/pgplot/include \
     -DPGPLOT_LIBRARIES=/usr/local/opt/pgplot/lib \
     -DSKIP_PGPLOT=1 \

--- a/carta/scripts/buildcasa.sh
+++ b/carta/scripts/buildcasa.sh
@@ -232,7 +232,7 @@ mkdir build && cd build
 if [ "$(uname)" == "Darwin" ]; then
     cmake -DBoost_NO_BOOST_CMAKE=1 -DCASA_BUILD=1 \
     -DUseCasacoreNamespace=1 \
-    -DCMAKE_Fortran_COMPILER=/usr/local/Cellar/gcc/6.3.0_1/bin/gfortran-6 \
+	-DCMAKE_Fortran_COMPILER=/usr/local/bin/gfortran \
     -DPYTHON_LIBRARY=/System/Library/Frameworks/Python.framework/Versions/2.7/Python \
     -DWCSLIB_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/wcslib \
     -DCFITSIO_ROOT_DIR=$cartawork/CARTAvis-externals/ThirdParty/cfitsio \

--- a/carta/scripts/buildcasa.sh
+++ b/carta/scripts/buildcasa.sh
@@ -6,7 +6,6 @@
 
 if [ -z ${cartawork+x} ]; then
 	export cartawork=`pwd`
-else
 fi
 
 isCentOS=true

--- a/carta/scripts/buildcasa.sh
+++ b/carta/scripts/buildcasa.sh
@@ -133,7 +133,7 @@ else
     ## since the original source code will not be compiled OK by gcc 5.4, gcc 4.8 seem neither
     git clone https://github.com/grimmer0125/libsakura
 
-    wget -O gtest-1.7.0.zip https://github.com/google/googletest/archive/release-1.7.0.zip
+    curl -o gtest-1.7.0.zip -L https://github.com/google/googletest/archive/release-1.7.0.zip
     unzip gtest-1.7.0.zip -d libsakura
     cd libsakura
     ln -s googletest-release-1.7.0 gtest

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -65,47 +65,6 @@ sudo -u $SUDO_USER ruby \
 sudo su $SUDO_USER -c "brew install wget"
 printDuration
 
-if [ -f $cartawork/CARTAvis-externals/ThirdParty/macports/bin/flex ]; then
-  echo "Macports-flex exist, so ignore macports part"
-else
-  echo "Macports-flex does not exist, so start to install macports and its flex, bison"
-
-  echo "step2-2: prerequisite: install macports" ## ~ 3.5 min
-  pause
-
-  # 3. install macports, can not use 2.4.1 version which will install flex 2.6.x and not compatible with CARTA, no region drawn
-  macporthome=$cartawork/CARTAvis-externals/ThirdParty/macports
-  # mkdir -p $cartawork/CARTAvis-externals/ThirdParty
-  cd $cartawork/CARTAvis-externals/ThirdParty
-  curl -o MacPorts-2.3.4.tar.gz https://distfiles.macports.org/MacPorts/MacPorts-2.3.4.tar.gz
-  tar zxf MacPorts-2.3.4.tar.gz
-  cd MacPorts-2.3.4
-  # ./configure --prefix=/opt/casa/02 --with-macports-user=root --with-applications-dir=/opt/casa/02/Applications
-  ./configure --prefix=$macporthome
-  make
-  sudo make install
-  #sudo /opt/casa/02/bin/port -v selfupdate
-  sudo $macporthome/bin/port -v selfupdate
-  printDuration
-
-  echo "step2-3: install flex from macports"
-  pause
-
-  # these can be installed by ordinary Macports, too.
-  sudo $macporthome/bin/port -N install flex  # 2.5.37, long time to install,
-  # try this later https://github.com/apiaryio/homebrew/blob/master/Library/Formula/flex.rb
-  # https://searchcode.com/codesearch/view/92040310/
-  # homebrew official default :2.6.3
-  printDuration
-
-  echo "step2-4: install bison from macports"
-  pause
-
-  sudo $macporthome/bin/port -N install bison # 3.0.4
-  ###
-  printDuration
-
-fi
 
 ### download CARTA soure code
 echo "step3: download CARTA soure code"

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+### TODO
+## 1. use the following two to improve sudo part
+## https://askubuntu.com/questions/585043/run-only-parts-of-a-script-as-sudo-entering-password-only-once
+## or https://unix.stackexchange.com/questions/70859/why-doesnt-sudo-su-in-a-shell-script-run-the-rest-of-the-script-as-root
+## 2. cache for gsl??? no, at least need build again !!! sakura and homebrew global part, hombrew can not be used with sudo
+## x3. webkit preview 5 of qt 5.8 !!!!!
+
+### define your variables first
+export cartawork=~/src2
+branch=upgradeToNewNamespace #optional
+qtwebkit=qtwebkit-tp5-qt58-darwin-x64
+export QT5PATH=/usr/local/Cellar/qt/5.8.0_2
+export CARTABUILDHOME=$cartawork/CARTAvis/build
+##
+
+### prerequisite
+# 1. xcode
+# 2. isntall homebrw
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+brew install wget
+# 3. install macports
+mkdir -p $cartawork/CARTAvis-externals/ThirdParty
+cd $cartawork/CARTAvis-externals/ThirdParty
+curl -o MacPorts-2.4.1.tar.gz https://distfiles.macports.org/MacPorts/MacPorts-2.4.1.tar.gz
+tar zxf MacPorts-2.4.1.tar.gz
+cd MacPorts-2.4.1
+./configure --prefix=/opt/casa/02 --with-macports-user=root --with-applications-dir=/opt/casa/02/Applications
+make
+sudo make install
+sudo /opt/casa/02/bin/port -v selfupdate
+##
+
+### download CARTA soure code
+mkdir -p $cartawork
+cd $cartawork
+git clone https://github.com/CARTAvis/carta.git CARTAvis
+cd CARTAvis
+git checkout $branch
+
+brew install qt
+
+### Install 3 party for CARTA
+cd $cartawork
+sudo ./CARTAvis/carta/scripts/install3party.sh
+# these can be installed by ordinary Macports, too.
+sudo /opt/casa/02/bin/port -N install flex  # 2.5.37
+sudo /opt/casa/02/bin/port -N install bison # 3.0.4
+
+### Install the libraries for casa
+# part1 homebrew part
+./CARTAvis/carta/scripts/installLibsForCASAonMac.sh
+# part2
+cd $cartawork/CARTAvis-externals/ThirdParty
+## build libsakura-4.0.2065.
+git clone https://github.com/grimmer0125/libsakura
+wget -O gtest-1.7.0.zip https://github.com/google/googletest/archive/release-1.7.0.zip
+unzip gtest-1.7.0.zip -d libsakura
+cd libsakura
+ln -s googletest-release-1.7.0 gtest
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_DOC=BOOL:OFF -DSIMD_ARCH=SSE4 \
+-DEIGEN3_INCLUDE_DIR=/usr/local/Cellar/eigen@3.2/3.2.10/include/eigen3 ..
+make
+make apidoc
+sudo make install
+cd ../../
+# in casa-code's cmake, its related parameter is -DLIBSAKURA_ROOT_DIR, but not need now since we install into /usr/local
+# part3, Build rpfits-2.24, make sure you are still in `your-carta-work`/CARTAvis-externals/ThirdParty/
+wget ftp://ftp.atnf.csiro.au/pub/software/rpfits/rpfits-2.24.tar.gz
+tar xvfz rpfits-2.24.tar.gz && mv rpfits rpfits-src
+mkdir -p rpfits/lib
+mkdir -p rpfits/include
+mkdir -p rpfits/bin
+cd rpfits-src
+export RPARCH="darwin"
+export PATH=/usr/local/Cellar/gcc/6.3.0_1/bin:$PATH
+make FC=gfortran-6 -f GNUmakefile
+cp librpfits.a ../rpfits/lib/
+cp rpfex rpfhdr ../rpfits/bin/
+cp code/RPFITS.h ../rpfits/include/
+
+### build casa
+cd $cartawork
+./CARTAvis/carta/scripts/buildcasa.sh
+
+### setup QtWebkit
+cd $cartawork/CARTAvis-externals/ThirdParty
+wget https://github.com/annulen/webkit/releases/download/qtwebkit-tp5/$qtwebkit.tar.xz
+tar -xvzf $qtwebkit.tar.xz
+# export QT5PATH=/usr/local/Cellar/qt/5.8.0_2
+# /Users/grimmer/Qt/5.7/clang_64
+# copy include
+cp -r $cartawork/CARTAvis-externals/ThirdParty/$qtwebkit/include/QtWebKit $QT5PATH/include/
+cp -r $cartawork/CARTAvis-externals/ThirdParty/$qtwebkit/include/QtWebKitWidgets $QT5PATH/include/
+# copy lib
+cp $cartawork/CARTAvis-externals/ThirdParty/$qtwebkit/lib/libqt* $QT5PATH/lib/
+cp -r $cartawork/CARTAvis-externals/ThirdParty/$qtwebkit/lib/QtWebKit.framework $QT5PATH/lib/
+cp -r $cartawork/CARTAvis-externals/ThirdParty/$qtwebkit/lib/QtWebKitWidgets.framework $QT5PATH/lib/
+cp -r $cartawork/CARTAvis-externals/ThirdParty/$qtwebkit/lib/cmake/* $QT5PATH/lib/cmake/
+cp $cartawork/CARTAvis-externals/ThirdParty/$qtwebkit/lib/pkgconfig/* $QT5PATH/lib/pkgconfig/
+# copy mkspecs
+cp $cartawork/CARTAvis-externals/ThirdParty/$qtwebkit/mkspecs/modules/* $QT5PATH/mkspecs/modules/
+echo "QT.webkit.module = QtWebKit" >> $QT5PATH/mkspecs/modules/qt_lib_webkit.pri
+perl -pi.bak -e 's/QT.webkit.module_config =/QT.webkit.module_config = v2 lib_bundle/g' $QT5PATH/mkspecs/modules/qt_lib_webkit.pri
+echo "QT.webkitwidgets.module = QtWebKitWidgets" >> $QT5PATH/mkspecs/modules/qt_lib_webkitwidgets.pri
+perl -pi.bak -e 's/QT.webkitwidgets.module_config =/QT.webkitwidgets.module_config = v2 lib_bundle /g' $QT5PATH/mkspecs/modules/qt_lib_webkitwidgets.pri
+
+### build UI of CARTA
+cd $cartawork/CARTAvis/carta/html5/common/skel
+./generate.py
+
+### build CARTA
+export PATH=$QT5PATH/bin:$PATH
+mkdir -p $CARTABUILDHOME
+cd $CARTABUILDHOME
+qmake -config release NOSERVER=1 CARTA_BUILD_TYPE=release $cartawork/CARTAvis/carta -r
+make -j2
+
+### packagize CARTA
+curl -O https://raw.githubusercontent.com/CARTAvis/deploytask/Qt5.8.0/final_mac_packaging_steps.sh
+chmod 755 final_mac_packaging_steps.sh && ./final_mac_packaging_steps.sh

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -103,8 +103,8 @@ printDuration
 echo "step4-3: Use homebrew to Install some libs needed by flex and bison for CARTA"
 su $SUDO_USER <<EOF
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/49887a8f215bd8b365c28c6ae5ea62bb1350c893/Formula/bison.rb
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/091e0bebb25d235b9efeeebf184a819ed7ade8a7/Formula/autoconf.rb
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/c679306cc10018711fc3f16d46b3392909601e9b/Formula/automake.rb
+brew install autoconf
+brew install automake
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/d407fb8563f480391d918e1f1160cb7e244a1a12/Formula/gettext.rb
 brew cask install basictex
 EOF

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -128,7 +128,8 @@ printDuration
 echo "step4-2: Install Third party for CARTA"
 pause
 cd $cartawork
-sudo ./CARTAvis/carta/scripts/install3party.sh
+## if use sudo ./xx.sh will let it can not inherit QT5PATH
+./CARTAvis/carta/scripts/install3party.sh
 ###
 printDuration
 
@@ -188,7 +189,6 @@ printDuration
 ### setup QtWebkit
 echo "step7: setup QtWebkit"
 pause
-
 su $SUDO_USER <<EOF
 cd $cartawork/CARTAvis-externals/ThirdParty
 wget https://github.com/annulen/webkit/releases/download/qtwebkit-tp5/$qtwebkit.tar.xz
@@ -215,23 +215,28 @@ EOF
 printDuration
 
 ### build UI of CARTA
-su $SUDO_USER <<EOF
 echo "step8: Build UI of CARTA"
 pause
+su $SUDO_USER <<EOF
+echo $cartawork
 cd $cartawork/CARTAvis/carta/html5/common/skel
 ./generate.py
 ###
+EOF
 printDuration
 
 ### build CARTA
 echo "step9: Build CARTA"
 pause
+su $SUDO_USER <<EOF
+echo $QT5PATH
 export PATH=$QT5PATH/bin:$PATH
 mkdir -p $CARTABUILDHOME
 cd $CARTABUILDHOME
 qmake -config release NOSERVER=1 CARTA_BUILD_TYPE=release $cartawork/CARTAvis/carta -r
 make -j2
 ###
+EOF
 printDuration
 
 echo "end time:"
@@ -240,6 +245,7 @@ date
 ### packagize CARTA
 echo "step10: packagize CARTA"
 pause
+su $SUDO_USER <<EOF
 curl -O https://raw.githubusercontent.com/CARTAvis/deploytask/Qt5.8.0/final_mac_packaging_steps.sh
 chmod 755 final_mac_packaging_steps.sh
 ./final_mac_packaging_steps.sh

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -39,22 +39,41 @@ sudo -u $SUDO_USER ruby \
   </dev/null
 sudo su $SUDO_USER -c "brew install wget"
 printDuration
+
 echo "step2-2: prerequisite: install macports"
-# 3. install macports
-macporthome=$cartawork/CARTAvis-externals/ThirdParty/macports
-mkdir -p $cartawork/CARTAvis-externals/ThirdParty
-cd $cartawork/CARTAvis-externals/ThirdParty
-curl -o MacPorts-2.4.1.tar.gz https://distfiles.macports.org/MacPorts/MacPorts-2.4.1.tar.gz
-tar zxf MacPorts-2.4.1.tar.gz
-cd MacPorts-2.4.1
-# ./configure --prefix=/opt/casa/02 --with-macports-user=root --with-applications-dir=/opt/casa/02/Applications
-./configure --prefix=$macporthome
-make
-sudo make install
-#sudo /opt/casa/02/bin/port -v selfupdate
-sudo $macporthome/bin/port -v selfupdate
-###
-printDuration
+
+if [ -f /Users/grimmer/src3/CARTAvis-externals/ThirdParty/macports/bin/flex ]; then
+  echo "Macports-flex exist, so ignore macports part"
+else
+  echo "Macports-flex exist, so start to install macports and its flex, bison"
+  # 3. install macports
+  macporthome=$cartawork/CARTAvis-externals/ThirdParty/macports
+  mkdir -p $cartawork/CARTAvis-externals/ThirdParty
+  cd $cartawork/CARTAvis-externals/ThirdParty
+  curl -o MacPorts-2.4.1.tar.gz https://distfiles.macports.org/MacPorts/MacPorts-2.4.1.tar.gz
+  tar zxf MacPorts-2.4.1.tar.gz
+  cd MacPorts-2.4.1
+  # ./configure --prefix=/opt/casa/02 --with-macports-user=root --with-applications-dir=/opt/casa/02/Applications
+  ./configure --prefix=$macporthome
+  make
+  sudo make install
+  #sudo /opt/casa/02/bin/port -v selfupdate
+  sudo $macporthome/bin/port -v selfupdate
+  printDuration
+
+  echo "step2-3: install flex from macports"
+  # these can be installed by ordinary Macports, too.
+  sudo $macporthome/bin/port -N install flex  # 2.5.37, long time to install,
+  # try this later https://github.com/apiaryio/homebrew/blob/master/Library/Formula/flex.rb
+  # https://searchcode.com/codesearch/view/92040310/
+  # homebrew official default :2.6.3
+  printDuration
+
+  echo "step2-4: install bison from macports"
+  sudo $macporthome/bin/port -N install bison # 3.0.4
+  ###
+  printDuration
+fi
 
 ### download CARTA soure code
 echo "step3: download CARTA soure code"
@@ -64,29 +83,27 @@ cd $cartawork
 git clone https://github.com/CARTAvis/carta.git CARTAvis
 cd CARTAvis
 git checkout $branch
+mkdir -p $cartawork/CARTAvis-externals/ThirdParty
 EOF
 ###
 printDuration
 
 ### Install 3 party for CARTA
-echo "step4: Install Qt & Third party for CARTA"
+echo "step4: Install Qt for CARTA"
 sudo su $SUDO_USER -c "brew install qt"
 printDuration
+echo "step4-2: Install Third party for CARTA"
 cd $cartawork
 sudo ./CARTAvis/carta/scripts/install3party.sh
-# these can be installed by ordinary Macports, too.
-sudo $macporthome/bin/port -N install flex  # 2.5.37, long time to install,
-# try this later https://github.com/apiaryio/homebrew/blob/master/Library/Formula/flex.rb
-# https://searchcode.com/codesearch/view/92040310/
-# homebrew official default :2.6.3
-sudo $macporthome/bin/port -N install bison # 3.0.4
 ###
 printDuration
 
 ### Install the libraries for casa
-echo "step5: Install the libraries for casa"
+echo "step5: Install some libraries for casa from homebrew"
 # part1 homebrew part
 sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/installLibsForCASAonMac.sh"
+printDuration
+echo "step5-2: Install some libraries for casa, build from source"
 # part2
 cd $cartawork/CARTAvis-externals/ThirdParty
 ## build libsakura-4.0.2065.
@@ -123,7 +140,7 @@ printDuration
 ### build casa
 echo "step6: Build casa"
 cd $cartawork
-sudo ./CARTAvis/carta/scripts/buildcasa.sh
+sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/buildcasa.sh"
 ###
 printDuration
 

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -36,6 +36,7 @@ fi
 echo "CARTA working folder is $cartawork"
 
 qt57brew=/usr/local/opt/qt\@5.7
+export qt57brewrealpath=/usr/local/Cellar/qt@5.7/5.7.1
 export QT5PATH=$qt57brew
 export CARTABUILDHOME=$cartawork/CARTAvis/build
 branch=upgradeToNewNamespace #optional

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -22,9 +22,17 @@ SECONDS=0
 
 echo "step1: define your variables first"
 
-if [ -z ${cartawork+x} ]; then
+# if [ -z ${cartawork+x} ]; then
+#   export cartawork=~/cartahome
+# fi
+
+if [ $# -eq 0 ] ; then
   export cartawork=~/cartahome
+else
+  export cartawork=$1
 fi
+
+echo "CARTA working folder is $cartawork"
 
 export QT5PATH=/usr/local/Cellar/qt/5.8.0_2
 export CARTABUILDHOME=$cartawork/CARTAvis/build
@@ -33,7 +41,11 @@ branch=upgradeToNewNamespace #optional
 ##
 
 echo "step1-2: create ThirdParty folder"
-sudo su $SUDO_USER -c "mkdir -p $cartawork/CARTAvis-externals/ThirdParty"
+
+su $SUDO_USER <<EOF
+mkdir -p $cartawork
+mkdir -p $cartawork/CARTAvis-externals/ThirdParty
+EOF
 
 # su $SUDO_USER <<EOF
 # /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
@@ -50,7 +62,6 @@ sudo -u $SUDO_USER ruby \
   </dev/null
 sudo su $SUDO_USER -c "brew install wget"
 printDuration
-
 
 if [ -f $cartawork/CARTAvis-externals/ThirdParty/macports/bin/flex ]; then
   echo "Macports-flex exist, so ignore macports part"
@@ -99,12 +110,10 @@ echo "step3: download CARTA soure code"
 pause
 
 su $SUDO_USER <<EOF
-mkdir -p $cartawork
 cd $cartawork
 git clone https://github.com/CARTAvis/carta.git CARTAvis
 cd CARTAvis
 git checkout $branch
-mkdir -p $cartawork/CARTAvis-externals/ThirdParty
 EOF
 ###
 printDuration
@@ -115,9 +124,9 @@ pause
 
 sudo su $SUDO_USER -c "brew install qt"
 printDuration
+
 echo "step4-2: Install Third party for CARTA"
 pause
-
 cd $cartawork
 sudo ./CARTAvis/carta/scripts/install3party.sh
 ###
@@ -126,7 +135,6 @@ printDuration
 ### Install the libraries for casa
 echo "step5: Install some libraries for casa from homebrew"
 pause
-
 # part1 homebrew part
 sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/installLibsForCASAonMac.sh"
 printDuration

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -167,6 +167,7 @@ printDuration
 echo "step7: setup QtWebkit"
 read -p "Press [Enter] key to start backup..."
 
+su $SUDO_USER <<EOF
 cd $cartawork/CARTAvis-externals/ThirdParty
 wget https://github.com/annulen/webkit/releases/download/qtwebkit-tp5/$qtwebkit.tar.xz
 tar -xvzf $qtwebkit.tar.xz
@@ -187,10 +188,9 @@ echo "QT.webkit.module = QtWebKit" >> $QT5PATH/mkspecs/modules/qt_lib_webkit.pri
 perl -pi.bak -e 's/QT.webkit.module_config =/QT.webkit.module_config = v2 lib_bundle/g' $QT5PATH/mkspecs/modules/qt_lib_webkit.pri
 echo "QT.webkitwidgets.module = QtWebKitWidgets" >> $QT5PATH/mkspecs/modules/qt_lib_webkitwidgets.pri
 perl -pi.bak -e 's/QT.webkitwidgets.module_config =/QT.webkitwidgets.module_config = v2 lib_bundle /g' $QT5PATH/mkspecs/modules/qt_lib_webkitwidgets.pri
+EOF
 ###
 printDuration
-
-
 
 ### build UI of CARTA
 su $SUDO_USER <<EOF

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -112,6 +112,7 @@ printDuration
 ##
 
 echo "step4-3: Use homebrew to Install some libs needed by flex and bison for CARTA"
+pause
 su $SUDO_USER <<EOF
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/49887a8f215bd8b365c28c6ae5ea62bb1350c893/Formula/bison.rb
 brew install autoconf
@@ -165,25 +166,25 @@ make apidoc
 sudo make install #/usr/local
 cd ../../
 printDuration
-echo "step5-3: Install some libraries for casa, build from source-rpfits"
-pause
-# in casa-code's cmake, its related parameter is -DLIBSAKURA_ROOT_DIR, but not need now since we install into /usr/local
-# part3, Build rpfits-2.24, make sure you are still in `your-carta-work`/CARTAvis-externals/ThirdParty/
-cd $cartawork/CARTAvis-externals/ThirdParty
-curl -O ftp://ftp.atnf.csiro.au/pub/software/rpfits/rpfits-2.24.tar.gz
-tar xvfz rpfits-2.24.tar.gz && mv rpfits rpfits-src
-mkdir -p rpfits/lib
-mkdir -p rpfits/include
-mkdir -p rpfits/bin
-cd rpfits-src
-export RPARCH="darwin"
-export PATH=/usr/local/Cellar/gcc/6.3.0_1/bin:$PATH
-make FC=gfortran-6 -f GNUmakefile
-cp librpfits.a ../rpfits/lib/
-cp rpfex rpfhdr ../rpfits/bin/
-cp code/RPFITS.h ../rpfits/include/
-###
-printDuration
+# echo "step5-3: Install some libraries for casa, build from source-rpfits"
+# pause
+# # in casa-code's cmake, its related parameter is -DLIBSAKURA_ROOT_DIR, but not need now since we install into /usr/local
+# # part3, Build rpfits-2.24, make sure you are still in `your-carta-work`/CARTAvis-externals/ThirdParty/
+# cd $cartawork/CARTAvis-externals/ThirdParty
+# curl -O ftp://ftp.atnf.csiro.au/pub/software/rpfits/rpfits-2.24.tar.gz
+# tar xvfz rpfits-2.24.tar.gz && mv rpfits rpfits-src
+# mkdir -p rpfits/lib
+# mkdir -p rpfits/include
+# mkdir -p rpfits/bin
+# cd rpfits-src
+# export RPARCH="darwin"
+# export PATH=/usr/local/Cellar/gcc/6.3.0_1/bin:$PATH
+# make FC=gfortran-6 -f GNUmakefile
+# cp librpfits.a ../rpfits/lib/
+# cp rpfex rpfhdr ../rpfits/bin/
+# cp code/RPFITS.h ../rpfits/include/
+# ###
+# printDuration
 
 ### build casa
 echo "step6: Build casa"

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -89,19 +89,19 @@ brew link --overwrite cmake
 ## now it is 7.1 we only use its gfortran which is also used by code
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/0ab90d39e3ca786c9f0b2fb44c2fd29880336cd2/Formula/gcc.rb
 EOF
-pause
+printDuration
 
 ### Install 3 party for CARTA
 echo "step4: Install Qt for CARTA if you use default homebrew-qt"
-pause
 if [ "$QT5PATH" == "$qt57brew" ]; then
   echo "start to install homebrew-qt"
+  pause
   sudo su $SUDO_USER -c "brew tap CARTAvis/tap"
   sudo su $SUDO_USER -c "brew install CARTAvis/tap/qt@5.7"
+  printDuration
 else
   echo "you use your own qt version"
 fi
-printDuration
 echo "step4-2: Install Third party for CARTA"
 pause
 cd $cartawork
@@ -129,7 +129,7 @@ tar zxvf flex-2.5.37.tar.gz
 mv flex-flex-2.5.37 flex-2.5.37
 cd flex-2.5.37
 export PATH=/usr/local/opt/gettext/bin:$PATH
-export PATH=/usr/local/opt/texinfo/bin:$PATH 
+export PATH=/usr/local/opt/texinfo/bin:$PATH
 export PATH=/usr/local/Cellar/help2man/1.47.4/bin:$PATH
 export PATH="$PATH:/Library/TeX/texbin"
 ./autogen.sh

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -6,6 +6,7 @@ function printDuration(){
 }
 
 function pause(){
+  afplay /System/Library/Sounds/Funk.aiff
   read -p "Press [Enter] key to continue"
 }
 
@@ -34,9 +35,10 @@ fi
 
 echo "CARTA working folder is $cartawork"
 
-export QT5PATH=/usr/local/Cellar/qt/5.8.0_2
+
+export QT5PATH=/usr/local/opt/qt\@5.7
 export CARTABUILDHOME=$cartawork/CARTAvis/build
-export qtwebkit=qtwebkit-tp5-qt58-darwin-x64
+export qtwebkit=qtwebkit-tp4-qt57-darwin
 branch=upgradeToNewNamespace #optional
 ##
 
@@ -68,16 +70,16 @@ if [ -f $cartawork/CARTAvis-externals/ThirdParty/macports/bin/flex ]; then
 else
   echo "Macports-flex does not exist, so start to install macports and its flex, bison"
 
-  echo "step2-2: prerequisite: install macports"
+  echo "step2-2: prerequisite: install macports" ## ~ 3.5 min
   pause
 
-  # 3. install macports
+  # 3. install macports, can not use 2.4.1 version which will install flex 2.6.x and not compatible with CARTA, no region drawn
   macporthome=$cartawork/CARTAvis-externals/ThirdParty/macports
   # mkdir -p $cartawork/CARTAvis-externals/ThirdParty
   cd $cartawork/CARTAvis-externals/ThirdParty
-  curl -o MacPorts-2.4.1.tar.gz https://distfiles.macports.org/MacPorts/MacPorts-2.4.1.tar.gz
-  tar zxf MacPorts-2.4.1.tar.gz
-  cd MacPorts-2.4.1
+  curl -o MacPorts-2.3.4.tar.gz https://distfiles.macports.org/MacPorts/MacPorts-2.3.4.tar.gz
+  tar zxf MacPorts-2.3.4.tar.gz
+  cd MacPorts-2.3.4
   # ./configure --prefix=/opt/casa/02 --with-macports-user=root --with-applications-dir=/opt/casa/02/Applications
   ./configure --prefix=$macporthome
   make
@@ -122,7 +124,7 @@ printDuration
 echo "step4: Install Qt for CARTA"
 pause
 
-sudo su $SUDO_USER -c "brew install qt"
+sudo su $SUDO_USER -c "brew install qt@5.7"
 printDuration
 
 echo "step4-2: Install Third party for CARTA"
@@ -191,7 +193,7 @@ echo "step7: setup QtWebkit"
 pause
 su $SUDO_USER <<EOF
 cd $cartawork/CARTAvis-externals/ThirdParty
-wget https://github.com/annulen/webkit/releases/download/qtwebkit-tp5/$qtwebkit.tar.xz
+wget https://github.com/annulen/webkit/releases/download/qtwebkit-tp4/qtwebkit-tp4-qt57-darwin.tar.xz
 tar -xvzf $qtwebkit.tar.xz
 # export QT5PATH=/usr/local/Cellar/qt/5.8.0_2
 # /Users/grimmer/Qt/5.7/clang_64

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -40,12 +40,14 @@ sudo -u $SUDO_USER ruby \
 sudo su $SUDO_USER -c "brew install wget"
 printDuration
 
-echo "step2-2: prerequisite: install macports"
+read -p "Press [Enter] key to start backup..."
 
 if [ -f /Users/grimmer/src3/CARTAvis-externals/ThirdParty/macports/bin/flex ]; then
   echo "Macports-flex exist, so ignore macports part"
 else
   echo "Macports-flex exist, so start to install macports and its flex, bison"
+
+  echo "step2-2: prerequisite: install macports"
   # 3. install macports
   macporthome=$cartawork/CARTAvis-externals/ThirdParty/macports
   mkdir -p $cartawork/CARTAvis-externals/ThirdParty
@@ -62,6 +64,8 @@ else
   printDuration
 
   echo "step2-3: install flex from macports"
+  read -p "Press [Enter] key to start backup..."
+
   # these can be installed by ordinary Macports, too.
   sudo $macporthome/bin/port -N install flex  # 2.5.37, long time to install,
   # try this later https://github.com/apiaryio/homebrew/blob/master/Library/Formula/flex.rb
@@ -70,13 +74,18 @@ else
   printDuration
 
   echo "step2-4: install bison from macports"
+  read -p "Press [Enter] key to start backup..."
+
   sudo $macporthome/bin/port -N install bison # 3.0.4
   ###
   printDuration
+
 fi
 
 ### download CARTA soure code
 echo "step3: download CARTA soure code"
+read -p "Press [Enter] key to start backup..."
+
 su $SUDO_USER <<EOF
 mkdir -p $cartawork
 cd $cartawork
@@ -90,9 +99,13 @@ printDuration
 
 ### Install 3 party for CARTA
 echo "step4: Install Qt for CARTA"
+read -p "Press [Enter] key to start backup..."
+
 sudo su $SUDO_USER -c "brew install qt"
 printDuration
 echo "step4-2: Install Third party for CARTA"
+read -p "Press [Enter] key to start backup..."
+
 cd $cartawork
 sudo ./CARTAvis/carta/scripts/install3party.sh
 ###
@@ -100,10 +113,14 @@ printDuration
 
 ### Install the libraries for casa
 echo "step5: Install some libraries for casa from homebrew"
+read -p "Press [Enter] key to start backup..."
+
 # part1 homebrew part
 sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/installLibsForCASAonMac.sh"
 printDuration
 echo "step5-2: Install some libraries for casa, build from source"
+read -p "Press [Enter] key to start backup..."
+
 # part2
 cd $cartawork/CARTAvis-externals/ThirdParty
 ## build libsakura-4.0.2065.
@@ -139,6 +156,8 @@ printDuration
 
 ### build casa
 echo "step6: Build casa"
+read -p "Press [Enter] key to start backup..."
+
 cd $cartawork
 sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/buildcasa.sh"
 ###
@@ -146,6 +165,8 @@ printDuration
 
 ### setup QtWebkit
 echo "step7: setup QtWebkit"
+read -p "Press [Enter] key to start backup..."
+
 cd $cartawork/CARTAvis-externals/ThirdParty
 wget https://github.com/annulen/webkit/releases/download/qtwebkit-tp5/$qtwebkit.tar.xz
 tar -xvzf $qtwebkit.tar.xz
@@ -169,9 +190,12 @@ perl -pi.bak -e 's/QT.webkitwidgets.module_config =/QT.webkitwidgets.module_conf
 ###
 printDuration
 
+
+
 ### build UI of CARTA
 su $SUDO_USER <<EOF
 echo "step8: Build UI of CARTA"
+read -p "Press [Enter] key to start backup..."
 cd $cartawork/CARTAvis/carta/html5/common/skel
 ./generate.py
 ###
@@ -179,6 +203,7 @@ printDuration
 
 ### build CARTA
 echo "step9: Build CARTA"
+read -p "Press [Enter] key to start backup..."
 export PATH=$QT5PATH/bin:$PATH
 mkdir -p $CARTABUILDHOME
 cd $CARTABUILDHOME
@@ -191,6 +216,8 @@ echo "end time:"
 date
 
 ### packagize CARTA
+echo "step10: packagize CARTA"
+read -p "Press [Enter] key to start backup..."
 curl -O https://raw.githubusercontent.com/CARTAvis/deploytask/Qt5.8.0/final_mac_packaging_steps.sh
 chmod 755 final_mac_packaging_steps.sh
 ./final_mac_packaging_steps.sh

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -9,10 +9,10 @@
 
 ### define your variables first
 export cartawork=~/src2
-branch=upgradeToNewNamespace #optional
-qtwebkit=qtwebkit-tp5-qt58-darwin-x64
 export QT5PATH=/usr/local/Cellar/qt/5.8.0_2
 export CARTABUILDHOME=$cartawork/CARTAvis/build
+qtwebkit=qtwebkit-tp5-qt58-darwin-x64
+branch=upgradeToNewNamespace #optional
 ##
 
 ### prerequisite
@@ -50,7 +50,7 @@ sudo /opt/casa/02/bin/port -N install bison # 3.0.4
 
 ### Install the libraries for casa
 # part1 homebrew part
-./CARTAvis/carta/scripts/installLibsForCASAonMac.sh
+sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/installLibsForCASAonMac.sh"
 # part2
 cd $cartawork/CARTAvis-externals/ThirdParty
 ## build libsakura-4.0.2065.

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -35,11 +35,12 @@ fi
 
 echo "CARTA working folder is $cartawork"
 
-
-export QT5PATH=/usr/local/opt/qt\@5.7
+qt57brew=/usr/local/opt/qt\@5.7
+export QT5PATH=$qt57brew
 export CARTABUILDHOME=$cartawork/CARTAvis/build
-export qtwebkit=qtwebkit-tp4-qt57-darwin
 branch=upgradeToNewNamespace #optional
+qtwebkit=qtwebkit-tp4-qt57-darwin
+qtwebkitlink=https://github.com/annulen/webkit/releases/download/qtwebkit-tp4/qtwebkit-tp4-qt57-darwin.tar.xz
 ##
 
 echo "step1-2: create ThirdParty folder"
@@ -79,10 +80,15 @@ EOF
 printDuration
 
 ### Install 3 party for CARTA
-echo "step4: Install Qt for CARTA"
+echo "step4: Install Qt for CARTA if you use default homebrew-qt"
 pause
-sudo su $SUDO_USER -c "brew tap CARTAvis/tap"
-sudo su $SUDO_USER -c "brew install CARTAvis/tap/qt@5.7"
+if [ "$QT5PATH" == "$qt57brew" ]; then
+  echo "start to install homebrew-qt"
+  sudo su $SUDO_USER -c "brew tap CARTAvis/tap"
+  sudo su $SUDO_USER -c "brew install CARTAvis/tap/qt@5.7"
+else
+  echo "you use your own qt version"
+fi
 printDuration
 echo "step4-2: Install Third party for CARTA"
 pause
@@ -175,10 +181,8 @@ echo "step7: setup QtWebkit"
 pause
 su $SUDO_USER <<EOF
 cd $cartawork/CARTAvis-externals/ThirdParty
-curl -O -L https://github.com/annulen/webkit/releases/download/qtwebkit-tp4/qtwebkit-tp4-qt57-darwin.tar.xz
+curl -O -L $qtwebkitlink
 tar -xvzf $qtwebkit.tar.xz
-# export QT5PATH=/usr/local/Cellar/qt/5.8.0_2
-# /Users/grimmer/Qt/5.7/clang_64
 # copy include
 cp -r $cartawork/CARTAvis-externals/ThirdParty/$qtwebkit/include/QtWebKit $QT5PATH/include/
 cp -r $cartawork/CARTAvis-externals/ThirdParty/$qtwebkit/include/QtWebKitWidgets $QT5PATH/include/

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -80,6 +80,17 @@ EOF
 ###
 printDuration
 
+
+echo "step4-0:install homebrew's gcc to get gfortran for ast, also cmake for libsakura, casa libs"
+su $SUDO_USER <<EOF
+### Basic tools
+brew install cmake
+brew link --overwrite cmake
+## now it is 7.1 we only use its gfortran which is also used by code
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/0ab90d39e3ca786c9f0b2fb44c2fd29880336cd2/Formula/gcc.rb
+EOF
+pause
+
 ### Install 3 party for CARTA
 echo "step4: Install Qt for CARTA if you use default homebrew-qt"
 pause
@@ -129,6 +140,7 @@ echo "finish building flex"
 echo "step5: Install some libraries for casa from homebrew"
 pause
 # part1 homebrew part
+cd $cartawork
 sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/installLibsForCASAonMac.sh"
 printDuration
 echo "step5-2: Install some libraries for casa, build from source-libsakura"
@@ -154,6 +166,7 @@ echo "step5-3: Install some libraries for casa, build from source-rpfits"
 pause
 # in casa-code's cmake, its related parameter is -DLIBSAKURA_ROOT_DIR, but not need now since we install into /usr/local
 # part3, Build rpfits-2.24, make sure you are still in `your-carta-work`/CARTAvis-externals/ThirdParty/
+cd $cartawork/CARTAvis-externals/ThirdParty
 curl -O ftp://ftp.atnf.csiro.au/pub/software/rpfits/rpfits-2.24.tar.gz
 tar xvfz rpfits-2.24.tar.gz && mv rpfits rpfits-src
 mkdir -p rpfits/lib

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -17,7 +17,11 @@ date
 SECONDS=0
 
 echo "step1: define your variables first"
-export cartawork=~/src3
+
+if [ -z ${cartawork+x} ]; then
+  export cartawork=~/cartahome
+fi
+
 export QT5PATH=/usr/local/Cellar/qt/5.8.0_2
 export CARTABUILDHOME=$cartawork/CARTAvis/build
 export qtwebkit=qtwebkit-tp5-qt58-darwin-x64
@@ -42,7 +46,7 @@ printDuration
 
 read -p "Press [Enter] key to start backup..."
 
-if [ -f /Users/grimmer/src3/CARTAvis-externals/ThirdParty/macports/bin/flex ]; then
+if [ -f $cartawork/CARTAvis-externals/ThirdParty/macports/bin/flex ]; then
   echo "Macports-flex exist, so ignore macports part"
 else
   echo "Macports-flex exist, so start to install macports and its flex, bison"

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -252,3 +252,6 @@ curl -O https://raw.githubusercontent.com/CARTAvis/deploytask/Qt5.8.0/final_mac_
 chmod 755 final_mac_packaging_steps.sh
 ./final_mac_packaging_steps.sh
 EOF
+
+echo "step11: reset folder permission to normal owner, not root"
+chown -R $SUDO_USER:staff $cartawork

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -138,9 +138,9 @@ pause
 # part1 homebrew part
 sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/installLibsForCASAonMac.sh"
 printDuration
-echo "step5-2: Install some libraries for casa, build from source"
-pause
 
+echo "step5-2: Install some libraries for casa, build from source-libsakura"
+pause
 # part2
 cd $cartawork/CARTAvis-externals/ThirdParty
 ## build libsakura-4.0.2065.
@@ -157,6 +157,8 @@ make
 make apidoc
 sudo make install #/usr/local
 cd ../../
+echo "step5-3: Install some libraries for casa, build from source-rpfits"
+pause
 # in casa-code's cmake, its related parameter is -DLIBSAKURA_ROOT_DIR, but not need now since we install into /usr/local
 # part3, Build rpfits-2.24, make sure you are still in `your-carta-work`/CARTAvis-externals/ThirdParty/
 wget ftp://ftp.atnf.csiro.au/pub/software/rpfits/rpfits-2.24.tar.gz

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -110,7 +110,6 @@ fi
 ### download CARTA soure code
 echo "step3: download CARTA soure code"
 pause
-
 su $SUDO_USER <<EOF
 cd $cartawork
 git clone https://github.com/CARTAvis/carta.git CARTAvis
@@ -123,15 +122,35 @@ printDuration
 ### Install 3 party for CARTA
 echo "step4: Install Qt for CARTA"
 pause
-
 sudo su $SUDO_USER -c "brew install qt@5.7"
 printDuration
-
 echo "step4-2: Install Third party for CARTA"
 pause
 cd $cartawork
 ## if use sudo ./xx.sh will let it can not inherit QT5PATH
 ./CARTAvis/carta/scripts/install3party.sh
+###
+printDuration
+###
+echo "step4-3: Install flex and bison for CARTA"
+su $SUDO_USER <<EOF
+brew install bison
+cd $cartawork/CARTAvis-externals/ThirdParty
+curl -O -L https://github.com/westes/flex/archive/flex-2.5.37.tar.gz 
+tar zxvf flex-2.5.37.tar.gz
+mv flex-flex-2.5.37 flex-2.5.37
+cd flex-2.5.37
+brew install autoconf
+brew install automake 
+brew install gettext
+export PATH=/usr/local/opt/gettext/bin:$PATH
+export PATH=/usr/local/opt/texinfo/bin:$PATH
+brew cask install basictex
+export PATH="$PATH:/Library/TeX/texbin"
+./autogen.sh
+./configure --disable-dependency-tracking  --prefix=`pwd`/../flex
+make install 
+EOF
 ###
 printDuration
 
@@ -141,7 +160,6 @@ pause
 # part1 homebrew part
 sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/installLibsForCASAonMac.sh"
 printDuration
-
 echo "step5-2: Install some libraries for casa, build from source-libsakura"
 pause
 # part2
@@ -160,6 +178,7 @@ make
 make apidoc
 sudo make install #/usr/local
 cd ../../
+printDuration
 echo "step5-3: Install some libraries for casa, build from source-rpfits"
 pause
 # in casa-code's cmake, its related parameter is -DLIBSAKURA_ROOT_DIR, but not need now since we install into /usr/local
@@ -182,7 +201,6 @@ printDuration
 ### build casa
 echo "step6: Build casa"
 pause
-
 cd $cartawork
 sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/buildcasa.sh"
 ###

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -116,6 +116,8 @@ su $SUDO_USER <<EOF
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/49887a8f215bd8b365c28c6ae5ea62bb1350c893/Formula/bison.rb
 brew install autoconf
 brew install automake
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/056def4318cd874871b266c9f1df88e450411966/Formula/texinfo.rb
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/512e7f6e9673a6f359c4c36d908126cb9c284f9f/Formula/help2man.rb
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/d407fb8563f480391d918e1f1160cb7e244a1a12/Formula/gettext.rb
 brew cask install basictex
 EOF
@@ -127,7 +129,8 @@ tar zxvf flex-2.5.37.tar.gz
 mv flex-flex-2.5.37 flex-2.5.37
 cd flex-2.5.37
 export PATH=/usr/local/opt/gettext/bin:$PATH
-export PATH=/usr/local/opt/texinfo/bin:$PATH
+export PATH=/usr/local/opt/texinfo/bin:$PATH 
+export PATH=/usr/local/Cellar/help2man/1.47.4/bin:$PATH
 export PATH="$PATH:/Library/TeX/texbin"
 ./autogen.sh
 ./configure --disable-dependency-tracking  --prefix=`pwd`/../flex

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -131,28 +131,32 @@ cd $cartawork
 ./CARTAvis/carta/scripts/install3party.sh
 ###
 printDuration
-###
-echo "step4-3: Install flex and bison for CARTA"
+##
+
+echo "step4-3: Use homebrew to Install some libs needed by flex and bison for CARTA"
 su $SUDO_USER <<EOF
 brew install bison
-cd $cartawork/CARTAvis-externals/ThirdParty
-curl -O -L https://github.com/westes/flex/archive/flex-2.5.37.tar.gz 
-tar zxvf flex-2.5.37.tar.gz
-mv flex-flex-2.5.37 flex-2.5.37
-cd flex-2.5.37
 brew install autoconf
 brew install automake 
 brew install gettext
+brew cask install basictex
+EOF
+printDuration
+echo "step4-3: build flex"
+cd $cartawork/CARTAvis-externals/ThirdParty
+curl -O -L https://github.com/westes/flex/archive/flex-2.5.37.tar.gz
+tar zxvf flex-2.5.37.tar.gz
+mv flex-flex-2.5.37 flex-2.5.37
+cd flex-2.5.37
 export PATH=/usr/local/opt/gettext/bin:$PATH
 export PATH=/usr/local/opt/texinfo/bin:$PATH
-brew cask install basictex
 export PATH="$PATH:/Library/TeX/texbin"
 ./autogen.sh
 ./configure --disable-dependency-tracking  --prefix=`pwd`/../flex
 make install 
-EOF
 ###
 printDuration
+echo "finish building flex"
 
 ### Install the libraries for casa
 echo "step5: Install some libraries for casa from homebrew"

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -5,6 +5,10 @@ function printDuration(){
   echo "$(($duration / 60)) minutes and $(($duration % 60)) seconds elapsed."
 }
 
+function pause(){
+  read -p "Press [Enter] key to continue"
+}
+
 
 ### TODO
 ## 1. use the following two to improve sudo part
@@ -51,10 +55,10 @@ printDuration
 if [ -f $cartawork/CARTAvis-externals/ThirdParty/macports/bin/flex ]; then
   echo "Macports-flex exist, so ignore macports part"
 else
-  echo "Macports-flex exist, so start to install macports and its flex, bison"
+  echo "Macports-flex does not exist, so start to install macports and its flex, bison"
 
   echo "step2-2: prerequisite: install macports"
-  read -p "Press [Enter] key to start backup..."
+  pause
 
   # 3. install macports
   macporthome=$cartawork/CARTAvis-externals/ThirdParty/macports
@@ -72,7 +76,7 @@ else
   printDuration
 
   echo "step2-3: install flex from macports"
-  read -p "Press [Enter] key to start backup..."
+  pause
 
   # these can be installed by ordinary Macports, too.
   sudo $macporthome/bin/port -N install flex  # 2.5.37, long time to install,
@@ -82,7 +86,7 @@ else
   printDuration
 
   echo "step2-4: install bison from macports"
-  read -p "Press [Enter] key to start backup..."
+  pause
 
   sudo $macporthome/bin/port -N install bison # 3.0.4
   ###
@@ -92,7 +96,7 @@ fi
 
 ### download CARTA soure code
 echo "step3: download CARTA soure code"
-read -p "Press [Enter] key to start backup..."
+pause
 
 su $SUDO_USER <<EOF
 mkdir -p $cartawork
@@ -107,12 +111,12 @@ printDuration
 
 ### Install 3 party for CARTA
 echo "step4: Install Qt for CARTA"
-read -p "Press [Enter] key to start backup..."
+pause
 
 sudo su $SUDO_USER -c "brew install qt"
 printDuration
 echo "step4-2: Install Third party for CARTA"
-read -p "Press [Enter] key to start backup..."
+pause
 
 cd $cartawork
 sudo ./CARTAvis/carta/scripts/install3party.sh
@@ -121,13 +125,13 @@ printDuration
 
 ### Install the libraries for casa
 echo "step5: Install some libraries for casa from homebrew"
-read -p "Press [Enter] key to start backup..."
+pause
 
 # part1 homebrew part
 sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/installLibsForCASAonMac.sh"
 printDuration
 echo "step5-2: Install some libraries for casa, build from source"
-read -p "Press [Enter] key to start backup..."
+pause
 
 # part2
 cd $cartawork/CARTAvis-externals/ThirdParty
@@ -164,7 +168,7 @@ printDuration
 
 ### build casa
 echo "step6: Build casa"
-read -p "Press [Enter] key to start backup..."
+pause
 
 cd $cartawork
 sudo su $SUDO_USER -c "./CARTAvis/carta/scripts/buildcasa.sh"
@@ -173,7 +177,7 @@ printDuration
 
 ### setup QtWebkit
 echo "step7: setup QtWebkit"
-read -p "Press [Enter] key to start backup..."
+pause
 
 su $SUDO_USER <<EOF
 cd $cartawork/CARTAvis-externals/ThirdParty
@@ -203,7 +207,7 @@ printDuration
 ### build UI of CARTA
 su $SUDO_USER <<EOF
 echo "step8: Build UI of CARTA"
-read -p "Press [Enter] key to start backup..."
+pause
 cd $cartawork/CARTAvis/carta/html5/common/skel
 ./generate.py
 ###
@@ -211,7 +215,7 @@ printDuration
 
 ### build CARTA
 echo "step9: Build CARTA"
-read -p "Press [Enter] key to start backup..."
+pause
 export PATH=$QT5PATH/bin:$PATH
 mkdir -p $CARTABUILDHOME
 cd $CARTABUILDHOME
@@ -225,7 +229,7 @@ date
 
 ### packagize CARTA
 echo "step10: packagize CARTA"
-read -p "Press [Enter] key to start backup..."
+pause
 curl -O https://raw.githubusercontent.com/CARTAvis/deploytask/Qt5.8.0/final_mac_packaging_steps.sh
 chmod 755 final_mac_packaging_steps.sh
 ./final_mac_packaging_steps.sh

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -28,6 +28,9 @@ export qtwebkit=qtwebkit-tp5-qt58-darwin-x64
 branch=upgradeToNewNamespace #optional
 ##
 
+echo "step1-2: create ThirdParty folder"
+sudo su $SUDO_USER -c "mkdir -p $cartawork/CARTAvis-externals/ThirdParty"
+
 # su $SUDO_USER <<EOF
 # /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 # brew install wget
@@ -44,7 +47,6 @@ sudo -u $SUDO_USER ruby \
 sudo su $SUDO_USER -c "brew install wget"
 printDuration
 
-read -p "Press [Enter] key to start backup..."
 
 if [ -f $cartawork/CARTAvis-externals/ThirdParty/macports/bin/flex ]; then
   echo "Macports-flex exist, so ignore macports part"
@@ -52,9 +54,11 @@ else
   echo "Macports-flex exist, so start to install macports and its flex, bison"
 
   echo "step2-2: prerequisite: install macports"
+  read -p "Press [Enter] key to start backup..."
+
   # 3. install macports
   macporthome=$cartawork/CARTAvis-externals/ThirdParty/macports
-  mkdir -p $cartawork/CARTAvis-externals/ThirdParty
+  # mkdir -p $cartawork/CARTAvis-externals/ThirdParty
   cd $cartawork/CARTAvis-externals/ThirdParty
   curl -o MacPorts-2.4.1.tar.gz https://distfiles.macports.org/MacPorts/MacPorts-2.4.1.tar.gz
   tar zxf MacPorts-2.4.1.tar.gz

--- a/carta/scripts/ci_mac.sh
+++ b/carta/scripts/ci_mac.sh
@@ -7,7 +7,7 @@ function printDuration(){
 
 function pause(){
   afplay /System/Library/Sounds/Funk.aiff
-  read -p "Press [Enter] key to continue"
+  # read -p "Press [Enter] key to continue"
 }
 
 
@@ -62,7 +62,7 @@ echo "step2: prerequisite: install homebrew"
 sudo -u $SUDO_USER ruby \
   -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" \
   </dev/null
-sudo su $SUDO_USER -c "brew install wget"
+# sudo su $SUDO_USER -c "brew install wget"
 printDuration
 
 
@@ -81,7 +81,8 @@ printDuration
 ### Install 3 party for CARTA
 echo "step4: Install Qt for CARTA"
 pause
-sudo su $SUDO_USER -c "brew install qt@5.7"
+sudo su $SUDO_USER -c "brew tap CARTAvis/tap"
+sudo su $SUDO_USER -c "brew install CARTAvis/tap/qt@5.7"
 printDuration
 echo "step4-2: Install Third party for CARTA"
 pause
@@ -94,10 +95,10 @@ printDuration
 
 echo "step4-3: Use homebrew to Install some libs needed by flex and bison for CARTA"
 su $SUDO_USER <<EOF
-brew install bison
-brew install autoconf
-brew install automake 
-brew install gettext
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/49887a8f215bd8b365c28c6ae5ea62bb1350c893/Formula/bison.rb
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/091e0bebb25d235b9efeeebf184a819ed7ade8a7/Formula/autoconf.rb
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/c679306cc10018711fc3f16d46b3392909601e9b/Formula/automake.rb
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/d407fb8563f480391d918e1f1160cb7e244a1a12/Formula/gettext.rb
 brew cask install basictex
 EOF
 printDuration
@@ -112,7 +113,7 @@ export PATH=/usr/local/opt/texinfo/bin:$PATH
 export PATH="$PATH:/Library/TeX/texbin"
 ./autogen.sh
 ./configure --disable-dependency-tracking  --prefix=`pwd`/../flex
-make install 
+make install
 ###
 printDuration
 echo "finish building flex"
@@ -129,7 +130,7 @@ pause
 cd $cartawork/CARTAvis-externals/ThirdParty
 ## build libsakura-4.0.2065.
 git clone https://github.com/grimmer0125/libsakura
-wget -O gtest-1.7.0.zip https://github.com/google/googletest/archive/release-1.7.0.zip
+curl -o gtest-1.7.0.zip -L https://github.com/google/googletest/archive/release-1.7.0.zip
 unzip gtest-1.7.0.zip -d libsakura
 cd libsakura
 ln -s googletest-release-1.7.0 gtest
@@ -146,7 +147,7 @@ echo "step5-3: Install some libraries for casa, build from source-rpfits"
 pause
 # in casa-code's cmake, its related parameter is -DLIBSAKURA_ROOT_DIR, but not need now since we install into /usr/local
 # part3, Build rpfits-2.24, make sure you are still in `your-carta-work`/CARTAvis-externals/ThirdParty/
-wget ftp://ftp.atnf.csiro.au/pub/software/rpfits/rpfits-2.24.tar.gz
+curl -O ftp://ftp.atnf.csiro.au/pub/software/rpfits/rpfits-2.24.tar.gz
 tar xvfz rpfits-2.24.tar.gz && mv rpfits rpfits-src
 mkdir -p rpfits/lib
 mkdir -p rpfits/include
@@ -174,7 +175,7 @@ echo "step7: setup QtWebkit"
 pause
 su $SUDO_USER <<EOF
 cd $cartawork/CARTAvis-externals/ThirdParty
-wget https://github.com/annulen/webkit/releases/download/qtwebkit-tp4/qtwebkit-tp4-qt57-darwin.tar.xz
+curl -O -L https://github.com/annulen/webkit/releases/download/qtwebkit-tp4/qtwebkit-tp4-qt57-darwin.tar.xz
 tar -xvzf $qtwebkit.tar.xz
 # export QT5PATH=/usr/local/Cellar/qt/5.8.0_2
 # /Users/grimmer/Qt/5.7/clang_64

--- a/carta/scripts/install3party.sh
+++ b/carta/scripts/install3party.sh
@@ -103,30 +103,30 @@ else
 fi
 
 cd $cartawork/CARTAvis-externals/ThirdParty
-curl -O -L http://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2
-tar xvfj qwt-6.1.2.tar.bz2 && mv qwt-6.1.2 qwt-6.1.2-src
-cd qwt-6.1.2-src # can use qwt 6.1.3 Pavol uses
+curl -O -L http://downloads.sourceforge.net/project/qwt/qwt/6.1.3/qwt-6.1.3.tar.bz2
+tar xvfj qwt-6.1.3.tar.bz2 && mv qwt-6.1.3 qwt-6.1.3-src
+cd qwt-6.1.3-src # can use qwt 6.1.3 Pavol uses
 if [ "$(uname)" == "Darwin" ]; then
-  perl -i -pe 's/.*/ QWT_INSTALL_PREFIX    = $ENV{cartawork}\/CARTAvis-externals\/ThirdParty\/qwt-6.1.2\/ / if $.==22' qwtconfig.pri
+  perl -i -pe 's/.*/ QWT_INSTALL_PREFIX    = $ENV{cartawork}\/CARTAvis-externals\/ThirdParty\/qwt-6.1.3\/ / if $.==22' qwtconfig.pri
 else
 	# for unix part, not work on Mac
-	sed -i "22,22c QWT_INSTALL_PREFIX    = $cartawork/CARTAvis-externals/ThirdParty/qwt-6.1.2" qwtconfig.pri
+	sed -i "22,22c QWT_INSTALL_PREFIX    = $cartawork/CARTAvis-externals/ThirdParty/qwt-6.1.3" qwtconfig.pri
 fi
 qmake qwt.pro
 make && make install
 cd ..
-ln -s qwt-6.1.2 qwt
+ln -s qwt-6.1.3 qwt
 if [ "$(uname)" == "Darwin" ]; then
 	cd qwt
 	# sometimes Versions/6 or Versions/1, have not investigated why
-	ln -s ../qwt-6.1.2/lib/qwt.framework/Versions/Current/Headers include
+	ln -s ../qwt-6.1.3/lib/qwt.framework/Versions/Current/Headers include
 	cd ..
 fi
 
 echo "install qooxdoo"
 cd $cartawork/CARTAvis-externals/ThirdParty
 ## Install qooxdoo for CARTA
-curl -o qooxdoo-3.5-sdk.zip -L http://downloads.sourceforge.net/project/qooxdoo/qooxdoo-current/3.5/qooxdoo-3.5-sdk.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fqooxdoo%2Ffiles%2Fqooxdoo-current%2F3.5%2F&ts=1479095500&use_mirror=excellmedia
+curl -o qooxdoo-3.5-sdk.zip -L https://github.com/qooxdoo/qooxdoo/releases/download/release_3_5_1/qooxdoo-3.5.1-sdk.zip
 unzip qooxdoo-3.5-sdk.zip
 
 ## rapidjson

--- a/carta/scripts/install3party.sh
+++ b/carta/scripts/install3party.sh
@@ -126,8 +126,8 @@ fi
 echo "install qooxdoo"
 cd $cartawork/CARTAvis-externals/ThirdParty
 ## Install qooxdoo for CARTA
-curl -o qooxdoo-3.5-sdk.zip -L http://downloads.sourceforge.net/project/qooxdoo/qooxdoo-current/3.5/qooxdoo-3.5-sdk.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fqooxdoo%2Ffiles%2Fqooxdoo-current%2F3.5%2F&ts=1479095500&use_mirror=excellmedia
-unzip qooxdoo-3.5-sdk.zip
+curl -o qooxdoo-3.5.1-sdk.zip -L https://github.com/qooxdoo/qooxdoo/releases/download/release_3_5_1/qooxdoo-3.5.1-sdk.zip
+unzip qooxdoo-3.5.1-sdk.zip
 
 ## rapidjson
 echo "build rapidjson"
@@ -161,9 +161,9 @@ cd ..
 echo "build ast"
 cd $cartawork/CARTAvis-externals/ThirdParty
 ## ast: carta only, static linking with CARTA
-curl -O -L http://www.starlink.ac.uk/download/ast/ast-8.0.2.tar.gz
-tar xvfz ast-8.0.2.tar.gz && mv ast-8.0.2 ast-8.0.2-src
-cd ast-8.0.2-src
+curl -O -L http://www.starlink.ac.uk/download/ast/ast-8.4.0.tar.gz
+tar xvfz ast-8.4.0.tar.gz && mv ast-8.4.0 ast-8.4.0-src
+cd ast-8.4.0-src
 ./configure --prefix=`pwd`/../ast/
 make && make install
 cd ..

--- a/carta/scripts/install3party.sh
+++ b/carta/scripts/install3party.sh
@@ -103,23 +103,23 @@ else
 fi
 
 cd $cartawork/CARTAvis-externals/ThirdParty
-curl -O -L http://downloads.sourceforge.net/project/qwt/qwt/6.1.3/qwt-6.1.3.tar.bz2
-tar xvfj qwt-6.1.3.tar.bz2 && mv qwt-6.1.3 qwt-6.1.3-src
-cd qwt-6.1.3-src # can use qwt 6.1.3 Pavol uses
+curl -O -L http://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2
+tar xvfj qwt-6.1.2.tar.bz2 && mv qwt-6.1.2 qwt-6.1.2-src
+cd qwt-6.1.2-src # can use qwt 6.1.2 Pavol uses
 if [ "$(uname)" == "Darwin" ]; then
-  perl -i -pe 's/.*/ QWT_INSTALL_PREFIX    = $ENV{cartawork}\/CARTAvis-externals\/ThirdParty\/qwt-6.1.3\/ / if $.==22' qwtconfig.pri
+  perl -i -pe 's/.*/ QWT_INSTALL_PREFIX    = $ENV{cartawork}\/CARTAvis-externals\/ThirdParty\/qwt-6.1.2\/ / if $.==22' qwtconfig.pri
 else
 	# for unix part, not work on Mac
-	sed -i "22,22c QWT_INSTALL_PREFIX    = $cartawork/CARTAvis-externals/ThirdParty/qwt-6.1.3" qwtconfig.pri
+	sed -i "22,22c QWT_INSTALL_PREFIX    = $cartawork/CARTAvis-externals/ThirdParty/qwt-6.1.2" qwtconfig.pri
 fi
 qmake qwt.pro
 make && make install
 cd ..
-ln -s qwt-6.1.3 qwt
+ln -s qwt-6.1.2 qwt
 if [ "$(uname)" == "Darwin" ]; then
 	cd qwt
 	# sometimes Versions/6 or Versions/1, have not investigated why
-	ln -s ../qwt-6.1.3/lib/qwt.framework/Versions/Current/Headers include
+	ln -s ../qwt-6.1.2/lib/qwt.framework/Versions/Current/Headers include
 	cd ..
 fi
 

--- a/carta/scripts/install3party.sh
+++ b/carta/scripts/install3party.sh
@@ -126,7 +126,7 @@ fi
 echo "install qooxdoo"
 cd $cartawork/CARTAvis-externals/ThirdParty
 ## Install qooxdoo for CARTA
-curl -o qooxdoo-3.5-sdk.zip -L https://github.com/qooxdoo/qooxdoo/releases/download/release_3_5_1/qooxdoo-3.5.1-sdk.zip
+curl -o qooxdoo-3.5-sdk.zip -L http://downloads.sourceforge.net/project/qooxdoo/qooxdoo-current/3.5/qooxdoo-3.5-sdk.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fqooxdoo%2Ffiles%2Fqooxdoo-current%2F3.5%2F&ts=1479095500&use_mirror=excellmedia
 unzip qooxdoo-3.5-sdk.zip
 
 ## rapidjson

--- a/carta/scripts/install3party.sh
+++ b/carta/scripts/install3party.sh
@@ -84,7 +84,6 @@ fi
 
 #####
 mkdir -p $cartawork/CARTAvis-externals/ThirdParty
-cd $cartawork/CARTAvis-externals/ThirdParty
 
 ## for building qwt by qt5.3 for carta
 if [ -z ${QT5PATH+x} ]; then
@@ -103,6 +102,7 @@ else
 	# export PATH=$QT5PATH/gcc_64/bin:$PATH # Qt official installer case
 fi
 
+cd $cartawork/CARTAvis-externals/ThirdParty
 curl -O -L http://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2
 tar xvfj qwt-6.1.2.tar.bz2 && mv qwt-6.1.2 qwt-6.1.2-src
 cd qwt-6.1.2-src # can use qwt 6.1.3 Pavol uses
@@ -123,11 +123,15 @@ if [ "$(uname)" == "Darwin" ]; then
 	cd ..
 fi
 
+echo "install qooxdoo"
+cd $cartawork/CARTAvis-externals/ThirdParty
 ## Install qooxdoo for CARTA
 curl -o qooxdoo-3.5-sdk.zip -L http://downloads.sourceforge.net/project/qooxdoo/qooxdoo-current/3.5/qooxdoo-3.5-sdk.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fqooxdoo%2Ffiles%2Fqooxdoo-current%2F3.5%2F&ts=1479095500&use_mirror=excellmedia
 unzip qooxdoo-3.5-sdk.zip
 
 ## rapidjson
+echo "build rapidjson"
+cd $cartawork/CARTAvis-externals/ThirdParty
 curl -O -L https://github.com/miloyip/rapidjson/archive/v1.0.2.tar.gz
 mv v1.0.2.tar.gz rapidjson_v1.0.2.tar.gz
 tar xvfz rapidjson_v1.0.2.tar.gz
@@ -135,6 +139,8 @@ ln -s rapidjson-1.0.2 rapidjson
 
 ## to get the same version with casa, so cfitsio, wcslib are built for carta, casa
 ## wcslib-5.15
+echo "build wcslib"
+cd $cartawork/CARTAvis-externals/ThirdParty
 curl -O -L ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-5.15.tar.bz2
 tar xvfj wcslib-5.15.tar.bz2 && mv wcslib-5.15 wcslib-5.15-src
 cd wcslib-5.15-src
@@ -143,6 +149,8 @@ make && make install
 cd ..
 
 ## cfitsio3390
+echo "build cfitsio"
+cd $cartawork/CARTAvis-externals/ThirdParty
 curl -O -L http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3390.tar.gz
 tar xvfz cfitsio3390.tar.gz && mv cfitsio cfitsio-src
 cd cfitsio-src
@@ -150,6 +158,8 @@ cd cfitsio-src
 make && make install
 cd ..
 
+echo "build ast"
+cd $cartawork/CARTAvis-externals/ThirdParty
 ## ast: carta only, static linking with CARTA
 curl -O -L http://www.starlink.ac.uk/download/ast/ast-8.0.2.tar.gz
 tar xvfz ast-8.0.2.tar.gz && mv ast-8.0.2 ast-8.0.2-src
@@ -159,6 +169,8 @@ make && make install
 cd ..
 
 ## gsl
+echo "build gsl"
+cd $cartawork/CARTAvis-externals/ThirdParty
 # yum:1.15. so carta keeps building it from source code.
 # casa's cmake needs yum version to pass the check but it will use /usr/local in high priority when building
 curl -O -L http://ftp.gnu.org/gnu/gsl/gsl-2.1.tar.gz
@@ -167,4 +179,5 @@ cd gsl-2.1-src
 ./configure
 make
 sudo make install
-cd ..
+#cd ..
+cd $cartawork/CARTAvis-externals/ThirdParty

--- a/carta/scripts/install3party.sh
+++ b/carta/scripts/install3party.sh
@@ -124,7 +124,7 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 ## Install qooxdoo for CARTA
-wget 'http://downloads.sourceforge.net/project/qooxdoo/qooxdoo-current/3.5/qooxdoo-3.5-sdk.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fqooxdoo%2Ffiles%2Fqooxdoo-current%2F3.5%2F&ts=1479095500&use_mirror=excellmedia' -O qooxdoo-3.5-sdk.zip
+curl -o qooxdoo-3.5-sdk.zip -L http://downloads.sourceforge.net/project/qooxdoo/qooxdoo-current/3.5/qooxdoo-3.5-sdk.zip?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fqooxdoo%2Ffiles%2Fqooxdoo-current%2F3.5%2F&ts=1479095500&use_mirror=excellmedia
 unzip qooxdoo-3.5-sdk.zip
 
 ## rapidjson
@@ -135,7 +135,7 @@ ln -s rapidjson-1.0.2 rapidjson
 
 ## to get the same version with casa, so cfitsio, wcslib are built for carta, casa
 ## wcslib-5.15
-wget ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-5.15.tar.bz2
+curl -O -L ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-5.15.tar.bz2
 tar xvfj wcslib-5.15.tar.bz2 && mv wcslib-5.15 wcslib-5.15-src
 cd wcslib-5.15-src
 ./configure --prefix=`pwd`/../wcslib/  ##--without-pgplot, pgplot is needed by casa
@@ -151,7 +151,7 @@ make && make install
 cd ..
 
 ## ast: carta only, static linking with CARTA
-wget http://www.starlink.ac.uk/download/ast/ast-8.0.2.tar.gz
+curl -O -L http://www.starlink.ac.uk/download/ast/ast-8.0.2.tar.gz
 tar xvfz ast-8.0.2.tar.gz && mv ast-8.0.2 ast-8.0.2-src
 cd ast-8.0.2-src
 ./configure --prefix=`pwd`/../ast/

--- a/carta/scripts/install3party.sh
+++ b/carta/scripts/install3party.sh
@@ -1,22 +1,11 @@
 #!/bin/bash
 
-## working folder, $CARTAWORKHOME
-export CARTAWORKHOME=`pwd`
+## working folder, $cartawork
 
-##################################
-# Install some required packages
-##################################
-
-## Requirement of carta:
-## g++ >= 4.8.1
-## cfitsio >= 3360
-## wcslib >= 4.23
-## gsl >= 2.1
-## ast >= 8.0.2
-
-#####
-# How to solve portable issues for dynamic libs, e.g. move carta binary or even packaing? Use rpath??
-####
+if [ -z ${cartawork+x} ]; then
+	export cartawork=`pwd`
+else
+fi
 
 isCentOS=true
 if grep -q CentOS /etc/os-release; then
@@ -33,28 +22,14 @@ if [ "$(uname)" == "Darwin" ]; then
 elif [ "$isCentOS" = true ] ; then
 	##### CentOS 7
 
-	## these (wcslib, cfitsio) are required by Carta (but also duplicate install from source),
-	## also are required by casa-submodules (at least casacore)
-	## Todo [Giveup] !!: carta switchs to use yum version which are 3370, 5.15.
-	## carta uses ThirdParty to look for cfitsio, wcslio,
-	## so to use yum version, switch to /usr/lib, /usr/include etc? <-on Linux, default search path
 	sudo yum -y install epel-release ## which has cfitsio, leveldb, old wcslib
-	## to get the same version, so that cfitsio, wcslib are built for carta, casa
 
-	## move to buildcasa
+	## Default wcslib on CentOS 7 is 4.x. But it seems toe become 5.x, after using casa.repo.
+	## wcslib.x86_64 5.15-2.el7.1 @casa
 	# sudo yum -y install wcslib wcslib-devel
-
 	# sudo yum -y install cfitsio cfitsio-devel
 	# -> change to all use build from code, since yum/apt/mac ports have different version
 
-	## Default wcslib on CentOS 7 is 4.x. But it seems that, after using casa.repo.
-	## wcslib.x86_64 5.15-2.el7.1 @casa
-
-	## required by carta, casa-submodue:code
-	# yum:1.15. so carta keeps building it from source code.
-	# Todo [Done]: fix header/lib/dynamic path in Qt, on Mac, CentOS, for Carta.
-	# carta uses /usr/local to look for gsl.
-	# Maybe just build from source and install there, let carta and casa use
 	# sudo yum -y install gsl gsl-devel -> move to buildcasa.sh
 
 	## these are required by carta, also are required by casa-submodules
@@ -64,15 +39,12 @@ elif [ "$isCentOS" = true ] ; then
 	sudo yum -y install Cython
 	sudo yum install python-matplotlib
 
-	## carta only:
-	## ast (static linking)
-
 	## sqlite
 	sudo yum -y install sqlite-devel
 
 	## leveldb
 	# leveldb needs epel-release, so install it first
-	# (nrao-carta does not mention but nrao-casa mention)
+	# (nrao-carta page does not mention but nrao-casa page mention)
 	# second way: curl -O -L  https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 	# mv RPM-GPG-KEY-EPEL-7  /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
 	sudo yum -y install leveldb leveldb-devel
@@ -81,6 +53,14 @@ elif [ "$isCentOS" = true ] ; then
 	## needed by building gsl and casacore,
 	## but seems already exist or no need ?
 	sudo yum -y install blas blas-devel
+
+	# for building Qt 4.8.5,
+	# On Grimmer's docker -centos 7.3 , only when buidling Carta by Qt-5.3.2, we need gstreamer-devel, gstreamer-plugins-base
+	# But on Chia-Jung Hsu's pc - centos 7.3, building Qt 4.8.5 needs pkgconfig(gstreamer-app-0.10) which install gstreamer-plugins-base-devel ,
+	#    also gstreamer-devel, gstreamer-plugins-base,  gstreamer
+	# Qt's QtWebkit may use gstreamer libs
+	# We do not build Qt 4.8.5 on CentOS anymore, but building CARTA may need this, so move here
+	sudo yum -y install 'pkgconfig(gstreamer-app-0.10)'
 else
 	##### Ubuntu 16.04
 	# sudo apt-get -y install libcfitsio3-dev
@@ -98,13 +78,14 @@ else
 
 	## needed for compiling qwt
 	apt-get install mesa-common-dev libgl1-mesa-dev libglu1-mesa-dev
+
+	## needed for building CARTA
+	sudo apt-get -y install libgstreamer0.10-dev gstreamer0.10-plugins-base
 fi
 
-
 #####
-
-mkdir -p $CARTAWORKHOME/CARTAvis-externals/ThirdParty
-cd $CARTAWORKHOME/CARTAvis-externals/ThirdParty
+mkdir -p $cartawork/CARTAvis-externals/ThirdParty
+cd $cartawork/CARTAvis-externals/ThirdParty
 
 ## for building qwt by qt5.3 for carta
 if [ -z ${QT5PATH+x} ]; then
@@ -118,17 +99,19 @@ if [ -z ${QT5PATH+x} ]; then
 	export PATH=$QT5PATH:$PATH
 else
 	echo "QT5PATH is already set to '$QT5PATH'";
-	export PATH=$QT5PATH:$PATH
+	export PATH=$QT5PATH/bin:$PATH # Homebrew case
+	export PATH=$QT5PATH/clang_64/bin:$PATH # Qt official installer case
+	export PATH=$QT5PATH/gcc_64/bin:$PATH # Qt official installer case
 fi
 
 curl -O -L http://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2
 tar xvfj qwt-6.1.2.tar.bz2 && mv qwt-6.1.2 qwt-6.1.2-src
 cd qwt-6.1.2-src # can use qwt 6.1.3 Pavol uses
 if [ "$(uname)" == "Darwin" ]; then
-  perl -i -pe 's/.*/ QWT_INSTALL_PREFIX    = $ENV{CARTAWORKHOME}\/CARTAvis-externals\/ThirdParty\/qwt-6.1.2\/ / if $.==22' qwtconfig.pri
+  perl -i -pe 's/.*/ QWT_INSTALL_PREFIX    = $ENV{cartawork}\/CARTAvis-externals\/ThirdParty\/qwt-6.1.2\/ / if $.==22' qwtconfig.pri
 else
 	# for unix part, not work on Mac
-	sed -i "22,22c QWT_INSTALL_PREFIX    = $CARTAWORKHOME/CARTAvis-externals/ThirdParty/qwt-6.1.2" qwtconfig.pri
+	sed -i "22,22c QWT_INSTALL_PREFIX    = $cartawork/CARTAvis-externals/ThirdParty/qwt-6.1.2" qwtconfig.pri
 fi
 qmake qwt.pro
 make && make install
@@ -146,15 +129,16 @@ unzip qooxdoo-3.5-sdk.zip
 
 ## rapidjson
 curl -O -L https://github.com/miloyip/rapidjson/archive/v1.0.2.tar.gz
-tar xvfz v1.0.2.tar.gz
-ln -s rapidjson-1.0.2 rapidjson # can become mv
+mv v1.0.2.tar.gz rapidjson_v1.0.2.tar.gz
+tar xvfz rapidjson_v1.0.2.tar.gz
+ln -s rapidjson-1.0.2 rapidjson
 
+## to get the same version with casa, so cfitsio, wcslib are built for carta, casa
 ## wcslib-5.15
 wget ftp://ftp.atnf.csiro.au/pub/software/wcslib/wcslib-5.15.tar.bz2
 tar xvfj wcslib-5.15.tar.bz2 && mv wcslib-5.15 wcslib-5.15-src
 cd wcslib-5.15-src
-# ./configure --prefix=${THIRDPARTY_PATH}/wcslib/ --without-pgplot <-pgplot ?? <-add back later
-./configure --prefix=`pwd`/../wcslib/  ##--without-pgplot which is needed by casa
+./configure --prefix=`pwd`/../wcslib/  ##--without-pgplot, pgplot is needed by casa
 make && make install
 cd ..
 
@@ -166,7 +150,7 @@ cd cfitsio-src
 make && make install
 cd ..
 
-## ast
+## ast: carta only, static linking with CARTA
 wget http://www.starlink.ac.uk/download/ast/ast-8.0.2.tar.gz
 tar xvfz ast-8.0.2.tar.gz && mv ast-8.0.2 ast-8.0.2-src
 cd ast-8.0.2-src
@@ -175,9 +159,12 @@ make && make install
 cd ..
 
 ## gsl
+# yum:1.15. so carta keeps building it from source code.
+# casa's cmake needs yum version to pass the check but it will use /usr/local in high priority when building
 curl -O -L http://ftp.gnu.org/gnu/gsl/gsl-2.1.tar.gz
 tar xvfz gsl-2.1.tar.gz && mv gsl-2.1 gsl-2.1-src
 cd gsl-2.1-src
 ./configure
-make && make install
+make
+sudo make install
 cd ..

--- a/carta/scripts/install3party.sh
+++ b/carta/scripts/install3party.sh
@@ -4,7 +4,6 @@
 
 if [ -z ${cartawork+x} ]; then
 	export cartawork=`pwd`
-else
 fi
 
 isCentOS=true
@@ -92,16 +91,16 @@ if [ -z ${QT5PATH+x} ]; then
 	echo "QT5PATH is unset";
 	QT5PATH=/
 	if [ "$(uname)" == "Darwin" ]; then
-		QT5PATH=$HOME/Qt/5.3/clang_64/bin
+		QT5PATH=$HOME/Qt/5.3/clang_64
 	else
-		QT5PATH=/opt/Qt/5.3/gcc_64/bin
+		QT5PATH=/opt/Qt/5.3/gcc_64
 	fi
-	export PATH=$QT5PATH:$PATH
+	export PATH=$QT5PATH/bin:$PATH
 else
 	echo "QT5PATH is already set to '$QT5PATH'";
 	export PATH=$QT5PATH/bin:$PATH # Homebrew case
-	export PATH=$QT5PATH/clang_64/bin:$PATH # Qt official installer case
-	export PATH=$QT5PATH/gcc_64/bin:$PATH # Qt official installer case
+	# export PATH=$QT5PATH/clang_64/bin:$PATH # Qt official installer case
+	# export PATH=$QT5PATH/gcc_64/bin:$PATH # Qt official installer case
 fi
 
 curl -O -L http://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2

--- a/carta/scripts/install3party.sh
+++ b/carta/scripts/install3party.sh
@@ -118,7 +118,8 @@ cd ..
 ln -s qwt-6.1.2 qwt
 if [ "$(uname)" == "Darwin" ]; then
 	cd qwt
-	ln -s ../qwt-6.1.2/lib/qwt.framework/Versions/6/Headers include
+	# sometimes Versions/6 or Versions/1, have not investigated why
+	ln -s ../qwt-6.1.2/lib/qwt.framework/Versions/Current/Headers include
 	cd ..
 fi
 

--- a/carta/scripts/installLibsForCASAonMac.sh
+++ b/carta/scripts/installLibsForCASAonMac.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-### Basic tools
-brew install cmake
-brew link --overwrite cmake
-
 ### For CASA - submodule - casacore
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/0ab90d39e3ca786c9f0b2fb44c2fd29880336cd2/Formula/gcc.rb ## now it is 7.1 we only use its gfortran which is also used by code
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/cb79fc2ec2c5fcebf35f7bf26bb7459c9f87ae0b/Formula/fftw.rb
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/198f8903db0bb77f1b84e19e020c6f825210433d/Formula/boost-python.rb ## also used by code submodules
 

--- a/carta/scripts/installLibsForCASAonMac.sh
+++ b/carta/scripts/installLibsForCASAonMac.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+### Basic tools
+brew install cmake
+brew link --overwrite cmake
+brew install wget
+
+### For building libsakura
+brew install doxygen
+brew install eigen@3.2 ## eigen is 3.3.3 but its 3.3.3 is not compatible with libsakura 4.0.2065
+brew install log4cxx
+
+### For CASA - submodule - casacore
+brew install gcc ## only use its gfortran
+brew install fftw
+brew install boost-python ## also used by code submodules
+
+### For CASA - submodule - code - imageanalysis, stdcasa, components, the following all are needed by **submodule-code**
+brew install readline
+
+# PGPLOT: 5.2.2_2.
+# We modify code's cmake to build without pgplot but the cmake's check is still there,
+# so keep installing pgplot to pass the check. imageanalysis's testing code needs this (`<casa/System/PGPlotter.h>`)
+# but we remove the testing part of it. casacore's lattices' source codes have "pgplot" insdie but seems not need pgplot when compiling casacore
+#if you already have xquartz installed, it will not install again. this is needed by pgplot
+brew cask install xquartz ## needed root
+brew install pgplot
+
+brew install dbus # To pass cmake's check
+
+brew install libxml2
+brew install xerces-c
+
+## Qt 4.8. Not sure if the target three submodules need Qt but cmake's check will check if Qt exists
+# brew tap cartr/qt4
+# brew tap-pin cartr/qt4
+# brew install qt # /usr/local/Cellar/qt/4.8.7_3
+## brew install cartr/qt4/qwt-qt4, somehow fail, so just build from source code.
+
+###########################

--- a/carta/scripts/installLibsForCASAonMac.sh
+++ b/carta/scripts/installLibsForCASAonMac.sh
@@ -3,33 +3,34 @@
 ### Basic tools
 brew install cmake
 brew link --overwrite cmake
-brew install wget
-
-### For building libsakura
-brew install doxygen
-brew install eigen@3.2 ## eigen is 3.3.3 but its 3.3.3 is not compatible with libsakura 4.0.2065
-brew install log4cxx
 
 ### For CASA - submodule - casacore
-brew install gcc ## only use its gfortran
-brew install fftw
-brew install boost-python ## also used by code submodules
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/0ab90d39e3ca786c9f0b2fb44c2fd29880336cd2/Formula/gcc.rb ## now it is 7.1 we only use its gfortran which is also used by code
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/cb79fc2ec2c5fcebf35f7bf26bb7459c9f87ae0b/Formula/fftw.rb
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/198f8903db0bb77f1b84e19e020c6f825210433d/Formula/boost-python.rb ## also used by code submodules
 
 ### For CASA - submodule - code - imageanalysis, stdcasa, components, the following all are needed by **submodule-code**
-brew install readline
+
+### For building libsakura
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/0ee09d116505e7a5cbc4e2b94335fca82a69e146/Formula/doxygen.rb
+brew install eigen@3.2 ## the latest of eigen is 3.3.3 but its 3.3.3 is not compatible with libsakura 4.0.2065
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/712fb0b23bad079214c28e325cd82548b216dcab/Formula/log4cxx.rb
+###
+
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/012b062a345e68ffbbd68cc8a26944cd3341f071/Formula/readline.rb
 
 # PGPLOT: 5.2.2_2.
 # We modify code's cmake to build without pgplot but the cmake's check is still there,
 # so keep installing pgplot to pass the check. imageanalysis's testing code needs this (`<casa/System/PGPlotter.h>`)
 # but we remove the testing part of it. casacore's lattices' source codes have "pgplot" insdie but seems not need pgplot when compiling casacore
 #if you already have xquartz installed, it will not install again. this is needed by pgplot
-# brew cask install xquartz 
-brew install --ignore-dependencies pgplot
+# brew cask install xquartz
+brew install --ignore-dependencies https://raw.githubusercontent.com/Homebrew/homebrew-core/1fa20e6da369410aa02a7d467ac0d24f36579d13/Formula/pgplot.rb
 
-brew install dbus # To pass cmake's check
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/70cdd3ed9ab1e4b7721f9884d363745e46a68539/Formula/dbus.rb # To pass cmake's check
 
-brew install libxml2
-brew install xerces-c
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/0eb58b8a50600eb3c663a788f6697c1f672433ed/Formula/libxml2.rb
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/8bac3e33d64f57a18b328b8284d37cb40979c481/Formula/xerces-c.rb
 
 ## Qt 4.8. Not sure if the target three submodules need Qt but cmake's check will check if Qt exists
 # brew tap cartr/qt4

--- a/carta/scripts/installLibsForCASAonMac.sh
+++ b/carta/scripts/installLibsForCASAonMac.sh
@@ -17,7 +17,7 @@ brew install eigen@3.2 ## the latest of eigen is 3.3.3 but its 3.3.3 is not comp
 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/712fb0b23bad079214c28e325cd82548b216dcab/Formula/log4cxx.rb
 ###
 
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/012b062a345e68ffbbd68cc8a26944cd3341f071/Formula/readline.rb
+brew install readline
 
 # PGPLOT: 5.2.2_2.
 # We modify code's cmake to build without pgplot but the cmake's check is still there,

--- a/carta/scripts/installLibsForCASAonMac.sh
+++ b/carta/scripts/installLibsForCASAonMac.sh
@@ -23,7 +23,7 @@ brew install readline
 # so keep installing pgplot to pass the check. imageanalysis's testing code needs this (`<casa/System/PGPlotter.h>`)
 # but we remove the testing part of it. casacore's lattices' source codes have "pgplot" insdie but seems not need pgplot when compiling casacore
 #if you already have xquartz installed, it will not install again. this is needed by pgplot
-brew cask install xquartz ## needed root
+brew cask install xquartz 
 brew install pgplot
 
 brew install dbus # To pass cmake's check

--- a/carta/scripts/installLibsForCASAonMac.sh
+++ b/carta/scripts/installLibsForCASAonMac.sh
@@ -23,8 +23,8 @@ brew install readline
 # so keep installing pgplot to pass the check. imageanalysis's testing code needs this (`<casa/System/PGPlotter.h>`)
 # but we remove the testing part of it. casacore's lattices' source codes have "pgplot" insdie but seems not need pgplot when compiling casacore
 #if you already have xquartz installed, it will not install again. this is needed by pgplot
-brew cask install xquartz 
-brew install pgplot
+# brew cask install xquartz 
+brew install --ignore-dependencies pgplot
 
 brew install dbus # To pass cmake's check
 

--- a/carta/scripts/installqt5.3.sh
+++ b/carta/scripts/installqt5.3.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-## create working folder, $CARTAWORKHOME
-# mkdir ~/src
-# cd ~/src
-
-export CARTAWORKHOME=`pwd`
 QTINSTALLER=qt-unified-linux-x64-2.0.5-online.run
 QTURL=http://ftp.jaist.ac.jp/pub/qtproject/archive/online_installers/2.0/$QTINSTALLER
 
@@ -30,15 +25,6 @@ else
     sudo apt-get -y install libgl1-mesa-glx libglib2.0-0
 fi
 
-## Use latest qt online installer to install latest creator + qt 5.3.2 choosed
-# Question: possible to use sudo yum to install qt 5.3.2 ? ref: qt5-qtbase-5.2.0-4.fc20.x86_64?
-
-# mkdir -p ~/download
-# cd ~/download
 wget $QTURL
 chmod 755 $QTINSTALLER
-# http://doc.qt.io/qt-5/linux.html
-# mkdir -p $CARTAWORKHOME/CARTAvis-externals/ThirdParty/Qt ## include qt creaetor
-./$QTINSTALLER ## will prompt UI to install, but font is missing
-# choose to install in  ~/src/CARTAvis-externals/ThirdParty/Qt5.3.2/,
-# can change to use default location, ~/Qt/?
+./$QTINSTALLER ## will prompt UI to install, use default location to install


### PR DESCRIPTION
Upgrade to use the new namespace of casa libs, `::casacore`

Improve build scripts:
1. make all-in-one script to build CARTA Mac Desktop. 
2. upgraded to use qooxdoo 3.5.1 and ast 8.4.0.
3. No more: macports, rpfits, java(jre), qwt6.1.0(for casa), qt4.8(for casa), and some of dependent dbus libs on mac. 
4. build flex 2.5.37.
5. Fix the installed of most of the libraries. 
6. all use curl, no wget. 