### PR TITLE
generalize polynomial from second power to third and fourth power

### DIFF
--- a/carta/cpp/CartaLib/PixelPipeline/CustomizablePixelPipeline.h
+++ b/carta/cpp/CartaLib/PixelPipeline/CustomizablePixelPipeline.h
@@ -82,7 +82,8 @@ private:
 enum class ScaleType
 {
     Linear, /// x' = x
-    Polynomial, /// x' = x^a
+    Polynomial3, /// x' = x^3
+    Polynomial4, /// x' = x^4
     Sqr, /// x' = x ^ 2
     Sqrt, /// x' = x ^ 1/2
     Log /// x' = log(ax + 1) / log(a+1)
@@ -119,8 +120,11 @@ public:
         case ScaleType::Sqrt :
             return gamma + "Sqrt";
 
-        case ScaleType::Polynomial :
-            return gamma + "Poly" + double2base64( m_a );
+        case ScaleType::Polynomial3 :
+              return gamma + "Poly3";
+
+        case ScaleType::Polynomial4 :
+              return gamma + "Poly4";
         }
         CARTA_ASSERT_X( false, "Invalid scale type" );
         return "";
@@ -189,8 +193,15 @@ public:
             };
             return;
 
-        case ScaleType::Polynomial :
-            setParam( 2.0 );
+        case ScaleType::Polynomial3 :
+            setParam( 3.0 );
+            m_func = [this] ( double & val ) {
+                val = std::pow( val, m_a );
+            };
+            return;
+
+        case ScaleType::Polynomial4 :
+            setParam( 4.0 );
             m_func = [this] ( double & val ) {
                 val = std::pow( val, m_a );
             };

--- a/carta/cpp/core/Data/Colormap/TransformsData.cpp
+++ b/carta/cpp/core/Data/Colormap/TransformsData.cpp
@@ -14,7 +14,9 @@ const QString TransformsData::TRANSFORM_NONE = "Linear";
 const QString TransformsData::TRANSFORM_ROOT = "Square Root";
 const QString TransformsData::TRANSFORM_SQUARE = "Square";
 const QString TransformsData::TRANSFORM_LOG = "Logarithm";
-const QString TransformsData::TRANSFORM_POLY = "Polynomial";
+const QString TransformsData::TRANSFORM_POLY3 = "Polynomial3";
+const QString TransformsData::TRANSFORM_POLY4 = "Polynomial4";
+
 
 class TransformsData::Factory : public Carta::State::CartaObjectFactory {
 
@@ -62,7 +64,9 @@ void TransformsData::_initializeDefaultState(){
     m_transforms.push_back(TRANSFORM_ROOT);
     m_transforms.push_back(TRANSFORM_SQUARE);
     m_transforms.push_back(TRANSFORM_LOG);
-    m_transforms.push_back(TRANSFORM_POLY );
+    m_transforms.push_back(TRANSFORM_POLY3);
+    m_transforms.push_back(TRANSFORM_POLY4);
+
 
     int transformCount = m_transforms.size();
     m_state.insertArray( DATA_TRANSFORMS, transformCount );
@@ -93,8 +97,11 @@ Carta::Lib::PixelPipeline::ScaleType TransformsData::getScaleType( const QString
     if ( name == TRANSFORM_LOG ){
         scaleType = Carta::Lib::PixelPipeline::ScaleType::Log;
     }
-    else if ( name == TRANSFORM_POLY ){
-        scaleType = Carta::Lib::PixelPipeline::ScaleType::Polynomial;
+    else if ( name == TRANSFORM_POLY3){
+        scaleType = Carta::Lib::PixelPipeline::ScaleType::Polynomial3;
+    }
+    else if ( name == TRANSFORM_POLY4){
+        scaleType = Carta::Lib::PixelPipeline::ScaleType::Polynomial4;
     }
     else if ( name == TRANSFORM_SQUARE ){
         scaleType = Carta::Lib::PixelPipeline::ScaleType::Sqr;

--- a/carta/cpp/core/Data/Colormap/TransformsData.h
+++ b/carta/cpp/core/Data/Colormap/TransformsData.h
@@ -54,7 +54,8 @@ private:
     const static QString DATA_TRANSFORMS;
     const static QString TRANSFORM_NONE;
     const static QString TRANSFORM_ROOT;
-    const static QString TRANSFORM_POLY;
+    const static QString TRANSFORM_POLY3;
+    const static QString TRANSFORM_POLY4;
     const static QString TRANSFORM_SQUARE;
     const static QString TRANSFORM_LOG;
     TransformsData( const QString& path, const QString& id );


### PR DESCRIPTION
related to issue #156 

The scale functions "polynomial" and "square" are identical, therefore it is redundant.

I adopted an easier way by modifying the original polynomial (2nd power) to the 3rd and 4th power. The changes are isolated in three files. In the code, it is possible to have the freedom to let user to set the power index to the polynomial scale function but there will be extra work to add UI. Perhaps this freedom is not necessary to users (too much freedom). So I just generalized polynomial from the 2nd power to the 3rd and 4th power. Detailed re-scaling of colormap should be achieved by "gamma" value. Here we just provide a few handy options to users.

As an example, polynomial (N-th power) == linear + gamma=N.