### PR TITLE
Add a basic spectral system in carta

### DIFF
--- a/carta/cpp/CartaLib/CartaLib.h
+++ b/carta/cpp/CartaLib/CartaLib.h
@@ -91,6 +91,20 @@ enum class KnownSkyCS
     Error ///< intended as an indication of error
 };
 
+/// known spectral systems
+enum class KnownSpecCS
+{
+    Unknown = 0,
+    Default,
+    FREQ,
+    VRAD,
+    VOPT,
+    BETA,
+    WAVE,
+    AWAV,
+    Error
+};
+
 /// convenience function to convert KnownSkyCS to int
 int knownSkyCS2int( KnownSkyCS cs);
 

--- a/carta/cpp/CartaLib/ICoordinateFormatter.h
+++ b/carta/cpp/CartaLib/ICoordinateFormatter.h
@@ -24,6 +24,7 @@ public:
 
     // \todo temporary typedef until we move this entire class to Carta::Lib
     typedef Carta::Lib::KnownSkyCS KnownSkyCS;
+    typedef Carta::Lib::KnownSpecCS KnownSpecCS;
 
     /// \todo we can remove this once we put this class into carta namespace
     typedef Carta::Lib::TextFormat TextFormat;
@@ -59,6 +60,8 @@ public:
     /// get the sky coordinate system used right now
     virtual KnownSkyCS skyCS() = 0;
 
+    virtual KnownSpecCS specCS() = 0;
+
     /// set the sky coordinate system
     /// \warning this can fail if conversion not possible/supported. Check skyCS() to see
     /// if it was successful.
@@ -91,4 +94,3 @@ public:
     virtual ~CoordinateFormatterInterface() {}
 
 };
-

--- a/carta/cpp/CartaLib/ICoordinateFormatter.h
+++ b/carta/cpp/CartaLib/ICoordinateFormatter.h
@@ -68,6 +68,8 @@ public:
     /// \warning this resets skyFormatting and precisions for the sky axes
     virtual Me & setSkyCS( const KnownSkyCS & scs) = 0;
 
+    virtual Me & setSpecCS( const KnownSpecCS & spcs ) = 0;
+
     /// get the current sky formatting (degree, sexagesimal, etc)
     /// \note never returns Default
     virtual SkyFormatting skyFormatting() = 0;

--- a/carta/cpp/CartaLib/IWcsGridRenderService.h
+++ b/carta/cpp/CartaLib/IWcsGridRenderService.h
@@ -116,6 +116,10 @@ public:
     virtual void
     setSkyCS( KnownSkyCS cs ) = 0;
 
+    /// current spectral system
+    virtual void
+    setSpecCS( KnownSpecCS cs ) = 0;
+
     //Set the length of the ticks
     virtual void
     setTickLength( double tickLength ) = 0;

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -2,6 +2,7 @@
 #include "State/UtilState.h"
 #include "Data/Image/Controller.h"
 #include "Data/Image/CoordinateSystems.h"
+#include "Data/Image/SpectralSystems.h"
 #include "Data/Image/DataFactory.h"
 #include "Data/Image/Stack.h"
 #include "Data/Image/DataSource.h"
@@ -437,6 +438,10 @@ QString Controller::_getRegionControlsId() const {
 	return m_regionControls->getPath();
 }
 
+Carta::Lib::KnownSpecCS Controller::getSpectralSystem() const {
+    return m_stack->_getSpectralSystem();
+}
+
 QString Controller::_getStackId() const {
     return m_stack->getPath();
 }
@@ -492,6 +497,7 @@ double Controller::getZoomLevel( ) const {
 void Controller::_gridChanged( const StateInterface& state, bool applyAll ){
     m_stack->_gridChanged( state, applyAll );
     _setSkyCSName();
+    _setSpecCSName();
 }
 
 void Controller::_onInputEvent( InputEvent  ev ){
@@ -1140,6 +1146,12 @@ void Controller::_setSkyCSName(){
     m_gridControls->_resetCoordinateSystem(csName);
 }
 
+void Controller::_setSpecCSName(){
+    const Carta::Lib::KnownSpecCS spcs = getSpectralSystem();
+    SpectralSystems* m_spec = Util::findSingletonObject<SpectralSystems>();
+    QString specName = m_spec->getName(spcs);
+    m_gridControls->_resetSpectralSystem(specName);
+}
 
 void Controller::_setFrameAxis(int value, AxisInfo::KnownType axisType ) {
     m_stack->_setFrameAxis( value, axisType );

--- a/carta/cpp/core/Data/Image/Controller.h
+++ b/carta/cpp/core/Data/Image/Controller.h
@@ -318,6 +318,8 @@ public:
      */
     int getRegionIndexCurrent() const;
 
+    Carta::Lib::KnownSpecCS getSpectralSystem() const;
+
     /**
      * Return a count of the number of image layers in the stack.
      * @return the number of image layers in the stack.
@@ -532,7 +534,7 @@ public:
      * Update the pan and zoom level settings.
      * @param centerX the screen x-coordinate where the zoom was centered.
      * @param centerY the screen y-coordinate where the zoom was centered.
-     * @param zoomLevel zoom level 
+     * @param zoomLevel zoom level
      * @param layerId specify the id of a layerData to update its Pan and Zoom level
      */
     void updatePanZoomLevel( double centerX, double centerY, double zoomLevel, double layerId );
@@ -679,6 +681,7 @@ private:
     // Set the AxisMapper::axisMap to use
     void _setAxisMap();
     void _setSkyCSName();
+    void _setSpecCSName();
 
 	/**
 	 * Make a frame selection.

--- a/carta/cpp/core/Data/Image/CoordinateSystems.cpp
+++ b/carta/cpp/core/Data/Image/CoordinateSystems.cpp
@@ -52,6 +52,8 @@ CoordinateSystems::CoordinateSystems( const QString& path, const QString& id):
 
     _initializeDefaultState();
     _initializeCallbacks();
+    //Don't display "Unknown" for users to select
+    m_coordSystems.insert(Carta::Lib::KnownSkyCS::Unknown, UNKNOWN);
 }
 
 QString CoordinateSystems::getDefault() const {
@@ -104,7 +106,7 @@ QList<Carta::Lib::KnownSkyCS> CoordinateSystems::getIndices() const{
 }
 
 QString CoordinateSystems::getName(Carta::Lib::KnownSkyCS skyCS ) const {
-    QString name;
+    QString name = UNKNOWN;
     if ( m_coordSystems.contains( skyCS )){
         name = m_coordSystems[skyCS];
     }

--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -1,5 +1,6 @@
 #include "DataSource.h"
 #include "CoordinateSystems.h"
+#include "SpectralSystems.h"
 #include "Data/Colormap/Colormaps.h"
 #include "Globals.h"
 #include "PluginManager.h"
@@ -34,6 +35,7 @@ const int DataSource::INDEX_FRAME_LOW = 3;
 const int DataSource::INDEX_FRAME_HIGH = 4;
 
 CoordinateSystems* DataSource::m_coords = nullptr;
+SpectralSystems* DataSource::m_spec = nullptr;
 
 DataSource::DataSource() :
     m_image( nullptr ),
@@ -242,6 +244,14 @@ QString DataSource::_getSkyCS(){
     return coordName;
 }
 
+QString DataSource::_getSpecCS(){
+
+    CoordinateFormatterInterface::SharedPtr cf(
+            m_image-> metaData()-> coordinateFormatter()-> clone() );
+
+    QString specName = m_spec->getName( cf->specCS() );
+    return specName;
+}
 
 QString DataSource::_getCursorText( int mouseX, int mouseY,
         Carta::Lib::KnownSkyCS cs, Carta::Lib::KnownSpecCS spcs, const std::vector<int>& frames,
@@ -784,6 +794,9 @@ void DataSource::_initializeSingletons( ){
     //Load the available color maps.
     if ( m_coords == nullptr ){
         m_coords = Util::findSingletonObject<CoordinateSystems>();
+    }
+    if ( m_spec == nullptr ){
+        m_spec = Util::findSingletonObject<SpectralSystems>();
     }
 }
 

--- a/carta/cpp/core/Data/Image/DataSource.h
+++ b/carta/cpp/core/Data/Image/DataSource.h
@@ -128,7 +128,8 @@ private:
      */
     QStringList _getCoordinates( double x, double y, Carta::Lib::KnownSkyCS system,
             const std::vector<int>& frames) const;
-
+    QStringList _getCoordinates( double x, double y, Carta::Lib::KnownSkyCS system,
+            Carta::Lib::KnownSpecCS spcs, const std::vector<int>& frames) const;
 
     QString _getSkyCS();
 
@@ -139,7 +140,8 @@ private:
      * @param frames - a list of current image frames.
      * @return a QString containing cursor text.
      */
-    QString _getCursorText( int mouseX, int mouseY, Carta::Lib::KnownSkyCS cs, const std::vector<int>& frames,
+    QString _getCursorText( int mouseX, int mouseY, Carta::Lib::KnownSkyCS cs,
+            Carta::Lib::KnownSpecCS spcs, const std::vector<int>& frames,
             double zoom, const QPointF& pan, const QSize& outputSize );
 
 
@@ -515,10 +517,10 @@ private:
 
     ///pixel pipeline
     std::shared_ptr<Carta::Lib::PixelPipeline::CustomizablePixelPipeline> m_pixelPipeline;
-    
+
     // disk cache
     std::shared_ptr<Carta::Lib::IPCache> m_diskCache;
-    
+
     //Indices of the display axes.
     int m_axisIndexX;
     int m_axisIndexY;

--- a/carta/cpp/core/Data/Image/DataSource.h
+++ b/carta/cpp/core/Data/Image/DataSource.h
@@ -40,6 +40,7 @@ class Service;
 namespace Data {
 
 class CoordinateSystems;
+class SpectralSystems;
 
 class DataSource : public QObject {
 
@@ -132,6 +133,7 @@ private:
             Carta::Lib::KnownSpecCS spcs, const std::vector<int>& frames) const;
 
     QString _getSkyCS();
+    QString _getSpecCS();
 
     /**
      * Returns information about the image at the current location of the cursor.
@@ -491,6 +493,7 @@ private:
 
     //Used pointer to coordinate systems.
     static CoordinateSystems* m_coords;
+    static SpectralSystems* m_spec;
 
     //Pointer to image interface.
     std::shared_ptr<Carta::Lib::Image::ImageInterface> m_image;

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -180,6 +180,12 @@ Carta::Lib::KnownSkyCS DataGrid::_getSkyCS() const {
     return index;
 }
 
+Carta::Lib::KnownSpecCS DataGrid::_getSpecCS() const {
+    // spectral system
+    QString specSystem = m_state.getValue<QString>( SPEC_SYSTEM );
+    Carta::Lib::KnownSpecCS index = m_specSystems->getIndex( specSystem);
+    return index;
+}
 
 QPen DataGrid::_getPen( const QString& key, const Carta::State::StateInterface& state  ){
     QString redLookup = Carta::State::UtilState::getLookup( key, Util::RED );

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -360,6 +360,9 @@ bool DataGrid::_isGridVisible() const {
 void DataGrid::_resetCoordinateSystem( const QString& coordSystem ){
     if ( m_state.getValue<QString>( COORD_SYSTEM) != coordSystem ){
         m_state.setValue<QString>( COORD_SYSTEM, coordSystem );
+        if ( coordSystem.isEmpty() ){
+            m_state.setValue<QString>( COORD_SYSTEM, QString("Unknown") );
+        }
     }
 }
 
@@ -462,7 +465,11 @@ void DataGrid::_resetGridRenderer(){
     }
 }
 
-
+void DataGrid::_resetSpectralSystem( const QString& specSystem ){
+    if ( m_state.getValue<QString>( SPEC_SYSTEM) != specSystem ){
+        m_state.setValue<QString>( SPEC_SYSTEM, specSystem );
+    }
+}
 
 void DataGrid::_resetState( const Carta::State::StateInterface& otherState ){
     if ( otherState.getValue<QString>( Carta::State::StateInterface::OBJECT_TYPE).length() > 0 ){
@@ -919,7 +926,7 @@ QString DataGrid::_setSpectralSystem( const QString& specSystem, bool* coordChan
         }
     }
     else {
-        result= "The coordinate system "+specSystem+" is not supported.";
+        result= "The spectral system "+specSystem+" is not supported.";
     }
     return result;
 }

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.h
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.h
@@ -64,6 +64,7 @@ private:
     Carta::Lib::KnownSpecCS _getSpecCS() const;
     bool _isGridVisible() const;
     void _resetCoordinateSystem( const QString& coordSystem );
+    void _resetSpectralSystem( const QString& specSystem );
     void _resetState( const Carta::State::StateInterface& otherState );
     QString _setAxis( const QString& axisId, const QString& purpose, bool* axisChanged );
     bool _setAxisTypes( std::vector<Carta::Lib::AxisInfo::KnownType> supportedAxes );

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.h
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.h
@@ -61,6 +61,7 @@ private:
      * @return the coordinate system that is selected.
      */
     Carta::Lib::KnownSkyCS _getSkyCS() const;
+    Carta::Lib::KnownSpecCS _getSpecCS() const;
     bool _isGridVisible() const;
     void _resetCoordinateSystem( const QString& coordSystem );
     void _resetState( const Carta::State::StateInterface& otherState );

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.h
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.h
@@ -23,6 +23,7 @@ namespace Carta {
 namespace Data {
 
 class CoordinateSystems;
+class SpectralSystems;
 class Fonts;
 class LabelFormats;
 class Themes;
@@ -86,6 +87,7 @@ private:
     QString _setShowInternalLabels( bool showInternalLabels, bool * gridChanged );
     QString _setShowStatistics( bool showStatistics, bool * statisticsChanged );
     QString _setShowTicks( bool showTicks, bool* ticksChanged );
+    QString _setSpectralSystem( const QString& specSystem, bool* coordChanged );
     QString _setTickLength( int tickLength, bool* lengthChanged );
     QString _setTickThickness( int tickThickness, bool* thicknessChanged );
     QStringList _setTickColor( int redAmount, int greenAmount, int blueAmount, bool* colorChanged );
@@ -109,6 +111,7 @@ private:
 
     const static QString AXES;
     const static QString COORD_SYSTEM;
+    const static QString SPEC_SYSTEM;
     const static QString DIRECTION;
     const static QString FONT;
     const static QString LABEL_AXIS;
@@ -145,6 +148,7 @@ private:
     std::shared_ptr<Carta::Lib::IWcsGridRenderService> m_wcsGridRenderer;
 
     static CoordinateSystems* m_coordSystems;
+    static SpectralSystems* m_specSystems;
     static Fonts* m_fonts;
     static Themes* m_themes;
     static LabelFormats* m_formats;

--- a/carta/cpp/core/Data/Image/Grid/GridControls.cpp
+++ b/carta/cpp/core/Data/Image/Grid/GridControls.cpp
@@ -153,6 +153,16 @@ void GridControls::_initializeCallbacks(){
                 return result;
             });
 
+    addCommandCallback( "setSpectralSystem", [=] (const QString & /*cmd*/,
+                    const QString & params, const QString & /*sessionId*/) -> QString {
+                std::set<QString> keys = {DataGrid::SPEC_SYSTEM};
+                std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+                QString showAxisStr = dataValues[DataGrid::SHOW_AXIS];
+                QString result = setSpectralSystem( dataValues[DataGrid::SPEC_SYSTEM] );
+                Util::commandPostProcess( result );
+                return result;
+            });
+
     addCommandCallback( "setGridLabelFormat", [=] (const QString & /*cmd*/,
                         const QString & params, const QString & /*sessionId*/) -> QString {
                     std::set<QString> keys = {DataGrid::FORMAT, DataGrid::LABEL_SIDE};
@@ -750,7 +760,14 @@ QString GridControls::setShowTicks( bool showTicks ){
     return result;
 }
 
-
+QString GridControls::setSpectralSystem( const QString& specSystem ){
+    bool coordChanged = false;
+    QString result = m_dataGrid->_setSpectralSystem( specSystem, &coordChanged );
+    if ( coordChanged ){
+        _updateGrid();
+    }
+    return result;
+}
 
 QStringList GridControls::setTickColor( int redAmount, int greenAmount, int blueAmount ){
     bool tickColorChanged = false;

--- a/carta/cpp/core/Data/Image/Grid/GridControls.cpp
+++ b/carta/cpp/core/Data/Image/Grid/GridControls.cpp
@@ -541,6 +541,14 @@ void GridControls::_resetCoordinateSystem( const QString coordSystem ){
     m_state.flushState();
 }
 
+void GridControls::_resetSpectralSystem( const QString specSystem ){
+    m_dataGrid->_resetSpectralSystem( specSystem );
+    Carta::State::StateInterface gridState = m_dataGrid->_getState();
+    QString gridStateStr = gridState.toString();
+    m_state.setObject( DataGrid::GRID, gridStateStr );
+    m_state.flushState();
+}
+
 void GridControls::_resetState( const Carta::State::StateInterface& otherState ){
     m_dataGrid->_resetState( otherState );
     QString gridStateStr = m_dataGrid->_getState().toString();

--- a/carta/cpp/core/Data/Image/Grid/GridControls.h
+++ b/carta/cpp/core/Data/Image/Grid/GridControls.h
@@ -268,6 +268,7 @@ private:
     QStringList _parseColorParams( const QString& params, const QString& label,
             int* red, int* green, int* blue ) const;
     void _resetCoordinateSystem( const QString coordSystem );
+    void _resetSpectralSystem( const QString specSystem );
     void _resetState( const Carta::State::StateInterface& otherState );
     void _setAxisTypes( std::vector<Carta::Lib::AxisInfo::KnownType> supportedAxes );
     void _setAxisInfos( std::vector<Carta::Lib::AxisInfo> supportedAxes );

--- a/carta/cpp/core/Data/Image/Grid/GridControls.h
+++ b/carta/cpp/core/Data/Image/Grid/GridControls.h
@@ -197,6 +197,9 @@ public:
      */
     QString setShowTicks( bool showTicks );
 
+
+    QString setSpectralSystem( const QString& specSystem );
+
     /**
      * Set the color of the tick marks.
      * @param redAmount - a nonnegative integer in [0,255].

--- a/carta/cpp/core/Data/Image/Layer.h
+++ b/carta/cpp/core/Data/Image/Layer.h
@@ -395,6 +395,7 @@ protected:
      */
     virtual std::vector< std::shared_ptr<ColorState> >  _getSelectedColorStates( bool global ) = 0;
 
+    virtual Carta::Lib::KnownSpecCS _getSpectralSystem() const = 0;
 
     /**
      * Return the state of this layer.

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -226,6 +226,7 @@ QString LayerData::_getCursorText( int mouseX, int mouseY, const std::vector<int
     QString cursorText;
     if ( m_dataSource ){
         Carta::Lib::KnownSkyCS cs = m_dataGrid->_getSkyCS();
+        Carta::Lib::KnownSpecCS spcs = m_dataGrid->_getSpecCS();
         //if(cs == Carta::Lib::KnownSkyCS::Default){
             //QString csName = m_dataSource->_getSkyCS();
             //bool *csChanged;
@@ -235,7 +236,7 @@ QString LayerData::_getCursorText( int mouseX, int mouseY, const std::vector<int
         //}
         QPointF pan = _getPan();
         double zoom = _getZoom();
-        cursorText = m_dataSource->_getCursorText( mouseX, mouseY, cs, frames, zoom, pan, outputSize );
+        cursorText = m_dataSource->_getCursorText( mouseX, mouseY, cs, spcs, frames, zoom, pan, outputSize );
     }
     return cursorText;
 }

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -558,6 +558,14 @@ QSize LayerData::_getSaveSize( const QSize& outputSize,  Qt::AspectRatioMode asp
     return saveSize;
 }
 
+Carta::Lib::KnownSpecCS LayerData::_getSpectralSystem() const {
+    Carta::Lib::KnownSpecCS spcs = Carta::Lib::KnownSpecCS::Unknown;
+    if ( m_dataGrid ){
+        spcs = m_dataGrid->_getSpecCS();
+    }
+    return spcs;
+}
+
 QString LayerData::_getStateString( bool truncatePaths ) const{
 
     Carta::State::StateInterface copyState( m_state );

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -6,6 +6,7 @@
 #include "Data/Util.h"
 #include "Data/Colormap/ColorState.h"
 #include "Data/Image/CoordinateSystems.h"
+#include "Data/Image/SpectralSystems.h"
 #include "Data/Image/Grid/AxisMapper.h"
 #include "Data/Image/Grid/LabelFormats.h"
 #include "State/UtilState.h"
@@ -637,6 +638,13 @@ void LayerData::_gridChanged( const Carta::State::StateInterface& state ){
         substituteState.setValue<QString>( skyCS, csName );
         //m_state.setValue<QString>( skyCS, csName );
         //m_state.flushState();
+    }
+    QString specCS = Carta::Data::DataGrid::SPEC_SYSTEM;
+    QString specName = state.getValue<QString>( specCS );
+    SpectralSystems* m_spec = Util::findSingletonObject<SpectralSystems>();
+    if(m_spec->getIndex(specName) == Carta::Lib::KnownSpecCS::Default){
+        specName = m_dataSource->_getSpecCS();
+        substituteState.setValue<QString>( specCS, specName );
     }
     m_dataGrid->_resetState( substituteState );
 }

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -275,6 +275,8 @@ protected:
      */
     virtual std::vector< std::shared_ptr<ColorState> >  _getSelectedColorStates( bool global ) Q_DECL_OVERRIDE;
 
+    virtual Carta::Lib::KnownSpecCS _getSpectralSystem() const Q_DECL_OVERRIDE;
+
     /**
      * Return the state of this layer.
      * @param truncatePaths - true if full paths to files should not be given.

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -659,6 +659,15 @@ std::shared_ptr<Layer> LayerGroup::_getSelectedGroup() {
     return group;
 }
 
+Carta::Lib::KnownSpecCS LayerGroup::_getSpectralSystem() const {
+    Carta::Lib::KnownSpecCS spcs = Carta::Lib::KnownSpecCS::Unknown;
+    int dataIndex = _getIndexCurrent();
+    if ( dataIndex >= 0){
+        spcs = m_children[dataIndex]->_getSpectralSystem();
+    }
+    return spcs;
+}
+
 int LayerGroup::_getStackSize() const {
     return m_children.size();
 }

--- a/carta/cpp/core/Data/Image/LayerGroup.h
+++ b/carta/cpp/core/Data/Image/LayerGroup.h
@@ -329,6 +329,8 @@ protected:
      */
     virtual std::vector< std::shared_ptr<ColorState> >  _getSelectedColorStates( bool global ) Q_DECL_OVERRIDE;
 
+    virtual Carta::Lib::KnownSpecCS _getSpectralSystem() const Q_DECL_OVERRIDE;
+
     int _getStackSize() const;
     int _getStackSizeVisible() const;
 

--- a/carta/cpp/core/Data/Image/SpectralSystems.cpp
+++ b/carta/cpp/core/Data/Image/SpectralSystems.cpp
@@ -99,10 +99,10 @@ QList<Carta::Lib::KnownSpecCS> SpectralSystems::getIndices() const{
     return m_specSystems.keys();
 }
 
-QString SpectralSystems::getName(Carta::Lib::KnownSpecCS skyCS ) const {
+QString SpectralSystems::getName(Carta::Lib::KnownSpecCS specCS ) const {
     QString name;
-    if ( m_specSystems.contains( skyCS )){
-        name = m_specSystems[skyCS];
+    if ( m_specSystems.contains( specCS )){
+        name = m_specSystems[specCS];
     }
     return name;
 }

--- a/carta/cpp/core/Data/Image/SpectralSystems.cpp
+++ b/carta/cpp/core/Data/Image/SpectralSystems.cpp
@@ -55,7 +55,7 @@ QString SpectralSystems::getDefault() const {
 }
 
 Carta::Lib::KnownSpecCS  SpectralSystems::getDefaultType() const {
-    return Carta::Lib::KnownSpecCS::Default;
+    return Carta::Lib::KnownSpecCS::VRAD;
 }
 
 QString SpectralSystems::getSpectralSystem( const QString& system ) const {

--- a/carta/cpp/core/Data/Image/SpectralSystems.cpp
+++ b/carta/cpp/core/Data/Image/SpectralSystems.cpp
@@ -1,0 +1,137 @@
+#include "Data/Image/SpectralSystems.h"
+#include "Data/Util.h"
+#include "State/UtilState.h"
+
+#include <QDebug>
+#include <set>
+
+namespace Carta {
+
+namespace Data {
+
+const QString SpectralSystems::CLASS_NAME = "SpectralSystems";
+const QString SpectralSystems::SYSTEM_NAME = "specCS";
+const QString SpectralSystems::COUNT = "specCSCount";
+const QString SpectralSystems::NATIVE = "Native";
+const QString SpectralSystems::CHANNEL = "Channel";
+const QString SpectralSystems::FREQUENCY = "Frequency";
+const QString SpectralSystems::RADIOVELOCITY = "Radio Velocity";
+const QString SpectralSystems::OPTICALVELOCITY = "Optical Velocity";
+
+class SpectralSystems::Factory : public Carta::State::CartaObjectFactory {
+
+    public:
+
+        Factory():
+            CartaObjectFactory( CLASS_NAME ){};
+
+        Carta::State::CartaObject * create (const QString & path, const QString & id)
+        {
+            return new SpectralSystems (path, id);
+        }
+    };
+
+
+bool SpectralSystems::m_registered =
+        Carta::State::ObjectManager::objectManager()->registerClass ( CLASS_NAME, new SpectralSystems::Factory());
+
+
+SpectralSystems::SpectralSystems( const QString& path, const QString& id):
+    CartaObject( CLASS_NAME, path, id ){
+    m_specSystems.insert(Carta::Lib::KnownSpecCS::Default, NATIVE );
+    m_specSystems.insert(Carta::Lib::KnownSpecCS::FREQ, FREQUENCY);
+    m_specSystems.insert(Carta::Lib::KnownSpecCS::VRAD, RADIOVELOCITY);
+    m_specSystems.insert(Carta::Lib::KnownSpecCS::VOPT, OPTICALVELOCITY);
+    //m_specSystems.insert(Carta::Lib::KnownSpecCS::BETA, BETA);
+    //m_specSystems.insert(Carta::Lib::KnownSpecCS::WAVE, WAVELENGTH);
+    //m_specSystems.insert(Carta::Lib::KnownSpecCS::AWAV, AIRWAVELENGTH);
+
+    _initializeDefaultState();
+    _initializeCallbacks();
+}
+
+QString SpectralSystems::getDefault() const {
+    return m_specSystems[ getDefaultType() ];
+}
+
+Carta::Lib::KnownSpecCS  SpectralSystems::getDefaultType() const {
+    return Carta::Lib::KnownSpecCS::Default;
+}
+
+QString SpectralSystems::getSpectralSystem( const QString& system ) const {
+    QString actualSystem;
+    int coordCount = m_specSystems.size();
+    QList<Carta::Lib::KnownSpecCS> keys = m_specSystems.keys();
+    for ( int i = 0; i < coordCount; i++ ){
+        int compareResult = QString::compare( system, m_specSystems[keys[i]], Qt::CaseInsensitive);
+        if ( compareResult == 0 ){
+            actualSystem = m_specSystems[keys[i]];
+            break;
+        }
+    }
+    return actualSystem;
+}
+
+QStringList SpectralSystems::getSpectralSystems() const {
+    QStringList buff;
+    int coordCount = m_specSystems.size();
+    QList<Carta::Lib::KnownSpecCS> keys = m_specSystems.keys();
+    for ( int i = 0; i < coordCount; i++ ){
+        buff.append( m_specSystems[keys[i]] );
+    }
+    return buff;
+}
+
+Carta::Lib::KnownSpecCS SpectralSystems::getIndex( const QString& name ) const {
+    Carta::Lib::KnownSpecCS index = Carta::Lib::KnownSpecCS::Unknown;
+    QMapIterator<Carta::Lib::KnownSpecCS, QString> iter(m_specSystems);
+    while (iter.hasNext()) {
+        iter.next();
+        if ( iter.value() == name ){
+            index = iter.key();
+            break;
+        }
+    }
+    return index;
+}
+
+QList<Carta::Lib::KnownSpecCS> SpectralSystems::getIndices() const{
+    return m_specSystems.keys();
+}
+
+QString SpectralSystems::getName(Carta::Lib::KnownSpecCS skyCS ) const {
+    QString name;
+    if ( m_specSystems.contains( skyCS )){
+        name = m_specSystems[skyCS];
+    }
+    return name;
+}
+
+
+void SpectralSystems::_initializeDefaultState(){
+    int coordCount = m_specSystems.size();
+    m_state.insertValue<int>( COUNT, coordCount );
+    m_state.insertArray( SYSTEM_NAME, coordCount );
+    QList<Carta::Lib::KnownSpecCS> keys = m_specSystems.keys();
+    for ( int i = 0; i < coordCount; i++ ){
+        QString lookup = Carta::State::UtilState::getLookup( SYSTEM_NAME, i );
+        m_state.setValue<QString>( lookup,m_specSystems[keys[i]]);
+    }
+    m_state.flushState();
+}
+
+void SpectralSystems::_initializeCallbacks(){
+    addCommandCallback( "getSpecSystems", [=] (const QString & /*cmd*/,
+                    const QString & /*params*/, const QString & /*sessionId*/) -> QString {
+            QStringList coordList = getSpectralSystems();
+            QString result = coordList.join(",");
+            return result;
+        });
+}
+
+
+SpectralSystems::~SpectralSystems(){
+
+}
+}
+}

--- a/carta/cpp/core/Data/Image/SpectralSystems.h
+++ b/carta/cpp/core/Data/Image/SpectralSystems.h
@@ -1,0 +1,106 @@
+/***
+ * List of all available SpectralSystems.
+ *
+ */
+
+#pragma once
+
+#include "State/ObjectManager.h"
+#include "State/StateInterface.h"
+#include "CartaLib/CartaLib.h"
+#include <vector>
+
+namespace Carta {
+namespace Lib {
+namespace PixelPipeline {
+class IColormapNamed;
+}
+}
+}
+
+namespace Carta {
+
+namespace Data {
+
+class SpectralSystems : public Carta::State::CartaObject {
+
+public:
+
+    /**
+     * Translates a non case sensitive spectral system into one
+     * that is case sensitive.
+     * @param system - a spectral system that may not have the proper capitalization.
+     * @return - a recognized spectral system or an empty string if the spectral
+     *      system is not recognized.
+     */
+    QString getSpectralSystem( const QString& system ) const;
+
+    /**
+     * Returns a list of available spectral systems.
+     * @return a QStringList containing the names of available spectral systems.
+     */
+    QStringList getSpectralSystems() const;
+
+    /**
+     * Returns the index of the spectral system matching the name or -1 if no such
+     * spectral system exists.
+     * @param name - an identifier for a spectral system.
+     * @return the official enum entry of the spectral system.
+     */
+    Carta::Lib::KnownSpecCS getIndex( const QString& name) const;
+
+    /**
+     * Returns the indices of supported spectral systems.
+     * @return a list of indices of the recognized spectral systems.
+     */
+    QList<Carta::Lib::KnownSpecCS> getIndices() const;
+
+    /**
+     * Returns the name of the spectral string matching the identifier.
+     * @param skyCS - an index of a spectral system.
+     * @return the name of the spectral system or an empty string if no such spectral
+     *      system exists.
+     */
+    QString getName(Carta::Lib::KnownSpecCS specCS ) const;
+
+    /**
+     * Returns the name of the default spectral system.
+     * @return the name of the default spectral system.
+     */
+    QString getDefault() const;
+
+    /**
+     * Return the default enumerated spectral system type.
+     * @return - the default enumerated spectral system type.
+     */
+    Carta::Lib::KnownSpecCS  getDefaultType() const;
+
+    virtual ~SpectralSystems();
+
+
+    const static QString CLASS_NAME;
+private:
+
+    void _initializeDefaultState();
+    void _initializeCallbacks();
+
+    static bool m_registered;
+    QMap < Carta::Lib::KnownSpecCS, QString > m_specSystems;
+    const static QString SYSTEM_NAME;
+    const static QString COUNT;
+    const static QString NATIVE;
+    const static QString FREQUENCY;
+    const static QString RADIOVELOCITY;
+    const static QString OPTICALVELOCITY;
+    const static QString CHANNEL;
+
+    SpectralSystems( const QString& path, const QString& id );
+
+    class Factory;
+
+	SpectralSystems( const SpectralSystems& other);
+	SpectralSystems& operator=( const SpectralSystems& other );
+};
+
+}
+}

--- a/carta/cpp/core/Data/ViewManager.cpp
+++ b/carta/cpp/core/Data/ViewManager.cpp
@@ -14,6 +14,7 @@
 #include "Data/Image/ImageContext.h"
 #include "Data/Image/ImageZoom.h"
 #include "Data/Image/LayerCompositionModes.h"
+#include "Data/Image/SpectralSystems.h"
 #include "Data/Histogram/ChannelUnits.h"
 #include "Data/DataLoader.h"
 #include "Data/Colormap/Gamma.h"
@@ -94,6 +95,7 @@ ViewManager::ViewManager( const QString& path, const QString& id)
     Util::findSingletonObject<PreferencesSave>();
     Util::findSingletonObject<ChannelUnits>();
     Util::findSingletonObject<CoordinateSystems>();
+    Util::findSingletonObject<SpectralSystems>();
     Util::findSingletonObject<Themes>();
     Util::findSingletonObject<ContourGenerateModes>();
     Util::findSingletonObject<ContourSpacingModes>();

--- a/carta/cpp/core/DummyGridRenderer.cpp
+++ b/carta/cpp/core/DummyGridRenderer.cpp
@@ -73,6 +73,10 @@ DummyGridRenderer::setSkyCS( Lib::KnownSkyCS )
 { }
 
 void
+DummyGridRenderer::setSpecCS( Lib::KnownSpecCS )
+{ }
+
+void
 DummyGridRenderer::setTickLength( double )
 { }
 

--- a/carta/cpp/core/DummyGridRenderer.h
+++ b/carta/cpp/core/DummyGridRenderer.h
@@ -70,6 +70,9 @@ public:
     setSkyCS( Carta::Lib::KnownSkyCS ) override;
 
     virtual void
+    setSpecCS( Carta::Lib::KnownSpecCS ) override;
+
+    virtual void
     setTickLength( double ) override;
 
     virtual void

--- a/carta/cpp/core/State/ObjectManager.cpp
+++ b/carta/cpp/core/State/ObjectManager.cpp
@@ -21,7 +21,7 @@ namespace State {
 
 QList<QString> CartaObjectFactory::globalIds = {"ChannelUnits",
         "Clips", "Colormaps","ContourGenerateModes","ContourSpacingModes","ContourStyles",
-        "CoordinateSystems","DataLoader","ErrorManager",
+        "CoordinateSystems","SpectralSystems","DataLoader","ErrorManager",
         "Gamma","GenerateModes","Fonts",
         "LabelFormats","Layout","LayerCompositionModes","LineStyles",
          "PlotStyles", "ProfilePlotStyles",

--- a/carta/cpp/core/core.pro
+++ b/carta/cpp/core/core.pro
@@ -83,6 +83,7 @@ HEADERS += \
     Data/Image/Save/SaveService.h \
     Data/Image/Save/SaveView.h \
     Data/Image/Save/SaveViewLayered.h \
+    Data/Image/SpectralSystems.h \
     Data/Selection.h \
     Data/Layout/Layout.h \
     Data/Layout/LayoutNode.h \
@@ -229,6 +230,7 @@ SOURCES += \
     Data/Image/Save/SaveService.cpp \
     Data/Image/Save/SaveView.cpp \
     Data/Image/Save/SaveViewLayered.cpp \
+    Data/Image/SpectralSystems.cpp \
     Data/DataLoader.cpp \
     Data/Error/ErrorReport.cpp \
     Data/Error/ErrorManager.cpp \

--- a/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
@@ -288,6 +288,32 @@ CCCoordinateFormatter::skyCS()
     } // switch
 } // skyCS
 
+Carta::Lib::KnownSpecCS
+CCCoordinateFormatter::specCS(){
+    if ( ! m_casaCS->hasSpectralAxis() ) {
+        return KnownSpecCS::Unknown;
+    }
+    const casa::SpectralCoordinate & specCoord= m_casaCS->spectralCoordinate();
+    casa::SpectralCoordinate::SpecType specType = specCoord.nativeType();
+    switch (specType) {
+        case casa::SpectralCoordinate::SpecType::FREQ :
+            return KnownSpecCS::FREQ;
+        case casa::SpectralCoordinate::SpecType::VRAD :
+            return KnownSpecCS::VRAD;
+        case casa::SpectralCoordinate::SpecType::VOPT :
+            return KnownSpecCS::VOPT;
+        case casa::SpectralCoordinate::SpecType::BETA :
+            return KnownSpecCS::BETA;
+        case casa::SpectralCoordinate::SpecType::WAVE :
+            return KnownSpecCS::WAVE;
+        case casa::SpectralCoordinate::SpecType::AWAV :
+            return KnownSpecCS::AWAV;
+
+        default:
+            return KnownSpecCS::Unknown;
+    }
+}
+
 CCCoordinateFormatter::Me &
 CCCoordinateFormatter::setSkyCS( const KnownSkyCS & scs )
 {

--- a/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
@@ -441,7 +441,7 @@ CCCoordinateFormatter::setSpecCS( const KnownSpecCS & spcs )
             break;
 
         default:
-            sptype = casa::SpectralCoordinate::SpecType::VRAD;
+            CARTA_ASSERT( false );
             break;
     }
 

--- a/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.h
+++ b/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.h
@@ -59,6 +59,9 @@ public:
     virtual KnownSkyCS
     skyCS() override;
 
+    virtual KnownSpecCS
+    specCS() override;
+
     virtual Me &
     setSkyCS( const KnownSkyCS & scs ) override;
 

--- a/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.h
+++ b/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.h
@@ -65,6 +65,9 @@ public:
     virtual Me &
     setSkyCS( const KnownSkyCS & scs ) override;
 
+    virtual Me &
+    setSpecCS( const KnownSpecCS & spcs ) override;
+
     virtual SkyFormatting
     skyFormatting() override;
 

--- a/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
+++ b/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.cpp
@@ -29,7 +29,10 @@ struct AstWcsGridRenderService::Pimpl
     QStringList fitsHeader;
 
     // current sky CS
-    Carta::Lib::KnownSkyCS knownSkyCS = Carta::Lib::KnownSkyCS::J2000;
+    Carta::Lib::KnownSkyCS knownSkyCS = Carta::Lib::KnownSkyCS::Default;
+
+    // current spectral system
+    Carta::Lib::KnownSpecCS knownSpecCS = Carta::Lib::KnownSpecCS::Default;
 
     // list of pens
     std::vector < QPen > pens;
@@ -279,7 +282,7 @@ AstWcsGridRenderService::renderNow()
        if ( Carta::Lib::AxisDisplayInfo::isCelestialPlane( m_axisDisplayInfos) ){
            sgp.setPlotOption( system );
        }
-   }
+    }
 
     // labelOPtion for Ast
     QString labelOPtion = _setDisplayLabelOptionforAst();
@@ -435,12 +438,13 @@ QString AstWcsGridRenderService::_setDisplayLabelOptionforAst()
                 else if(axisType == Carta::Lib::AxisInfo::KnownType::SPECTRAL)
                 {
                     // check system for spectral
-                    setPlotOption << QString("system(%1)=%2").arg(ii+1).arg( "VRAD" );
+                    // setPlotOption << QString("system(%1)=%2").arg(ii+1).arg( "VRAD" );
                     //setPlotOption << QString("system(%1)=%2").arg(ii+1).arg( "Freq" );
-                    setPlotOption << QString("Digits(%1)=%2").arg(ii+1).arg(precision);
+                    setPlotOption << QString("system(%1)=%2").arg(ii+1).arg( _getSpecSystem() );
+                    //setPlotOption << QString("Digits(%1)=%2").arg(ii+1).arg(precision);
 
                     // set unit
-                    setPlotOption << QString("Unit(%1)=%2").arg(ii+1).arg("km/s");
+                    //setPlotOption << QString("Unit(%1)=%2").arg(ii+1).arg("km/s");
 
                 }
                 else
@@ -517,7 +521,16 @@ AstWcsGridRenderService::setSkyCS( Carta::Lib::KnownSkyCS cs )
     }
 }
 
-
+void
+AstWcsGridRenderService::setSpecCS( Carta::Lib::KnownSpecCS cs )
+{
+    // invalidate vglist if the requested spectral system is different
+    // from the last one
+    if ( m().knownSpecCS != cs ) {
+        m_vgValid = false;
+        m().knownSpecCS = cs;
+    }
+}
 
 void
 AstWcsGridRenderService::setPen( Carta::Lib::IWcsGridRenderService::Element e, const QPen & pen )
@@ -667,6 +680,27 @@ AstWcsGridRenderService::_getSystem( ){
 
 
    return system;
+}
+
+QString
+AstWcsGridRenderService::_getSpecSystem(){
+    switch ( m().knownSpecCS ) {
+        case Carta::Lib::KnownSpecCS::FREQ :
+            return "FREQ";
+        case Carta::Lib::KnownSpecCS::VRAD :
+            return "VRAD";
+        case Carta::Lib::KnownSpecCS::VOPT :
+            return "VOPT";
+        case Carta::Lib::KnownSpecCS::BETA :
+            return "BETA";
+        case Carta::Lib::KnownSpecCS::WAVE :
+            return "WAVE";
+        case Carta::Lib::KnownSpecCS::AWAV :
+            return "AWAV";
+        default :
+            // This case should be avoided, or the gridline will show red color.
+            return "";
+    }
 }
 
 void

--- a/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.h
+++ b/carta/cpp/plugins/WcsPlotter/AstWcsGridRenderService.h
@@ -69,6 +69,9 @@ public:
     setSkyCS( Carta::Lib::KnownSkyCS cs ) override;
 
     virtual void
+    setSpecCS( Carta::Lib::KnownSpecCS cs ) override;
+
+    virtual void
     setPen( Element e, const QPen & pen ) override;
 
 //    virtual const QPen &
@@ -108,6 +111,7 @@ private:
     QString _getDisplayLocation( const Carta::Lib::AxisLabelInfo::Locations& labelLocation ) const;
 
     QString _getSystem();
+    QString _getSpecSystem();
     //Don't draw tick marks.
     void _turnOffTicks(WcsPlotterPluginNS::AstGridPlotter* sgp);
     //Don't label a particular axis

--- a/carta/cpp/plugins/qimage/QImagePlugin.cpp
+++ b/carta/cpp/plugins/qimage/QImagePlugin.cpp
@@ -286,6 +286,12 @@ public:
         return KnownSkyCS::Unknown;
     }
 
+    virtual KnownSpecCS
+    specCS() override
+    {
+        return KnownSpecCS::Unknown;
+    }
+
     virtual Me &
     setSkyCS( const KnownSkyCS & scs ) override
     {

--- a/carta/cpp/plugins/qimage/QImagePlugin.cpp
+++ b/carta/cpp/plugins/qimage/QImagePlugin.cpp
@@ -299,6 +299,13 @@ public:
         return * this;
     }
 
+    virtual Me &
+    setSpecCS( const KnownSpecCS & spcs ) override
+    {
+        Q_UNUSED( spcs );
+        return * this;
+    }
+
     virtual SkyFormatting
     skyFormatting() override
     {

--- a/carta/html5/common/skel/source/class/skel/widgets/Image/Grid/Settings/SettingsCanvasPage.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Image/Grid/Settings/SettingsCanvasPage.js
@@ -51,26 +51,30 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
          */
         _initSystem : function(){
             var systemContainer = new qx.ui.container.Composite();
-            systemContainer.setLayout( new qx.ui.layout.HBox(1));
+            systemContainer.setLayout( new qx.ui.layout.VBox(1));
 
+            var coordSystemContainer = new qx.ui.container.Composite( new qx.ui.layout.HBox(1) );
             this.m_coordSystem = new skel.boundWidgets.ComboBox("setCoordinateSystem", "skyCS");
             this.m_coordSystem.setToolTipText( "Select a coordinate system for the image.");
             skel.widgets.TestID.addTestId( this.m_coordSystem, "ImageCoordinateSystem");
             var systemLabel = new qx.ui.basic.Label( "Coordinate System:");
-            systemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
-            systemContainer.add( systemLabel );
-            systemContainer.add( this.m_coordSystem );
-            systemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
+            coordSystemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
+            coordSystemContainer.add( systemLabel );
+            coordSystemContainer.add( this.m_coordSystem );
+            coordSystemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
+            systemContainer.add( coordSystemContainer );
             //this.m_content.add( systemContainer );
 
+            var specSystemContainer = new qx.ui.container.Composite( new qx.ui.layout.HBox(1) );
             this.m_specSystem = new skel.boundWidgets.ComboBox("setSpectralSystem", "specCS");
             this.m_specSystem.setToolTipText( "Seletct a spectral system for the image." );
             skel.widgets.TestID.addTestId( this.m_specSystem, "ImageSpectralSystem" );
             var specLabel = new qx.ui.basic.Label( "Spectral System:" );
-            systemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
-            systemContainer.add( specLabel );
-            systemContainer.add( this.m_specSystem );
-            systemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
+            specSystemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
+            specSystemContainer.add( specLabel );
+            specSystemContainer.add( this.m_specSystem );
+            specSystemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
+            systemContainer.add( specSystemContainer );
             this.m_content.add( systemContainer );
         },
 

--- a/carta/html5/common/skel/source/class/skel/widgets/Image/Grid/Settings/SettingsCanvasPage.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Image/Grid/Settings/SettingsCanvasPage.js
@@ -209,6 +209,10 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
         _setCoordinateSystem : function( skyCS ){
             if ( typeof skyCS !== "undefined"){
                 this.m_coordSystem.setValue( skyCS );
+                this.m_coordSystem.setEnabled( true );
+                if ( skyCS === "Unknown" ){
+                    this.m_coordSystem.setEnabled( false );
+                }
             }
         },
 

--- a/carta/html5/common/skel/source/class/skel/widgets/Image/Grid/Settings/SettingsCanvasPage.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Image/Grid/Settings/SettingsCanvasPage.js
@@ -17,22 +17,24 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
         this.m_connector = mImport("connector");
         this._init();
         var pathDict = skel.widgets.Path.getInstance();
-        
+
         this.m_sharedVar = this.m_connector.getSharedVar(pathDict.COORDINATE_SYSTEMS);
         this.m_sharedVar.addCB(this._systemsChangedCB.bind(this));
+        this.m_sharedSpecCS = this.m_connector.getSharedVar(pathDict.SPECTRAL_SYSTEMS);
+        this.m_sharedSpecCS.addCB(this._systemsChangedCB.bind(this));
         this._systemsChangedCB();
     },
 
     members : {
-        
-       
-        
+
+
+
         /**
          * Initializes the UI.
          */
         _init : function( ) {
             this.setPadding( 0, 0, 0, 0 );
-            
+
             this._setLayout(new qx.ui.layout.VBox(1));
             this.m_content = new qx.ui.container.Composite();
             this._add( this.m_content );
@@ -42,7 +44,7 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
             this._initSystem();
             this.m_content.add( new qx.ui.core.Spacer(5), {flex:1});
         },
-        
+
 
         /**
          * Initializes the coordinate system.
@@ -50,59 +52,69 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
         _initSystem : function(){
             var systemContainer = new qx.ui.container.Composite();
             systemContainer.setLayout( new qx.ui.layout.HBox(1));
-            
+
             this.m_coordSystem = new skel.boundWidgets.ComboBox("setCoordinateSystem", "skyCS");
             this.m_coordSystem.setToolTipText( "Select a coordinate system for the image.");
             skel.widgets.TestID.addTestId( this.m_coordSystem, "ImageCoordinateSystem");
-            var systemLabel = new qx.ui.basic.Label( "System:");
+            var systemLabel = new qx.ui.basic.Label( "Coordinate System:");
             systemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
             systemContainer.add( systemLabel );
             systemContainer.add( this.m_coordSystem );
             systemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
+            //this.m_content.add( systemContainer );
+
+            this.m_specSystem = new skel.boundWidgets.ComboBox("setSpectralSystem", "specCS");
+            this.m_specSystem.setToolTipText( "Seletct a spectral system for the image." );
+            skel.widgets.TestID.addTestId( this.m_specSystem, "ImageSpectralSystem" );
+            var specLabel = new qx.ui.basic.Label( "Spectral System:" );
+            systemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
+            systemContainer.add( specLabel );
+            systemContainer.add( this.m_specSystem );
+            systemContainer.add( new qx.ui.core.Spacer(5), {flex:1});
             this.m_content.add( systemContainer );
         },
-        
+
         /**
          * Initialize the visibility controls.
          */
         _initVisible : function(){
             var visibleContainer = new qx.ui.container.Composite();
             visibleContainer.setLayout( new qx.ui.layout.VBox());
-            
+
             this.m_allImages = new qx.ui.form.CheckBox( "All Images");
             this.m_allImages.setToolTipText( "Apply grid control settings to all images in the stack.");
             this.m_allImages.setValue( false );
-            this.m_allListenerId = this.m_allImages.addListener( skel.widgets.Path.CHANGE_VALUE, 
+            this.m_allListenerId = this.m_allImages.addListener( skel.widgets.Path.CHANGE_VALUE,
                     this._sendApplyAllCmd, this );
             var allContainer = new qx.ui.container.Composite();
             allContainer.setLayout( new qx.ui.layout.HBox());
             allContainer.add( new qx.ui.core.Spacer(5), {flex:1});
             allContainer.add( this.m_allImages );
             allContainer.add( new qx.ui.core.Spacer(5), {flex:1});
-            
-            
+
+
             this.m_showSystem = new qx.ui.form.CheckBox( "Coordinate System");
             this.m_showSystem.setToolTipText( "Show the grid coordinate system.");
             this.m_showSystem.setValue( true );
-            this.m_showListenerId = this.m_showSystem.addListener( skel.widgets.Path.CHANGE_VALUE, 
+            this.m_showListenerId = this.m_showSystem.addListener( skel.widgets.Path.CHANGE_VALUE,
                     this._sendShowSystemCmd, this);
             var sysContainer = new qx.ui.container.Composite();
             sysContainer.setLayout( new qx.ui.layout.HBox());
             sysContainer.add( new qx.ui.core.Spacer(5), {flex:1});
             sysContainer.add( this.m_showSystem );
             sysContainer.add( new qx.ui.core.Spacer(5), {flex:1});
-            
+
             this.m_showStatistics = new qx.ui.form.CheckBox( "Cursor");
             this.m_showStatistics.setToolTipText( "Show/hide cursor information.");
             this.m_showStatistics.setValue( true );
-            this.m_cursorListenerId = this.m_showStatistics.addListener( skel.widgets.Path.CHANGE_VALUE, 
+            this.m_cursorListenerId = this.m_showStatistics.addListener( skel.widgets.Path.CHANGE_VALUE,
                     this._sendShowStatisticsCmd, this);
             var cursorContainer = new qx.ui.container.Composite();
             cursorContainer.setLayout( new qx.ui.layout.HBox());
             cursorContainer.add( new qx.ui.core.Spacer(5), {flex:1});
             cursorContainer.add( this.m_showStatistics );
             cursorContainer.add( new qx.ui.core.Spacer(5), {flex:1});
-            
+
             visibleContainer.add( new qx.ui.core.Spacer(5), {flex:1});
             visibleContainer.add( allContainer );
             visibleContainer.add( sysContainer );
@@ -110,7 +122,7 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
             visibleContainer.add( new qx.ui.core.Spacer(5), {flex:1});
             this.m_content.add( visibleContainer );
         },
-        
+
         /**
          * Sends command to server for applying (or not) the grid settings to all stacked
          * images.
@@ -122,7 +134,7 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
             var params = "applyAll:"+applyAll;
             this.m_connector.sendCommand( cmd, params, function(){});
         },
-        
+
         /**
          * Sends a command to the server to change the visibility of the image statistics.
          */
@@ -144,8 +156,8 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
             var params = "showCoordinateSystem:"+showCoords;
             this.m_connector.sendCommand( cmd, params, function(){});
         },
-        
-       
+
+
         /**
          * Update the UI based on server-side grid settings.
          * @param controls {Object} - server side grid settings.
@@ -155,24 +167,25 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
             this._setShowSystem( controls.grid.showCoordinateSystem );
             this._setCoordinateSystem( controls.grid.skyCS );
             this._setShowStatistics( controls.grid.showStatistics );
+            this._setSpectralSystem( controls.grid.specCS );
         },
-        
+
         /**
          * Set whether or not the grid coordinate system should be visible
          *      based on server side values.
-         * @param showSystem {boolean} - true if the grid coordinate system 
+         * @param showSystem {boolean} - true if the grid coordinate system
          *      should be shown; false otherwise.
          */
         _setShowSystem : function ( showSystem ){
-            if ( typeof showSystem !== "undefined" && 
+            if ( typeof showSystem !== "undefined" &&
                     this.m_showSystem.getValue() != showSystem ){
                 this.m_showSystem.removeListenerById( this.m_showListenerId );
                 this.m_showSystem.setValue( showSystem );
-                this.m_showListenerId = this.m_showSystem.addListener( skel.widgets.Path.CHANGE_VALUE, 
+                this.m_showListenerId = this.m_showSystem.addListener( skel.widgets.Path.CHANGE_VALUE,
                         this._sendShowSystemCmd, this);
             }
         },
-        
+
         /**
          * Set whether or not grid settings should be applied to all images in
          * the stack based on server side values.
@@ -180,15 +193,15 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
          *      to all images in the stack; false otherwise.
          */
         _setApplyAll : function ( applyAll ){
-            if ( typeof applyAll !== "undefined" && 
+            if ( typeof applyAll !== "undefined" &&
                     this.m_allImages.getValue() != applyAll ){
                 this.m_allImages.removeListenerById( this.m_allListenerId );
                 this.m_allImages.setValue( applyAll );
-                this.m_allListenerId = this.m_allImages.addListener( skel.widgets.Path.CHANGE_VALUE, 
+                this.m_allListenerId = this.m_allImages.addListener( skel.widgets.Path.CHANGE_VALUE,
                         this._sendApplyAllCmd, this );
             }
         },
-        
+
         /**
          * Set the coordinate system based on server side values.
          * @param skyCS {String} - an identifier for a coordinate system.
@@ -198,7 +211,13 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
                 this.m_coordSystem.setValue( skyCS );
             }
         },
-        
+
+        _setSpectralSystem : function( specCS ){
+            if ( typeof skyCS !== "undefined"){
+                this.m_specSystem.setValue( specCS );
+            }
+        },
+
         /**
          * Set the server side id of this control UI.
          * @param gridId {String} the server side id of the object that contains data for this control UI.
@@ -206,22 +225,23 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
         setId : function( gridId ){
             this.m_id = gridId;
             this.m_coordSystem.setId( gridId );
+            this.m_specSystem.setId( gridId );
         },
-        
+
         /**
          * Set the visibility of the axes.
          * @param showAxes {boolean} - true if the axes should be shown; false otherwise.
          */
         _setShowStatistics : function ( showStatistics ){
-            if ( typeof showStatistics !=="undefined" && 
+            if ( typeof showStatistics !=="undefined" &&
                     this.m_showStatistics.getValue() != showStatistics ){
                 this.m_showStatistics.removeListenerById( this.m_cursorListenerId );
                 this.m_showStatistics.setValue( showStatistics );
-                this.m_cursorListenerId = this.m_showStatistics.addListener( skel.widgets.Path.CHANGE_VALUE, 
+                this.m_cursorListenerId = this.m_showStatistics.addListener( skel.widgets.Path.CHANGE_VALUE,
                         this._sendShowStatisticsCmd, this);
             }
         },
-        
+
         /**
          * Callback for a change in the available coordinate systems.
          */
@@ -238,21 +258,33 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
                     }
                 }
             }
+            if ( this.m_sharedSpecCS ){
+                var specVal = this.m_sharedSpecCS.get();
+                if ( specVal ){
+                    try {
+                        var specSystems = JSON.parse( specVal );
+                        this.m_specSystem.setComboItems( specSystems.specCS );
+                    }
+                    catch( err ){
+                        console.log( "Axes spectral system could not parse: "+specVal );
+                    }
+                }
+            }
         },
-        
+
         m_content : null,
         m_id : null,
         m_connector : null,
-        
+
         m_coordSystem : null,
-        
+
         m_showStatistics : null,
         m_showSystem : null,
         m_allImages : null,
         m_cursorListenerId : null,
         m_showListenerId : null,
         m_allListenerId : null,
-        
+
         m_sharedVar : null
     }
 

--- a/carta/html5/common/skel/source/class/skel/widgets/Image/Grid/Settings/SettingsCanvasPage.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Image/Grid/Settings/SettingsCanvasPage.js
@@ -213,7 +213,7 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
         },
 
         _setSpectralSystem : function( specCS ){
-            if ( typeof skyCS !== "undefined"){
+            if ( typeof specCS !== "undefined"){
                 this.m_specSystem.setValue( specCS );
             }
         },
@@ -277,6 +277,7 @@ qx.Class.define("skel.widgets.Image.Grid.Settings.SettingsCanvasPage", {
         m_connector : null,
 
         m_coordSystem : null,
+        m_specSystem: null,
 
         m_showStatistics : null,
         m_showSystem : null,

--- a/carta/html5/common/skel/source/class/skel/widgets/Path.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Path.js
@@ -16,6 +16,7 @@ qx.Class.define("skel.widgets.Path", {
         this.CONTOUR_LINE_STYLES = this.BASE_PATH + "ContourStyles";
         this.CONTOUR_SPACING_MODES = this.BASE_PATH + "ContourSpacingModes";
         this.COORDINATE_SYSTEMS = this.BASE_PATH + "CoordinateSystems";
+        this.SPECTRAL_SYSTEMS = this.BASE_PATH + "SpectralSystems";
         this.DATA_COUNT = this.BASE_PATH + "controller"+ this.SEP + "dataCount";
         this.ERROR_HANDLER = this.BASE_PATH + "ErrorManager";
         this.FONTS = this.BASE_PATH + "Fonts";
@@ -44,14 +45,14 @@ qx.Class.define("skel.widgets.Path", {
         this.TRANSFORMS_DATA = this.BASE_PATH +"TransformsData";
         this.TRANSFORMS_IMAGE = this.BASE_PATH + "TransformsImage";
     },
-    
+
     statics : {
         CHANGE_VALUE : "changeValue",
         HORIZONTAL : "horizontal",
         VERTICAL : "vertical",
         MAX_RGB : 255
     },
-    
+
     members : {
         ANIMATOR : "Animator",
         ANIMATOR_TYPES : "",
@@ -71,6 +72,7 @@ qx.Class.define("skel.widgets.Path", {
         CONTOUR_LINE_STYLES : "",
         CONTOUR_SPACING_MODES : "",
         COORDINATE_SYSTEMS : "",
+        SPECTRAL_SYSTEMS : "",
         DATA : "data",
         DATA_COUNT : "",
         DATA_LOADER : "DataLoader",
@@ -124,8 +126,8 @@ qx.Class.define("skel.widgets.Path", {
         ZOOM : "zoom",
         VIEW : "view",
         VIEW_MANAGER : "ViewManager",
-        
-       
+
+
         /**
          * Returns the command for announcing the creation of a shape.
          * @param winId {String} the server side id of the object displaying the shape.
@@ -134,7 +136,7 @@ qx.Class.define("skel.widgets.Path", {
         getCommandRegisterShape : function(winId){
             return winId + this.SEP_COMMAND +"registerShape";
         },
-        
+
         /**
          * Returns the command for obtaining the unique identifier of a top level object.
          * @return {String} command for obtaining the unique identifier of a top level object.
@@ -142,7 +144,7 @@ qx.Class.define("skel.widgets.Path", {
         getCommandRegisterView : function(){
             return this.BASE_PATH + this.VIEW_MANAGER + this.SEP_COMMAND + "registerView";
         },
-        
+
         /**
          * Returns the command for getting a list of available data to load.
          * @return {String} command for getting a list of available data to load.
@@ -150,7 +152,7 @@ qx.Class.define("skel.widgets.Path", {
         getCommandLoadData : function(){
             return this.BASE_PATH + this.DATA_LOADER + this.SEP_COMMAND + "getData";
         },
-            
+
         /**
          * Returns the command for loading selected data.
          * @return {String} command for loading selected data.
@@ -158,7 +160,7 @@ qx.Class.define("skel.widgets.Path", {
         getCommandDataLoaded : function(){
             return this.BASE_PATH + this.VIEW_MANAGER + this.SEP_COMMAND + "dataLoaded";
         },
-        
+
         /**
          * Returns the command for changing a window location.
          * @return {String} command for changing a window location.
@@ -166,7 +168,7 @@ qx.Class.define("skel.widgets.Path", {
         getCommandMoveWindow : function(){
             return this.BASE_PATH + this.VIEW_MANAGER + this.SEP_COMMAND + "moveWindow";
         },
-        
+
         /**
          * Returns the command for indicating which object the animator should control.
          * @return {String} command for linking the animator with a controlled object.
@@ -174,7 +176,7 @@ qx.Class.define("skel.widgets.Path", {
         getCommandLinkAnimator : function(){
             return this.BASE_PATH + this.VIEW_MANAGER + this.SEP_COMMAND + "linkAnimator";
         },
-        
+
         /**
          * Returns the command for resetting (emptying) the layout.
          * @return {String} command for resetting the layout.
@@ -182,7 +184,7 @@ qx.Class.define("skel.widgets.Path", {
         getCommandClearLayout : function(){
             return this.BASE_PATH + this.VIEW_MANAGER + this.SEP_COMMAND + "clearLayout";
         },
-        
+
         /**
          * Returns the command to register snapshots.
          * @return {String} command for registering snapshots.
@@ -190,7 +192,7 @@ qx.Class.define("skel.widgets.Path", {
         getCommandRegisterSnapshots : function(){
             return this.BASE_PATH + this.VIEW_MANAGER + this.SEP_COMMAND + "registerSnapshots";
         },
-        
+
         /**
          * Returns the command for resizing the number of rows/columns in the layout.
          * @return {String} command for resizing the layout.
@@ -198,7 +200,7 @@ qx.Class.define("skel.widgets.Path", {
         getCommandSetLayoutSize : function(){
             return this.BASE_PATH + this.LAYOUT_MANAGER + this.SEP_COMMAND + "setLayoutSize";
         },
-        
+
         /**
          * Returns the command for updating the plug-in that is displayed.
          * @return {String} command for updating the displayed plug-in.
@@ -206,7 +208,7 @@ qx.Class.define("skel.widgets.Path", {
         getCommandSetPlugin : function(){
             return this.BASE_PATH + this.VIEW_MANAGER + this.SEP_COMMAND + "setPlugin";
         },
-        
+
         /**
          * Returns the command for updating a shape.
          * @return {String} command for updating a shape.


### PR DESCRIPTION
 This pull request is inherited from #163 and relative to the issue #70.  I created a class "SpectralSystems". Most of the methods are similar to "CoordinateSystems". Its usage in CARTA is a counterpart of "CoordinateSystems" for spectral coordinates.
At this stage, the class provides three basic options for a spectral coordinate, frequency, radio velocity and optical velocity. In UI part, it displayed in Image Settings > Canvas. The default selection is radio velocity. AstRender and cursor are synced with the selection.
In the future, the spectral system should support setting of units, Doppler types and rest frames. The information of rest frame should be displayed when Ast rendering.