### PR TITLE
Get the path of root in FileTree

### DIFF
--- a/carta/html5/common/skel/source/class/skel/widgets/IO/FileTreeMixin.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/IO/FileTreeMixin.js
@@ -70,11 +70,10 @@ qx.Mixin.define("skel.widgets.IO.FileTreeMixin", {
                 }
                 else if ( fileName == ".."){
                     //Strip off child from path, and make that the new text.
-                    var lastSepIndex = this.m_path.lastIndexOf( path.SEP );
-                    if ( lastSepIndex >= 0 ){
-                        var parentPath = this.m_path.substr(0, lastSepIndex );
-                        dirPath = parentPath;
-                    }
+                    // lastIndexOf should larger then 1 ( means the path of root "/")
+                    var lastSepIndex = Math.max( 1, this.m_path.lastIndexOf( path.SEP ));
+                    var parentPath = this.m_path.substr(0, lastSepIndex );
+                    dirPath = parentPath;
                 }
                 else if ( this._isDirectory( fileName )){
                     //If the node is a directory, add the directory to the base path.


### PR DESCRIPTION
This pull request fixes the problem that the filetree couldn't access the root. By making sure the index using to strip larger than 1, the "/" can be conserved in the string of path.