### PR TITLE
Menu bar button icon fix (minor UI adjustment)

### DIFF
--- a/carta/html5/common/skel/source/class/skel/widgets/Util.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Util.js
@@ -140,7 +140,7 @@ qx.Class.define("skel.widgets.Util", {
             var label = cmd.getLabel();
             var button = new qx.ui.menu.Button( label );
             if ( tool ){
-                button = new qx.ui.toolbar.MenuButton( label );
+                button = new qx.ui.toolbar.Button( label );
             }
             button.addListener( "execute", function(){
                 this.doAction( value, cb );

--- a/carta/html5/common/skel/source/class/skel/widgets/Util.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Util.js
@@ -138,10 +138,7 @@ qx.Class.define("skel.widgets.Util", {
          */
         makeButton : function( cmd, cb, tool, value){
             var label = cmd.getLabel();
-            var button = new qx.ui.menu.Button( label );
-            if ( tool ){
-                button = new qx.ui.toolbar.Button( label );
-            }
+            var button = new qx.ui.toolbar.Button( label );
             button.addListener( "execute", function(){
                 this.doAction( value, cb );
             }, cmd );


### PR DESCRIPTION
Minor UI fix to change button icons for Save/Pan Reset/Zoom Reset.
These are currently shown as drop-down buttons in the menu bar, however they are actually functions and have no children so they should be just simple buttons.

The change is illustrated in the attached image.
![cartamenubar](https://user-images.githubusercontent.com/20866295/27491709-a98d2abc-5800-11e7-9bfe-d7976fa51843.png)