### PR TITLE
Fix bugs about hiding & fix related possible crash

### DIFF
--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -272,6 +272,9 @@ QString DataSource::_getCursorText(bool isAutoClip, double minPercent, double ma
         }
         out << "\n";
 
+        QString fileName = m_fileName.split("/").last();
+        out << fileName;
+
         str.replace( "\n", "<br />" );
     }
     return str;

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -455,7 +455,7 @@ std::vector< std::shared_ptr<Carta::Lib::Image::ImageInterface> > LayerGroup::_g
     int startIndex = _getIndexCurrent();
     for ( int i = 0; i < dataCount; i++ ){
         int dIndex = (startIndex + i) % dataCount;
-        if ( m_children[dIndex]->_isVisible() ){
+        if ( dIndex > -1 && m_children[dIndex]->_isVisible() ){
             images.push_back( m_children[dIndex]->_getImage());
         }
     }

--- a/carta/html5/common/skel/source/class/skel/widgets/Window/DisplayWindowImage.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Window/DisplayWindowImage.js
@@ -508,8 +508,8 @@ qx.Class.define("skel.widgets.Window.DisplayWindowImage", {
             this.m_content.add( this.m_viewContent, {flex:1} );
             if ( this.m_statisticsVisible ){
                 this.m_content.add( this.m_statLabel );
-                this.m_content.add(this.m_fileLabel);
-                this._updateFileLabel();
+                // this.m_content.add(this.m_fileLabel);
+                // this._updateFileLabel();
             }
 
             if ( this.m_controlsVisible ){


### PR DESCRIPTION
This pull request fix two minor bugs.
1. CARTA crashed after hiding all images (more than two). This caused by the fault index.
2. The filename displayed in cursor didn't synchronize with the image. I moved the process from js to cpp so that it can be synced by controller.