### PR TITLE
Revert "Menu bar button icon fix (minor UI adjustment)"

### DIFF
--- a/carta/html5/common/skel/source/class/skel/widgets/Util.js
+++ b/carta/html5/common/skel/source/class/skel/widgets/Util.js
@@ -138,7 +138,10 @@ qx.Class.define("skel.widgets.Util", {
          */
         makeButton : function( cmd, cb, tool, value){
             var label = cmd.getLabel();
-            var button = new qx.ui.toolbar.Button( label );
+            var button = new qx.ui.menu.Button( label );
+            if ( tool ){
+                button = new qx.ui.toolbar.MenuButton( label );
+            }
             button.addListener( "execute", function(){
                 this.doAction( value, cb );
             }, cmd );


### PR DESCRIPTION
Reverts CARTAvis/carta#175

After testing on 
Mac, Qt 5.3 & Qt 5.7
Linux, Qt 5.6
There is are two side effects, 
1. right click of mouse becomes not working. 
2. Clicking on Data/Session on menubar will not open their menu.

Here is the screenshot of the log, 

![default](https://user-images.githubusercontent.com/5940941/28098700-63636b8e-66ea-11e7-937c-0e88d239f064.png)

So just revert it first. @JamieDass, I'm sorry that I test it late, I was waiting for fixes of travis-ci.  


