### PR TITLE
Fix for broken plugins in Travis-CI builds (missing libgsl.19.dylib)

### DIFF
--- a/carta/scripts/ci_mac_common.sh
+++ b/carta/scripts/ci_mac_common.sh
@@ -85,8 +85,15 @@ function installqt() {
 
 function installgsl() {
 su $SUDO_USER <<EOF
-brew install https://github.com/CARTAvis/homebrew-tap/releases/download/0.1.3/gsl-2.3.el_capitan.bottle.tar.gz
-brew link --overwrite gsl
+# brew install https://github.com/CARTAvis/homebrew-tap/releases/download/0.1.3/gsl-2.3.el_capitan.bottle.tar.gz
+# brew link --overwrite gsl
+curl -O -L http://ftp.gnu.org/gnu/gsl/gsl-2.3.tar.gz
+tar xvfz gsl-2.3.tar.gz > /dev/null
+mv gsl-2.3 gsl-2.3-src
+cd gsl-2.3-src
+./configure
+make
+sudo make install
 EOF
 }
 


### PR DESCRIPTION
Homebrew updated its gsl version to 2.4. This version no longer provides libgsl.19.dylib which is currently used by some other cached libraries in our Travis-CI setup. 
The result is that some plugins (e.g. profiler and image statistics) will fail to work in the final package.

A temporary workaround is to build the older gsl 2.3 from its source code instead.