### PR TITLE
Add CartaLib directory to libcore RPATH / RUNPATH to fix linker issue on Ubuntu 17.04

### DIFF
--- a/carta/cpp/core/core.pro
+++ b/carta/cpp/core/core.pro
@@ -342,6 +342,8 @@ INCLUDEPATH += $$absolute_path(../../../ThirdParty/rapidjson/include)
 #INCLUDEPATH += ../../../ThirdParty/qwt/include
 #LIBS += -L../../../ThirdParty/qwt/lib -lqwt
 
+QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/../CartaLib\''
+
 QWT_ROOT = $$absolute_path("../../../ThirdParty/qwt")
 INCLUDEPATH += $$QWT_ROOT/include
 unix:macx {

--- a/carta/cpp/desktop/desktop.pro
+++ b/carta/cpp/desktop/desktop.pro
@@ -26,9 +26,11 @@ RESOURCES = resources.qrc
 INCLUDEPATH += ../../../ThirdParty/rapidjson/include
 
 unix: LIBS += -L$$OUT_PWD/../core/ -lcore
+unix: LIBS += -L$$OUT_PWD/../CartaLib/ -lCartaLib
 DEPENDPATH += $$PROJECT_ROOT/core
+DEPENDPATH += $$PROJECT_ROOT/CartaLib
 
-QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/../core\''
+QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/../CartaLib:\$$ORIGIN/../core\''
 
 QWT_ROOT = $$absolute_path("../../../ThirdParty/qwt")
 unix:macx {

--- a/carta/cpp/desktop/desktop.pro
+++ b/carta/cpp/desktop/desktop.pro
@@ -26,11 +26,9 @@ RESOURCES = resources.qrc
 INCLUDEPATH += ../../../ThirdParty/rapidjson/include
 
 unix: LIBS += -L$$OUT_PWD/../core/ -lcore
-unix: LIBS += -L$$OUT_PWD/../CartaLib/ -lCartaLib
 DEPENDPATH += $$PROJECT_ROOT/core
-DEPENDPATH += $$PROJECT_ROOT/CartaLib
 
-QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/../CartaLib:\$$ORIGIN/../core\''
+QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/../core\''
 
 QWT_ROOT = $$absolute_path("../../../ThirdParty/qwt")
 unix:macx {


### PR DESCRIPTION
Since version 2.28, `ld` (on Debian and possibly other Linux systems) creates a RUNPATH instead of an RPATH (in response to [this issue](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=835859)). Because RPATH and RUNPATH are [resolved differently](https://blog.qt.io/blog/2011/10/28/rpath-and-runpath/), this in combination with the way that `libcore.so` is built makes it impossible to run the CARTA executable from the build directory on Ubuntu 17.04 (without making more additions to LD_LIBRARY_PATH at runtime) because the executable cannot find `libCartaLib.so`.

This commit fixes the link from `libcore.so` to `libCartaLib.so`, which fixes the issue on Ubuntu 17.04, and does not appear to impact the build on e.g. Ubuntu 16.04, which uses an older `ld` which creates RPATHs rather than RUNPATHs.

I'm not sure if this change has any impact on the final packaging process, and it has not been tested on OSX.