### PR TITLE
Remove hover behaviour for regions

### DIFF
--- a/carta/cpp/core/Data/Region/Region.cpp
+++ b/carta/cpp/core/Data/Region/Region.cpp
@@ -15,7 +15,6 @@ namespace Carta {
 namespace Data {
 
 const QString Region::ACTIVE = "active";
-const QString Region::HOVERED = "hovered";
 const QString Region::COLOR = "color";
 const QString Region::REGION_TYPE = "regionType";
 const QString Region::CUSTOM_NAME = "customName";
@@ -137,19 +136,6 @@ void Region::handleDragStart( const QPointF & pt ) {
 	}
 }
 
-void Region::handleHover( const QPointF& pt ){
-	//Only active shapes participate in user events
-	if ( isActive() ){
-		bool hovered = false;
-		if ( m_shape->isPointInside( pt ) ){
-			hovered = true;
-		}
-		setHovered( hovered );
-	}
-}
-
-
-
 void Region::handleTouch( const QPointF& pt ){
 	//Only active shapes participate in user events
 	if ( isActive() ){
@@ -181,7 +167,6 @@ void Region::_initializeState(){
 	m_state.insertValue<bool>( Util::SELECTED, true );
 	m_state.insertValue<bool>( CUSTOM_NAME, false );
 	m_state.insertValue<bool>( ACTIVE, true );
-	m_state.insertValue<bool>( HOVERED, true );
         m_state.insertValue<QString>( Util::COLOR, "" );
 	m_state.insertValue<QString>( Util::NAME, "");
 	m_state.insertValue<QString>( Util::ID, getId() );
@@ -200,11 +185,6 @@ bool Region::isDraggable() const {
 
 bool Region::isEditMode() const {
 	return m_shape->isEditMode();
-}
-
-
-bool Region::isHovered() const {
-	return m_state.getValue<bool>( HOVERED );
 }
 
 
@@ -247,18 +227,6 @@ void Region::setEditMode( bool editMode ) {
 
 bool Region::setHeight( double /*value*/ ){
 	return false;
-}
-
-bool Region::setHovered( bool hovered ) {
-	bool oldHovered = isHovered();
-	bool redrawNeeded = false;
-	if ( hovered != oldHovered ){
-		m_state.setValue<bool>( HOVERED, hovered );
-		m_state.flushState();
-		m_shape->setHovered( hovered );
-		redrawNeeded = true;
-	}
-	return redrawNeeded;
 }
 
 void Region::setModel( Carta::Lib::Regions::RegionBase* /*model*/ ){
@@ -342,7 +310,6 @@ void Region::_updateName(){
 void Region::_updateShapeFromState(){
 	m_shape->setActive( isActive() );
 	m_shape->setSelected( isSelected() );
-	m_shape->setHovered( isHovered() );
 }
 
 Region::~Region(){

--- a/carta/cpp/core/Data/Region/Region.h
+++ b/carta/cpp/core/Data/Region/Region.h
@@ -119,12 +119,6 @@ public:
 	virtual void handleDragStart( const QPointF & pt );
 
 	/**
-	 * Notification of a hover event.
-	 * @param pt - the current location of the mouse.
-	 */
-	virtual void handleHover( const QPointF& pt );
-
-	/**
 	 * Notification of a click event.
 	 * @param pt - the current location of the mouse.
 	 */
@@ -159,12 +153,6 @@ public:
 	 * @return - true if the shape is being edited; false, otherwise.
 	 */
 	virtual bool isEditMode() const;
-
-	/**
-	 * Returns whether or not the shape is being hovered.
-	 * @return - true if the shape is hovered; false otherwise.
-	 */
-	virtual bool isHovered() const;
 
 	/**
 	 * Returns whether or not the shape is selected.
@@ -210,14 +198,6 @@ public:
 	 * @return - true if the height was successfully set; false, otherwise.
 	 */
 	virtual bool setHeight( double value );
-
-	/**
-	 * Sets whether or not the shape is in a hovered state.
-	 * @param hovered - true if the shape is hovered; false otherwise.
-	 * @return - true if the underlying VG graphics need to be updated; false,
-	 * 	otherwise.
-	 */
-	virtual bool setHovered( bool hovered );
 
 	/**
 	 * Set the underlying model for the region.
@@ -328,7 +308,6 @@ protected:
 
 	const static QString ACTIVE;
 	const static QString CUSTOM_NAME;
-	const static QString HOVERED;
         const static QString COLOR;
 	const static QString REGION_TYPE;
 	const static int SIGNIFICANT_DIGITS;

--- a/carta/cpp/core/Data/Region/RegionControls.cpp
+++ b/carta/cpp/core/Data/Region/RegionControls.cpp
@@ -228,30 +228,6 @@ bool RegionControls::_handleDrag( const Carta::Lib::InputEvents::Drag2Event& ev,
 	return validDrag;
 }
 
-bool RegionControls::_handleHover( const Carta::Lib::InputEvents::HoverEvent& ev,
-		const QPointF& imagePt ){
-	bool validHover = false;
-	if ( ev.isValid() ){
-		validHover = true;
-		if ( m_regionEdit ){
-			m_regionEdit->handleHover( imagePt );
-			emit regionsChanged();
-		}
-		else {
-			int regionCount = m_regions.size();
-			for ( int i = 0; i < regionCount; i++ ){
-				m_regions[i]->handleHover( imagePt );
-			}
-			if ( regionCount > 0 ){
-				emit regionsChanged();
-			}
-		}
-
-	}
-	return validHover;
-}
-
-
 bool RegionControls::_handleTouch( const Carta::Lib::InputEvents::TouchEvent& ev,
 		const QPointF& imagePt ){
 	bool validTap = false;
@@ -486,20 +462,18 @@ bool RegionControls::isAutoSelect() const {
 }
 
 void RegionControls::_onInputEvent(InputEvent & ev, const QPointF& imagePt ){
-	if ( !_handleHover( Carta::Lib::InputEvents::HoverEvent( ev ), imagePt ) ) {
-		if ( !_handleTapDouble( Carta::Lib::InputEvents::DoubleTapEvent( ev ), imagePt ) ) {
-			if ( !_handleTouch( Carta::Lib::InputEvents::TouchEvent( ev ), imagePt ) ){
-				if( !_handleDrag( Carta::Lib::InputEvents::Drag2Event(ev), imagePt) ){
-					//qWarning() << "RegionControls:: unhandled event: "<<ev.type();
-				}
-			}
-		}
-		else {
-			//Note that we are doing this so if we are editing a polygon region and
-			//closing it with a double click, the image will not also be panned.
-			ev.setConsumed();
-		}
-	}
+        if ( !_handleTapDouble( Carta::Lib::InputEvents::DoubleTapEvent( ev ), imagePt ) ) {
+        	if ( !_handleTouch( Carta::Lib::InputEvents::TouchEvent( ev ), imagePt ) ){
+                	if( !_handleDrag( Carta::Lib::InputEvents::Drag2Event(ev), imagePt) ){
+                        	//qWarning() << "RegionControls:: unhandled event: "<<ev.type();
+                        }
+                }
+        }
+        else {
+        	//Note that we are doing this so if we are editing a polygon region and
+	       	//closing it with a double click, the image will not also be panned.
+        	ev.setConsumed();
+        }
 }
 
 void RegionControls::refreshState(){

--- a/carta/cpp/core/Data/Region/RegionControls.h
+++ b/carta/cpp/core/Data/Region/RegionControls.h
@@ -197,7 +197,6 @@ private:
 	void _initializeStatics();
 
 	bool _handleDrag( const Carta::Lib::InputEvents::Drag2Event& ev, const QPointF& imagePt );
-	bool _handleHover( const Carta::Lib::InputEvents::HoverEvent& ev, const QPointF& imagePt );
 	bool _handleTapDouble( const Carta::Lib::InputEvents::DoubleTapEvent& ev, const QPointF& imagePt );
 	bool _handleTouch( const Carta::Lib::InputEvents::TouchEvent& ev, const QPointF& imagePt );
 

--- a/carta/cpp/core/Shape/ShapeBase.cpp
+++ b/carta/cpp/core/Shape/ShapeBase.cpp
@@ -107,10 +107,6 @@ bool ShapeBase::isEditMode() const {
 	return m_editMode;
 }
 
-bool ShapeBase::isHovered() const{
-	return m_hovered;
-}
-
 bool ShapeBase::isPointInside( const QPointF & pt ) const {
 	Q_UNUSED( pt );
 	return false;
@@ -137,14 +133,6 @@ void ShapeBase::setEditMode( bool editMode ){
 	m_editMode = editMode;
 	if ( oldEditMode != editMode ) {
 		editModeChanged();
-	}
-}
-
-void ShapeBase::setHovered( bool value ){
-	m_hovered = value;
-	int controlCount = m_controlPoints.size();
-	for ( int i = 0; i < controlCount; i++ ){
-		m_controlPoints[i]->setActive( value );
 	}
 }
 

--- a/carta/cpp/core/Shape/ShapeBase.h
+++ b/carta/cpp/core/Shape/ShapeBase.h
@@ -106,12 +106,6 @@ public:
 	bool isEditMode() const;
 
 	/**
-	 * Returns whether or not the shape is being hovered.
-	 * @return - true if the shape is hovered; false otherwise.
-	 */
-	bool isHovered() const;
-
-	/**
 	 * Returns whether or not the point is inside the shape or not.
 	 * @return - true if the point is inside the shape; false otherwise.
 	 */
@@ -158,14 +152,6 @@ public:
 	void setEditMode( bool editMode );
 
 	/**
-	 * Sets whether or not the shape is in a hovered state.
-	 * @param hovered - true if the shape is hovered; false otherwise.
-	 */
-	/// Default is to return false. Reimplement if the shape needs to be redrawn as
-	/// a result of changing hover state.
-	virtual void setHovered( bool value );
-
-	/**
 	 * Set a model for the shape.
 	 * @param json - the shape model (corner points, center, etc).
 	 */
@@ -204,7 +190,6 @@ private:
 	bool m_active = true;
 	bool m_deletable = false;
 	bool m_editMode = false;
-	bool m_hovered = false;
 	QString m_cursor;
 	bool m_selected = false;
 	void * m_userData = nullptr;

--- a/carta/cpp/core/Shape/ShapeEllipse.cpp
+++ b/carta/cpp/core/Shape/ShapeEllipse.cpp
@@ -66,8 +66,8 @@ Carta::Lib::VectorGraphics::VGList ShapeEllipse::getVGList() const {
 
 	//Only draw the rest if we are not creating the region.
 	if ( !isEditMode() ){
-		//Draw the control points and show the outline if hovered or selected
-		if ( isHovered() || isSelected()){
+		//Draw the control points and show the outline if selected
+		if ( isSelected()){
 			comp.append < vge::SetPen > ( rectPen );
 			comp.append < vge::DrawRect > ( m_shadowRect );
 			comp.append < vge::SetPen > ( pen );

--- a/carta/cpp/core/Shape/ShapePolygon.cpp
+++ b/carta/cpp/core/Shape/ShapePolygon.cpp
@@ -63,7 +63,7 @@ Carta::Lib::VectorGraphics::VGList ShapePolygon::getVGList() const {
 	//Only draw the rest if we are not creating the region.
 	if ( !isEditMode() ){
 		//Draw the outline box; use a different style if it is selected.
-	        if ( isSelected() || isHovered() ){
+	        if ( isSelected() ){
 			comp.append < vge::SetPen > ( rectPen );
 			QRectF shadowRect = m_shadowPolygon.boundingRect();
 			comp.append < vge::DrawRect > ( shadowRect );
@@ -71,7 +71,7 @@ Carta::Lib::VectorGraphics::VGList ShapePolygon::getVGList() const {
 		}
 
 		//Draw the control points
-		if ( isHovered() || isSelected()){
+		if ( isSelected()){
 			int cornerCount = m_controlPoints.size();
 			for ( int i = 0; i < cornerCount; i++ ){
 				comp.appendList( m_controlPoints[i]->getVGList() );

--- a/carta/cpp/core/Shape/ShapeRectangle.cpp
+++ b/carta/cpp/core/Shape/ShapeRectangle.cpp
@@ -60,7 +60,7 @@ Carta::Lib::VectorGraphics::VGList ShapeRectangle::getVGList() const {
 	//Only draw the rest if we are not creating the region.
 	if ( !isEditMode() ){
 		//Draw the control points
-		if ( isHovered() || isSelected()){
+		if ( isSelected()){
 			int cornerCount = m_controlPoints.size();
 			for ( int i = 0; i < cornerCount; i++ ){
 				comp.appendList( m_controlPoints[i]->getVGList() );

--- a/carta/scripts/buildcasa.sh
+++ b/carta/scripts/buildcasa.sh
@@ -4,6 +4,8 @@
 ## java/jre, pgplot, dbus, qt4.
 ## qwt has been removed
 
+echo "execute buildcasa.sh"
+
 if [ -z ${cartawork+x} ]; then
 	export cartawork=`pwd`
 fi


### PR DESCRIPTION
This change removes the hover behaviour for regions. Previously, hovering over a region would highlight its control points etc but at a performance cost. This behaviour does not really seem necessary.
This change resolves the cursor lag reported in [issue #105](https://github.com/CARTAvis/carta/issues/105)