### PR TITLE
Preserve the directorty path accessed at the last time opening filetree

### DIFF
--- a/carta/cpp/core/Data/DataLoader.cpp
+++ b/carta/cpp/core/Data/DataLoader.cpp
@@ -42,8 +42,6 @@ bool DataLoader::m_registered =
         Carta::State::ObjectManager::objectManager()->registerClass ( CLASS_NAME,
                                                    new DataLoader::Factory());
 
-QString DataLoader::lastAccessedDir = "";
-
 DataLoader::DataLoader( const QString& path, const QString& id ):
     CartaObject( CLASS_NAME, path, id ){
     _initCallbacks();
@@ -60,9 +58,10 @@ QString DataLoader::getData(const QString& dirName, const QString& sessionId) {
     }
 
     if ( rootDirName.length() == 0 || dirName == DataLoader::fakeRootDirName){
-        if ( lastAccessedDir.length() == 0 ) lastAccessedDir = getRootDir(sessionId);
+        if ( lastAccessedDir.length() == 0 ){
+            lastAccessedDir = getRootDir(sessionId);
+        }
         rootDirName = lastAccessedDir;
-        // rootDirName = getRootDir(sessionId);
     }
     else {
         rootDirName = getFile( dirName, sessionId );

--- a/carta/cpp/core/Data/DataLoader.cpp
+++ b/carta/cpp/core/Data/DataLoader.cpp
@@ -42,6 +42,7 @@ bool DataLoader::m_registered =
         Carta::State::ObjectManager::objectManager()->registerClass ( CLASS_NAME,
                                                    new DataLoader::Factory());
 
+QString DataLoader::lastAccessedDir = "";
 
 DataLoader::DataLoader( const QString& path, const QString& id ):
     CartaObject( CLASS_NAME, path, id ){
@@ -59,11 +60,14 @@ QString DataLoader::getData(const QString& dirName, const QString& sessionId) {
     }
 
     if ( rootDirName.length() == 0 || dirName == DataLoader::fakeRootDirName){
-        rootDirName = getRootDir(sessionId);
+        if ( lastAccessedDir.length() == 0 ) lastAccessedDir = getRootDir(sessionId);
+        rootDirName = lastAccessedDir;
+        // rootDirName = getRootDir(sessionId);
     }
     else {
         rootDirName = getFile( dirName, sessionId );
     }
+    lastAccessedDir = rootDirName;
     QDir rootDir(rootDirName);
     QJsonObject rootObj;
 

--- a/carta/cpp/core/Data/DataLoader.h
+++ b/carta/cpp/core/Data/DataLoader.h
@@ -85,7 +85,7 @@ private:
 
     static bool m_registered;
 
-    static QString lastAccessedDir;
+    QString lastAccessedDir = "";
 
     class Factory;
 

--- a/carta/cpp/core/Data/DataLoader.h
+++ b/carta/cpp/core/Data/DataLoader.h
@@ -85,6 +85,8 @@ private:
 
     static bool m_registered;
 
+    static QString lastAccessedDir;
+
     class Factory;
 
     const static QString DIR;


### PR DESCRIPTION
This PR preserves the directory path of filetree when opening filebrowser and uses it to replace the default path. @kswang1029 thinks that this is more convenient.