### PR TITLE
making point region highlighted when selected and other cosmetics tweaks

### DIFF
--- a/carta/cpp/CartaLib/Regions/Point.cpp
+++ b/carta/cpp/CartaLib/Regions/Point.cpp
@@ -37,7 +37,7 @@ bool Point::isPointInsideUnion( const RegionPointV & pts ) const {
 
 QRectF Point::outlineBox() const {
 	QRectF box;
-	const int SMALL_SIZE = 11;
+	const int SMALL_SIZE = 10;
 	double topLeftX = m_point.x() - SMALL_SIZE / 2;
 	double topLeftY = m_point.y() - SMALL_SIZE / 2;
 	box.setX( topLeftX );

--- a/carta/cpp/CartaLib/Regions/Point.cpp
+++ b/carta/cpp/CartaLib/Regions/Point.cpp
@@ -37,7 +37,7 @@ bool Point::isPointInsideUnion( const RegionPointV & pts ) const {
 
 QRectF Point::outlineBox() const {
 	QRectF box;
-	const int SMALL_SIZE = 30;
+	const int SMALL_SIZE = 11;
 	double topLeftX = m_point.x() - SMALL_SIZE / 2;
 	double topLeftY = m_point.y() - SMALL_SIZE / 2;
 	box.setX( topLeftX );

--- a/carta/cpp/core/Shape/ControlPointEditable.cpp
+++ b/carta/cpp/core/Shape/ControlPointEditable.cpp
@@ -28,14 +28,20 @@ QSizeF ControlPointEditable::getSize() const {
 
 Carta::Lib::VectorGraphics::VGList ControlPointEditable::getVGList() const {
 	Carta::Lib::VectorGraphics::VGComposer comp;
+	QPen pen = outlinePen;
+	pen.setCosmetic(true);
 	QRectF rect( m_pos.x() - m_size / 2, m_pos.y() - m_size / 2, m_size, m_size );
 	QColor color = m_fillColor;
 	if ( isSelected() ) {
-		comp.append < vge::FillRect > ( rect, color );
+		//comp.append < vge::FillRect > ( rect, color );
+		comp.append < vge::SetPen > ( pen );
+		comp.append < vge::DrawRect > ( rect );
 	}
 	else {
 		color.setAlpha( 128 );
-		comp.append < vge::FillRect > ( rect, color );
+		//comp.append < vge::FillRect > ( rect, color );
+		comp.append < vge::SetPen > ( pen );
+		comp.append < vge::DrawRect > ( rect );
 	}
 	return comp.vgList();
 }

--- a/carta/cpp/core/Shape/ControlPointEditable.h
+++ b/carta/cpp/core/Shape/ControlPointEditable.h
@@ -104,7 +104,7 @@ private:
     std::function < void (bool) > m_cb;
     QPointF m_pos;
     QColor m_fillColor;
-    double m_size = 7;
+    double m_size = 9;
 };
 
 }

--- a/carta/cpp/core/Shape/ControlPointEditable.h
+++ b/carta/cpp/core/Shape/ControlPointEditable.h
@@ -104,7 +104,7 @@ private:
     std::function < void (bool) > m_cb;
     QPointF m_pos;
     QColor m_fillColor;
-    double m_size = 11;
+    double m_size = 7;
 };
 
 }

--- a/carta/cpp/core/Shape/ShapeBase.cpp
+++ b/carta/cpp/core/Shape/ShapeBase.cpp
@@ -4,9 +4,9 @@ namespace Carta {
 
 namespace Shape{
 
-const QPen ShapeBase::shadowPen = QPen( QBrush( QColor( 255, 106, 0 ) ), 3 );
-const QBrush ShapeBase::shadowBrush = QBrush( QColor( 255, 106, 0 ) );
-const QPen ShapeBase::outlinePen = QPen( QBrush( QColor( 102, 153, 204 ) ), 2 );
+const QPen ShapeBase::shadowPen = QPen( QBrush( QColor( 255, 0, 255 ) ), 2 );
+const QBrush ShapeBase::shadowBrush = QBrush( QColor( 0, 255, 0 ) );
+const QPen ShapeBase::outlinePen = QPen( QBrush( QColor( 0, 255, 0 ) ), 1 );
 
 ShapeBase::ShapeBase( QObject* parent ):
 		QObject( parent ),

--- a/carta/cpp/core/Shape/ShapeBase.cpp
+++ b/carta/cpp/core/Shape/ShapeBase.cpp
@@ -6,7 +6,7 @@ namespace Shape{
 
 const QPen ShapeBase::shadowPen = QPen( QBrush( QColor( 255, 0, 255 ) ), 2 );
 const QBrush ShapeBase::shadowBrush = QBrush( QColor( 0, 255, 0 ) );
-const QPen ShapeBase::outlinePen = QPen( QBrush( QColor( 0, 255, 0 ) ), 1 );
+const QPen ShapeBase::outlinePen = QPen( QBrush( QColor( 0, 255, 0 ) ), 2 );
 
 ShapeBase::ShapeBase( QObject* parent ):
 		QObject( parent ),

--- a/carta/cpp/core/Shape/ShapePoint.cpp
+++ b/carta/cpp/core/Shape/ShapePoint.cpp
@@ -35,9 +35,9 @@ Carta::Lib::VectorGraphics::VGList ShapePoint::getVGList() const {
 	QBrush brush = Qt::NoBrush;
 
 	//Draw the basic polygon (exterior manipulation region of point)
-	comp.append < vge::SetPen > ( rectPen );
-	comp.append < vge::SetBrush > ( brush );
-	comp.append < vge::DrawEllipse > ( m_shadowRect );
+	//comp.append < vge::SetPen > ( rectPen );
+	//comp.append < vge::SetBrush > ( brush );
+	//comp.append < vge::DrawEllipse > ( m_shadowRect );
 
         //Draw crosshairs by calculating distance from center (Pythagorean theorem)
         QPointF center = m_shadowRect.center();
@@ -56,6 +56,14 @@ Carta::Lib::VectorGraphics::VGList ShapePoint::getVGList() const {
         comp.append < vge::DrawLine > ( topRight, QPointF( center.x()+innerRadius, center.y()+innerRadius ) );
         comp.append < vge::DrawLine > ( bottomRight, QPointF( center.x()+innerRadius, center.y()-innerRadius ) );
 
+	if ( !isEditMode() ){
+		if ( isSelected()){
+			comp.append < vge::SetPen > ( rectPen );
+			comp.append < vge::SetBrush > ( brush );
+			comp.append < vge::DrawEllipse > ( m_shadowRect );
+		}
+	}
+	
 	return comp.vgList();
 }
 

--- a/carta/cpp/core/Shape/ShapePoint.cpp
+++ b/carta/cpp/core/Shape/ShapePoint.cpp
@@ -26,9 +26,7 @@ QSizeF ShapePoint::getSize() const {
 Carta::Lib::VectorGraphics::VGList ShapePoint::getVGList() const {
 	Carta::Lib::VectorGraphics::VGComposer comp;
 	QPen pen = shadowPen;
-        // Set pen width 0 for precise presentation of point
-        // Width of zero indicates a cosmetic (i.e. zoom-independent) pen drawn 1px wide
-        pen.setWidth(0);
+        pen.setCosmetic(true);
         pen.setColor(m_color);
         QPen rectPen = outlinePen;
 	rectPen.setCosmetic(true);
@@ -61,6 +59,9 @@ Carta::Lib::VectorGraphics::VGList ShapePoint::getVGList() const {
 			comp.append < vge::SetPen > ( rectPen );
 			comp.append < vge::SetBrush > ( brush );
 			comp.append < vge::DrawEllipse > ( m_shadowRect );
+		}
+		else {
+			comp.append < vge::DrawEllipse > ( m_shadowRect );	
 		}
 	}
 	

--- a/carta/scripts/ci_mac_common.sh
+++ b/carta/scripts/ci_mac_common.sh
@@ -50,14 +50,9 @@ function installgfortran() {
 echo "install gfortran, start to backup travis-c++"
 mv /usr/local/include/c++ /usr/local/include/c++_backup # this folder is from homebrew's gcc49
 su $SUDO_USER <<EOF
-## now it is 7.1 we only use its gfortran which is also used by code
-if sw_vers -productVersion | grep 10.12 ; then
-  echo "it is 10.12"
-  brew install https://github.com/CARTAvis/homebrew-tap/releases/download/0.1.2/gcc-7.1.0.sierra.bottle.tar.gz
-else
-  echo "it is 10.11"
-  brew install https://github.com/CARTAvis/homebrew-tap/releases/download/0.1.2/gcc-7.1.0.el_capitan.bottle.tar.gz
-fi
+
+brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/3479e6239d3cd6b181229acb026d8424a035d045/Formula/gcc.rb
+
 EOF
 echo "resume travis-c++"
 mv /usr/local/include/c++_backup /usr/local/include/c++


### PR DESCRIPTION
Based on @JamieDass 's region cosmetics improvement of point region, this PR tries to make point region highlighted when being selected, like other shapes of region. Originally point region appears to be selected even if it is not. Attached image demonstrates the results. Colors are changed to high contrast and high saturation ones for better visibility. Line width is changed to thinner one. Control point is changed to smaller size. The size of the point region is also changed to smaller one. 

<img width="630" alt="screen shot 2017-08-22 at 9 40 41 pm" src="https://user-images.githubusercontent.com/20819712/29568743-df0dbf82-8783-11e7-805f-4d90535726de.png">


TODO: ideally the size of the control point and "point" region should be independent of image pixel size and image zoom level. Now they have fixed sizes. So when either image size is small (<100 px) or at high zoom level, the appearance of control point and "point" region will be too large. 

Note: commit 970d279 is only for making travis CI build successful.
