### PR TITLE
fix position offset of oblate ellipse region when dragging

### DIFF
--- a/carta/cpp/core/Shape/ShapeEllipse.cpp
+++ b/carta/cpp/core/Shape/ShapeEllipse.cpp
@@ -132,7 +132,7 @@ bool ShapeEllipse::isPointInside( const QPointF & pt ) const {
 void ShapeEllipse::_moveShadow( const QPointF& pt ){
 	// calculate offset to move the shadow polygon to match the un-edited shape
 	QRectF fixedRect = m_ellipseRegion->outlineBox();
-	QPointF alreadyMoved = m_shadowRect.topLeft() - fixedRect.topLeft();
+	QPointF alreadyMoved = m_shadowRect.center() - fixedRect.center();
 
 	// now move it by the amount of drag
 	QPointF totalDrag = pt - m_dragStart;


### PR DESCRIPTION
symptom: for oblate ellipse region, a position offset (equal to major axis) to the right of the cursor will be applied to the region when dragging. This issue is not seen in prolate ellipse region.

Root cause: it is due to the way how an oblate ellipse is defined in *void ShapeEllipse::_updateEllipseFromShadow()* The 90 degree rotation changes the position of the corners which are used in *void ShapeEllipse::_moveShadow( const QPointF& pt )* to move the region. Changing the reference point from *topLeft* to *center* fixes this issue. 