### PR TITLE
Cjhsu/histogram

### DIFF
--- a/carta/cpp/core/Data/Histogram/Histogram.cpp
+++ b/carta/cpp/core/Data/Histogram/Histogram.cpp
@@ -553,7 +553,7 @@ void Histogram::_initializeCallbacks(){
             double logMaxCount = qLn( maxBinCount ) / qLn(10);
             double percentage  = (binCount*1.0) / maxBinCount;
             double percentLogMax = percentage * logMaxCount;
-            int scaledBinCount = static_cast<int>( qPow(10, percentLogMax) );
+            int scaledBinCount = round( qPow(10, percentLogMax) );
             result = setBinCount( scaledBinCount );
         }
         else {
@@ -2059,7 +2059,7 @@ int Histogram::_toBinCount( double width ) const {
     double totalRange = maxRange-minRange;
     int count = m_state.getValue<int>(BIN_COUNT);
     // Use proper decimal to examine the error
-    if ( width > 0 && qAbs(totalRange/count-width) > m_errorMargin*pow(10, (int)log10(width)+1)){
+    if ( width > 0 && qAbs(totalRange/count-width) > m_errorMargin*pow(10, ceil(log10(width)))){
         count = qCeil( qAbs( maxRange - minRange)  / width);
     }
     return count;

--- a/carta/cpp/core/Data/Histogram/Histogram.cpp
+++ b/carta/cpp/core/Data/Histogram/Histogram.cpp
@@ -2161,6 +2161,9 @@ void Histogram::_updateColorSelection(){
 void Histogram::_updatePlots( ){
 	m_plotManager->clearData();
 	int dataCount = m_binDatas.size();
+    // The result is set by setHistogramResult()
+    // The result is computed from casacore::LatticeHistogram (in ImageHistogram.cpp)
+    // The values of bins are the middle points of each interval.
 	for ( int i = 0; i < dataCount; i++ ){
 		Carta::Lib::Hooks::HistogramResult result = m_binDatas[i]->getHistogramResult();
 		m_plotManager->addData( &result );

--- a/carta/cpp/core/Data/Histogram/Histogram.cpp
+++ b/carta/cpp/core/Data/Histogram/Histogram.cpp
@@ -505,6 +505,8 @@ void Histogram::_initializeDefaultState(){
 
     //Preferences - not image specific
     const int DEFAULT_BIN_COUNT = 25;
+    // Make the value consistent with the default setting of qwt.
+    const int DEFAULT_BIN_WIDTH = 40;
     m_state.insertValue<int>(BIN_COUNT, DEFAULT_BIN_COUNT );
     //Decide if the user has decided to override the maximum bin count.
     int histMaxBinCount = Globals::instance()->mainConfig()->getHistogramBinCountMax();
@@ -513,8 +515,7 @@ void Histogram::_initializeDefaultState(){
     }
 
     m_state.insertValue<int>(BIN_COUNT_MAX, histMaxBinCount );
-    double binWidth = _toBinWidth(DEFAULT_BIN_COUNT);
-    m_state.insertValue<double>(BIN_WIDTH, binWidth );
+    m_state.insertValue<double>(BIN_WIDTH, DEFAULT_BIN_WIDTH );
     m_state.insertValue<bool>(CLIP_APPLY, false );
     m_state.insertValue<bool>(CLIP_BUFFER, false);
     QString defaultStyle = m_graphStyles->getDefault();
@@ -1026,7 +1027,7 @@ void Histogram::_loadData( Controller* controller ){
         return;
     }
 
-    int binCount = m_state.getValue<int>(BIN_COUNT)+1;
+    int binCount = m_state.getValue<int>(BIN_COUNT);
     double minFrequency = -1;
     double maxFrequency = -1;
     QString rangeUnits = m_state.getValue<QString>(FREQUENCY_UNIT );
@@ -1988,6 +1989,8 @@ QString Histogram::setSignificantDigits( int digits ){
 }
 
 void Histogram::_setErrorMargin(){
+    // TODO: the error margin set here is not consistent with the definition
+    // of significant digits. It should be modified later.
     int significantDigits = m_state.getValue<int>(Util::SIGNIFICANT_DIGITS );
     m_errorMargin = 1.0/qPow(10,significantDigits);
 }
@@ -2053,8 +2056,10 @@ double Histogram::_toBinWidth( int count ) const {
 int Histogram::_toBinCount( double width ) const {
     double minRange = m_stateData.getValue<double>(CLIP_MIN );
     double maxRange = m_stateData.getValue<double>(CLIP_MAX);
-    int count = 0;
-    if ( width > 0 ){
+    double totalRange = maxRange-minRange;
+    int count = m_state.getValue<int>(BIN_COUNT);
+    // Use proper decimal to examine the error
+    if ( width > 0 && qAbs(totalRange/count-width) > m_errorMargin*pow(10, (int)log10(width)+1)){
         count = qCeil( qAbs( maxRange - minRange)  / width);
     }
     return count;

--- a/carta/cpp/core/Data/Histogram/Render/HistogramRenderRequest.cpp
+++ b/carta/cpp/core/Data/Histogram/Render/HistogramRenderRequest.cpp
@@ -42,11 +42,11 @@ QString HistogramRenderRequest::getFileName() const {
 	return m_fileName;
 }
 
-int HistogramRenderRequest::getFrequencyMax() const {
+double HistogramRenderRequest::getFrequencyMax() const {
 	return m_maxFrequency;
 }
 
-int HistogramRenderRequest::getFrequencyMin() const {
+double HistogramRenderRequest::getFrequencyMin() const {
 	return m_minFrequency;
 }
 
@@ -65,14 +65,14 @@ std::shared_ptr<Carta::Lib::Image::ImageInterface> HistogramRenderRequest::getIm
 	return m_image;
 }
 
-int HistogramRenderRequest::getIntensityMax() const {
+double HistogramRenderRequest::getIntensityMax() const {
 	return m_maxIntensity;
 }
 
 
-	int HistogramRenderRequest::getIntensityMin() const {
-		return m_minIntensity;
-	}
+double HistogramRenderRequest::getIntensityMin() const {
+	return m_minIntensity;
+}
 
 
 QString HistogramRenderRequest::getRangeUnits() const {
@@ -102,4 +102,3 @@ HistogramRenderRequest::~HistogramRenderRequest(){
 }
 }
 }
-

--- a/carta/cpp/core/Data/Histogram/Render/HistogramRenderRequest.h
+++ b/carta/cpp/core/Data/Histogram/Render/HistogramRenderRequest.h
@@ -87,25 +87,25 @@ public:
 	 * Get the maximum intensity value for the histogram.
 	 * @return - the maximum intensity value for the histogram.
 	 */
-	int getIntensityMax() const;
+	double getIntensityMax() const;
 
 	/**
 	 * Get the minimum intensity value for the histogram.
 	 * @return - the minimum intensity value for the histogram.
 	 */
-	int getIntensityMin() const;
+	double getIntensityMin() const;
 
 	/**
 	 * Return the maximum frequency for the histogram.
 	 * @return - the maximum frequency for the histogram.
 	 */
-	int getFrequencyMax() const;
+	double getFrequencyMax() const;
 
 	/**
 	 * Return the minimum frequency for the histogram.
 	 * @return - the minimum frequency for the histogram.
 	 */
-	int getFrequencyMin() const;
+	double getFrequencyMin() const;
 
 	/**
 	 * Return intensity units.
@@ -155,6 +155,3 @@ private:
 };
 }
 }
-
-
-

--- a/carta/cpp/core/Data/Histogram/Render/HistogramRenderWorker.cpp
+++ b/carta/cpp/core/Data/Histogram/Render/HistogramRenderWorker.cpp
@@ -86,7 +86,8 @@ int HistogramRenderWorker::computeHist(){
     QDataStream dataStream( &file );
     dataStream << m_result;
     file.close();
-    exit(0);
+    // Please refer the comment in the ProfileRenderWorker.cpp
+    _exit(EXIT_SUCCESS);
     return 0;
 }
 
@@ -95,4 +96,3 @@ HistogramRenderWorker::~HistogramRenderWorker(){
 }
 }
 }
-

--- a/carta/cpp/core/Data/Profile/Render/ProfileRenderWorker.cpp
+++ b/carta/cpp/core/Data/Profile/Render/ProfileRenderWorker.cpp
@@ -81,7 +81,9 @@ int ProfileRenderWorker::computeProfile(){
     QDataStream dataStream( &file );
     dataStream << m_result;
     file.close();
-    exit(0);
+    // If using "exit()", this child process will become a zombie process in CARTA
+    // We tried to use "wait()" and "waitpid()" to clean the dead process, but failed.
+    _exit(EXIT_SUCCESS);
     return 0;
 }
 

--- a/carta/cpp/core/Plot2D/Plot.cpp
+++ b/carta/cpp/core/Plot2D/Plot.cpp
@@ -33,7 +33,6 @@ Plot::Plot( QWidget* parent):
     m_visible = false;
 
     setCanvasBackground( Qt::white );
-    setAxisAutoScale( m_axisLocationY, false );
     setAutoReplot( false );
 }
 
@@ -364,4 +363,3 @@ Plot::~Plot(){
 
 }
 }
-	

--- a/carta/cpp/core/Plot2D/Plot2DHistogram.cpp
+++ b/carta/cpp/core/Plot2D/Plot2DHistogram.cpp
@@ -115,10 +115,11 @@ void Plot2DHistogram::setData ( std::vector<std::pair<double,double> > dataVecto
     m_maxValueX = -1;
     m_minValueX = std::numeric_limits<double>::max();
     m_data.clear();
-    for ( int i = 0; i < dataCount-1; i++ ){
+    double binHalfWidth = (dataVector[2].first - dataVector[1].first)/2.0;
+    for ( int i = 0; i < dataCount; i++ ){
         //Only add in nonzero counts
         if ( dataVector[i].second > 0 ){
-            QwtIntervalSample sample( dataVector[i].second, dataVector[i].first, dataVector[i+1].first );
+            QwtIntervalSample sample( dataVector[i].second, dataVector[i].first-binHalfWidth, dataVector[i].first+binHalfWidth );
             m_data.push_back( sample );
             if ( dataVector[i].second > m_maxValueY ){
                 m_maxValueY = dataVector[i].second;

--- a/carta/cpp/core/Plot2D/Plot2DHistogram.cpp
+++ b/carta/cpp/core/Plot2D/Plot2DHistogram.cpp
@@ -115,7 +115,11 @@ void Plot2DHistogram::setData ( std::vector<std::pair<double,double> > dataVecto
     m_maxValueX = -1;
     m_minValueX = std::numeric_limits<double>::max();
     m_data.clear();
-    double binHalfWidth = (dataVector[2].first - dataVector[1].first)/2.0;
+    // use a fake bin width to plot when bin count equals 1
+    double binHalfWidth = 1.0;
+    if ( dataVector.size() > 1 ){
+        binHalfWidth = (dataVector[1].first - dataVector[0].first)/2.0;
+    }
     for ( int i = 0; i < dataCount; i++ ){
         //Only add in nonzero counts
         if ( dataVector[i].second > 0 ){
@@ -145,4 +149,3 @@ Plot2DHistogram::~Plot2DHistogram(){
 
 }
 }
-	

--- a/carta/cpp/core/Plot2D/Plot2DHolder.cpp
+++ b/carta/cpp/core/Plot2D/Plot2DHolder.cpp
@@ -77,7 +77,6 @@ void Plot2DHolder::addData(std::vector<std::pair<double,double> > dataVector,
         pData->setId( id );
         pData->setData( dataVector );
         pData->attachToPlot(m_plot);
-        _updateScales();
     }
 }
 
@@ -615,7 +614,19 @@ void Plot2DHolder::setLegendVisible( bool visible ){
 
 void Plot2DHolder::setLogScale(bool logScale){
     m_logScale = logScale;
-    _updateScales();
+    if ( m_logScale ){
+        m_plot->setAxisScaleEngineY( new QwtLogScaleEngine());
+        for ( int i = 0; i < m_datas.size(); i++ ){
+            m_datas[i]->setBaseLine(1.0);
+        }
+    }
+    else {
+        m_plot->setAxisScaleEngineY(new QwtLinearScaleEngine());
+        for ( int i = 0; i < m_datas.size(); i++ ){
+            m_datas[i]->setBaseLine(0.0);
+        }
+    }
+    m_plot->replot();
 }
 
 
@@ -866,51 +877,6 @@ void Plot2DHolder::_updateLegend(){
 }
 
 
-void Plot2DHolder::_updateScales(){
-    int dataCount = m_datas.size();
-    if ( dataCount > 0 ){
-        std::pair<double,double> firstBounds = m_datas[0]->getBoundsY();
-        std::pair<double,double> firstBoundsX = m_datas[0]->getBoundsX();
-        double yMin = firstBounds.first;
-        double yMax = firstBounds.second;
-        double xMin = firstBoundsX.first;
-        double xMax = firstBoundsX.second;
-        for ( int i = 0; i < dataCount; i++ ){
-            std::pair<double,double> plotBounds = m_datas[i]->getBoundsY();
-            if ( plotBounds.first < yMin ){
-                yMin = plotBounds.first;
-            }
-            if ( plotBounds.second > yMax ){
-                yMax = plotBounds.second;
-            }
-            if( m_logScale ){
-                m_datas[i]->setBaseLine(1.0);
-            }
-            else{
-                m_datas[i]->setBaseLine(0.0);
-            }
-            std::pair<double,double> plotBoundsX = m_datas[i]->getBoundsX();
-            if ( plotBoundsX.first < xMin ){
-                xMin = plotBoundsX.first;
-            }
-            if ( plotBoundsX.second > xMax ){
-                xMax = plotBoundsX.second;
-            }
-        }
-        m_plot->setAxisScaleX( xMin, xMax );
-        if ( m_logScale ){
-            m_plot->setAxisScaleEngineY( new QwtLogScaleEngine());
-            m_plot->setAxisScaleY( 1, yMax );
-        }
-        else {
-            m_plot->setAxisScaleEngineY(new QwtLinearScaleEngine());
-            m_plot->setAxisScaleY( yMin, yMax );
-        }
-        m_plot->replot();
-    }
-}
-
-
 Plot2DHolder::~Plot2DHolder(){
     clearData();
     _clearMarkers();
@@ -919,4 +885,3 @@ Plot2DHolder::~Plot2DHolder(){
 }
 }
 }
-

--- a/carta/cpp/plugins/Histogram/Histogram1.cpp
+++ b/carta/cpp/plugins/Histogram/Histogram1.cpp
@@ -182,7 +182,7 @@ Histogram1::handleHook( BaseHook & hookData )
         	imageRegion = ImageRegionGenerator::makeRegion( casaImage, regionBase );
         }
         m_histogram->setRegion( imageRegion, regionId  );
-        m_histogram-> setBinCount( hook.paramsPtr->binCount );
+        m_histogram->setBinCount( hook.paramsPtr->binCount );
 
         double frequencyMin = hook.paramsPtr->minFrequency;
         double frequencyMax = hook.paramsPtr->maxFrequency;

--- a/carta/scripts/ci_mac_common.sh
+++ b/carta/scripts/ci_mac_common.sh
@@ -51,13 +51,7 @@ echo "install gfortran, start to backup travis-c++"
 mv /usr/local/include/c++ /usr/local/include/c++_backup # this folder is from homebrew's gcc49
 su $SUDO_USER <<EOF
 ## now it is 7.1 we only use its gfortran which is also used by code
-if sw_vers -productVersion | grep 10.12 ; then
-  echo "it is 10.12"
-  brew install https://github.com/CARTAvis/homebrew-tap/releases/download/0.1.2/gcc-7.1.0.sierra.bottle.tar.gz
-else
-  echo "it is 10.11"
-  brew install https://github.com/CARTAvis/homebrew-tap/releases/download/0.1.2/gcc-7.1.0.el_capitan.bottle.tar.gz
-fi
+brew install gcc
 EOF
 echo "resume travis-c++"
 mv /usr/local/include/c++_backup /usr/local/include/c++


### PR DESCRIPTION
This PR mainly contains three parts:
1) The histogram do not work for some images. This is caused by returning double type as int type.
2) Fix the wrong scale of histogram and use the default scale of qwt to draw.
3) The number of bins were usually reset by CARTA. Now it can work under the condition that the bin width is precise to the significant digit.
// Two commits were picked from cjhsu/profiler.