### PR TITLE
[mark/addReleaseLink] add a releases link on the top of CARTA menus

### DIFF
--- a/carta/cpp/desktop/MainWindow.cpp
+++ b/carta/cpp/desktop/MainWindow.cpp
@@ -67,7 +67,8 @@ MainWindow::MainWindow( )
     helpMenu->addAction(tr("GitHub Home"), this, SLOT(helpUrlGitHubHome()));
     helpMenu->addAction(tr("GitHub Wiki"), this, SLOT(helpUrlGitHubWiki()));
     helpMenu->addAction(tr("GitHub Issues"), this, SLOT(helpUrlGitHubIssues()));
-    helpMenu->addAction(tr("Release Notes"), this, SLOT(helpReleaseNote()));
+    helpMenu->addAction(tr("Release"), this, SLOT(helpReleaseNote()));
+    helpMenu->addAction(tr("Manual"), this, SLOT(helpManual()));
     helpMenu->addAction(tr("Helpdesk"), this, SLOT(helpUrlHelpdesk()));
     
     setCentralWidget(m_view);
@@ -172,6 +173,11 @@ void MainWindow::helpUrlGitHubIssues()
 void MainWindow::helpReleaseNote()
 {
     QDesktopServices::openUrl(QUrl("https://github.com/CARTAvis/carta/releases", QUrl::TolerantMode));
+}
+
+void MainWindow::helpManual()
+{
+    QDesktopServices::openUrl(QUrl("http://www.asiaa.sinica.edu.tw/~kswang/carta_doc/html/index.html", QUrl::TolerantMode));
 }
 
 void MainWindow::helpUrlHelpdesk()

--- a/carta/cpp/desktop/MainWindow.cpp
+++ b/carta/cpp/desktop/MainWindow.cpp
@@ -67,6 +67,7 @@ MainWindow::MainWindow( )
     helpMenu->addAction(tr("GitHub Home"), this, SLOT(helpUrlGitHubHome()));
     helpMenu->addAction(tr("GitHub Wiki"), this, SLOT(helpUrlGitHubWiki()));
     helpMenu->addAction(tr("GitHub Issues"), this, SLOT(helpUrlGitHubIssues()));
+    helpMenu->addAction(tr("Release Notes"), this, SLOT(helpReleaseNote()));
     helpMenu->addAction(tr("Helpdesk"), this, SLOT(helpUrlHelpdesk()));
     
     setCentralWidget(m_view);
@@ -166,6 +167,11 @@ void MainWindow::helpUrlGitHubWiki()
 void MainWindow::helpUrlGitHubIssues()
 {
     QDesktopServices::openUrl(QUrl("https://github.com/CARTAvis/carta/issues", QUrl::TolerantMode));
+}
+
+void MainWindow::helpReleaseNote()
+{
+    QDesktopServices::openUrl(QUrl("https://github.com/CARTAvis/carta/releases", QUrl::TolerantMode));
 }
 
 void MainWindow::helpUrlHelpdesk()

--- a/carta/cpp/desktop/MainWindow.cpp
+++ b/carta/cpp/desktop/MainWindow.cpp
@@ -177,7 +177,7 @@ void MainWindow::helpReleaseNote()
 
 void MainWindow::helpManual()
 {
-    QDesktopServices::openUrl(QUrl("http://www.asiaa.sinica.edu.tw/~kswang/carta_doc/html/index.html", QUrl::TolerantMode));
+    QDesktopServices::openUrl(QUrl("https://cartavis.github.io/manual/", QUrl::TolerantMode));
 }
 
 void MainWindow::helpUrlHelpdesk()

--- a/carta/cpp/desktop/MainWindow.h
+++ b/carta/cpp/desktop/MainWindow.h
@@ -42,6 +42,7 @@ protected slots:
     void helpUrlGitHubHome();
     void helpUrlGitHubWiki();
     void helpUrlGitHubIssues();
+    void helpReleaseNote();
     void helpUrlHelpdesk();
     void cartaLicense();
 

--- a/carta/cpp/desktop/MainWindow.h
+++ b/carta/cpp/desktop/MainWindow.h
@@ -43,6 +43,7 @@ protected slots:
     void helpUrlGitHubWiki();
     void helpUrlGitHubIssues();
     void helpReleaseNote();
+    void helpManual();
     void helpUrlHelpdesk();
     void cartaLicense();
 


### PR DESCRIPTION
This PR is for issue #204: `add a releases link on the top of CARTA menu` https://github.com/CARTAvis/carta/releases

<img width="376" alt="2017-09-14 12 59 24" src="https://user-images.githubusercontent.com/5379602/30413887-6dd5fbae-9953-11e7-9848-376c940bbc5f.png">
