### PR TITLE
[mark/changeCacheFileLocation] change the default path of SQLite cache under user's CARTA home directory

### DIFF
--- a/carta/config/config.json
+++ b/carta/config/config.json
@@ -7,7 +7,7 @@
     "disabledPlugins" : ["tester1", "clock1", "blurpy"],
     "plugins": {
         "PCacheSqlite3" : {
-            "dbPath": "/tmp/pcache.sqlite"
+            "dbPath": "$(HOME)/CARTA/cache/pcache.sqlite"
         }
     },
     "qtDecorations" : "true",

--- a/carta/cpp/plugins/PCacheLevelDB/PCacheLevelDB.cpp
+++ b/carta/cpp/plugins/PCacheLevelDB/PCacheLevelDB.cpp
@@ -76,7 +76,7 @@ public:
             qWarning() << "query insert failed:" << status.ToString().c_str();
         }
 
-        Q_UNUSED( priority);
+        //Q_UNUSED( priority);
         // \todo we'll have to embed  priority into the value, e.g. first 8 bytes?
     } // setEntry
 

--- a/carta/cpp/plugins/PCacheSqlite3/PCacheSqlite3.cpp
+++ b/carta/cpp/plugins/PCacheSqlite3/PCacheSqlite3.cpp
@@ -192,8 +192,8 @@ PCacheSQlite3Plugin::initialize( const IPlugin::InitInfo & initInfo )
     }
     else {
         // convert this to absolute path just in case
-        m_dbPath.replace("$(HOME)", QDir::homePath());
-        m_dbPath.replace("$(APPDIR)", QCoreApplication::applicationDirPath());
+        m_dbPath.replace("$(HOME)", QDir::homePath()); // get user's home directory
+        m_dbPath.replace("$(APPDIR)", QCoreApplication::applicationDirPath()); // get the directory of CARTA Application
         m_dbPath = QDir(m_dbPath).absolutePath();
     }
 }


### PR DESCRIPTION
This PR is for issue #189. The new location of SQLite cache file is under user's home directory: `$(HOME)/CARTA/cache/pcache.sqlite`
