### PR TITLE
fix issue 172: clickable area of ellipse region

### DIFF
--- a/carta/cpp/CartaLib/Regions/Ellipse.cpp
+++ b/carta/cpp/CartaLib/Regions/Ellipse.cpp
@@ -91,8 +91,10 @@ QRectF Ellipse::outlineBox() const {
 	double sinAngle = sin( m_angle * ( M_PI / 180));
 
 	//Now rotate by the given angle.
-	double xTransform = m_radiusMinor * cosAngle - m_radiusMajor * sinAngle;
-	double yTransform = m_radiusMinor * sinAngle + m_radiusMajor * cosAngle;
+	//double xTransform = m_radiusMinor * cosAngle - m_radiusMajor * sinAngle;
+	//double yTransform = m_radiusMinor * sinAngle + m_radiusMajor * cosAngle;
+	double xTransform = m_radiusMajor * cosAngle - m_radiusMinor * sinAngle;
+	double yTransform = m_radiusMajor * sinAngle + m_radiusMinor * cosAngle;
 	double left = m_center.x() - xTransform;
 	double top = m_center.y() - yTransform;
 	double right = m_center.x() + xTransform;

--- a/carta/cpp/core/Shape/ShapeEllipse.cpp
+++ b/carta/cpp/core/Shape/ShapeEllipse.cpp
@@ -171,16 +171,11 @@ void ShapeEllipse::_updateEllipseFromShadow(){
 	m_shadowRect = m_shadowRect.normalized();
 	double width = m_shadowRect.width();
 	double height = m_shadowRect.height();
-	if ( width < height ){
-		m_ellipseRegion->setRadiusMajor( height / 2 );
-		m_ellipseRegion->setRadiusMinor( width / 2 );
-		m_ellipseRegion->setAngle( 0 );
-	}
-	else {
-		m_ellipseRegion->setRadiusMajor( width / 2 );
-		m_ellipseRegion->setRadiusMinor( height / 2 );
-		m_ellipseRegion->setAngle( 90 );
-	}
+
+	m_ellipseRegion->setRadiusMajor( width / 2 );
+	m_ellipseRegion->setRadiusMinor( height / 2 );
+	m_ellipseRegion->setAngle( 0 );
+
 	m_ellipseRegion->setCenter( m_shadowRect.center() );
 }
 


### PR DESCRIPTION
this PR tries to solve the issue #172 

Now the clickable area should match with the drawn ellipse (either prolate or oblate). 

I have verified that the coordinates of the clickable area/drawn ellipse should be consistent with the coordinates as seen in "statistics" and "profiler" (need commit 71f0015 to see the correct coordinate information). Extensive tests on how well ellipse region co-works with other analysis tools (statistics/profiler/histogram etc) are still needed though. 
