### PR TITLE
Remove the html location bar on the top of UI panel

### DIFF
--- a/carta/cpp/desktop/MainWindow.cpp
+++ b/carta/cpp/desktop/MainWindow.cpp
@@ -27,12 +27,12 @@ MainWindow::MainWindow( )
     m_locationEdit->setSizePolicy(QSizePolicy::Expanding, m_locationEdit->sizePolicy().verticalPolicy());
     connect(m_locationEdit, SIGNAL(returnPressed()), SLOT(changeLocation()));
 
-    //QToolBar *toolBar = addToolBar(tr("Navigation"));
-    //toolBar->addAction(m_view->pageAction(QWebPage::Back));
-    //toolBar->addAction(m_view->pageAction(QWebPage::Forward));
-    //toolBar->addAction(m_view->pageAction(QWebPage::Reload));
-    //toolBar->addAction(QIcon("://icons/inspector.png"), "Inspector", this, SLOT(showJsConsole()));
-    //toolBar->addWidget(m_locationEdit);
+    QToolBar *toolBar = addToolBar(tr("Navigation"));
+    toolBar->addAction(m_view->pageAction(QWebPage::Back));
+    toolBar->addAction(m_view->pageAction(QWebPage::Forward));
+    toolBar->addAction(m_view->pageAction(QWebPage::Reload));
+    toolBar->addAction(QIcon("://icons/inspector.png"), "Inspector", this, SLOT(showJsConsole()));
+    toolBar->addWidget(m_locationEdit);
 
     m_inspector = new QWebInspector( nullptr);
     m_inspector-> setPage( m_view-> page());
@@ -81,7 +81,7 @@ MainWindow::MainWindow( )
 
     // set visibilities of window bars
     menuBar()->setVisible( true);
-    //toolBar->setVisible( false);
+    toolBar->setVisible( false);
     statusBar()->setVisible( true);
 
     // install 'fileq' protocol handler


### PR DESCRIPTION
This is the side effect of my previous PR branch `mark/remove-qtDecorations-opt`. It happens for the Mac but not on the Linux system.