### PR TITLE
Enable the colormap function for the histogram plot

### DIFF
--- a/carta/cpp/core/Data/Histogram/Histogram.cpp
+++ b/carta/cpp/core/Data/Histogram/Histogram.cpp
@@ -2178,6 +2178,8 @@ void Histogram::_updatePlots( ){
 	m_plotManager->setLogScale( m_state.getValue<bool>( GRAPH_LOG_COUNT ) );
 	m_plotManager->setStyle( m_state.getValue<QString>( GRAPH_STYLE ) );
 	m_plotManager->setColored( m_state.getValue<bool>( GRAPH_COLORED ) );
+    bool isColored = getColored();
+    if (isColored) updateColorMap();
 	m_plotManager->updatePlot();
 }
 

--- a/carta/cpp/core/Data/Histogram/Histogram.cpp
+++ b/carta/cpp/core/Data/Histogram/Histogram.cpp
@@ -2178,8 +2178,10 @@ void Histogram::_updatePlots( ){
 	m_plotManager->setLogScale( m_state.getValue<bool>( GRAPH_LOG_COUNT ) );
 	m_plotManager->setStyle( m_state.getValue<QString>( GRAPH_STYLE ) );
 	m_plotManager->setColored( m_state.getValue<bool>( GRAPH_COLORED ) );
-    bool isColored = getColored();
-    if (isColored) updateColorMap();
+	bool isColored = getColored();
+	if (isColored) {
+	    updateColorMap();
+	}
 	m_plotManager->updatePlot();
 }
 


### PR DESCRIPTION
Fix a bug so that the colormap can be applied on the histogram plot, as shown below: 

<img width="1275" alt="2017-11-02 2 50 53" src="https://user-images.githubusercontent.com/5379602/32313601-c04f9374-bf71-11e7-8023-a2de407063c5.png">
