### PR TITLE
Correct statistical information for different channels and regions

### DIFF
--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -242,8 +242,12 @@ void LayerGroup::_displayAxesChanged(std::vector<AxisInfo::KnownType> displayAxi
     }
 }
 
-Carta::Lib::AxisInfo::KnownType LayerGroup::_getAxisType( int /*index*/ ) const {
+Carta::Lib::AxisInfo::KnownType LayerGroup::_getAxisType( int index ) const {
     AxisInfo::KnownType axisType = AxisInfo::KnownType::OTHER;
+    int dataIndex = _getIndexCurrent();
+    if ( dataIndex >= 0 ){
+        axisType = m_children[dataIndex]->_getAxisType( index );
+    }
     return axisType;
 }
 

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -244,10 +244,10 @@ void LayerGroup::_displayAxesChanged(std::vector<AxisInfo::KnownType> displayAxi
 
 Carta::Lib::AxisInfo::KnownType LayerGroup::_getAxisType( int /*index*/ ) const {
     AxisInfo::KnownType axisType = AxisInfo::KnownType::OTHER;
-    //int dataIndex = _getIndexCurrent();
-    //if ( dataIndex >= 0 ){
-    //    axisType = m_children[dataIndex]->_getAxisType( index );
-    //}
+    int dataIndex = _getIndexCurrent();
+    if ( dataIndex >= 0 ){
+        axisType = m_children[dataIndex]->_getAxisType( index );
+    }
     return axisType;
 }
 

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -242,12 +242,12 @@ void LayerGroup::_displayAxesChanged(std::vector<AxisInfo::KnownType> displayAxi
     }
 }
 
-Carta::Lib::AxisInfo::KnownType LayerGroup::_getAxisType( int index ) const {
+Carta::Lib::AxisInfo::KnownType LayerGroup::_getAxisType( int /*index*/ ) const {
     AxisInfo::KnownType axisType = AxisInfo::KnownType::OTHER;
-    int dataIndex = _getIndexCurrent();
-    if ( dataIndex >= 0 ){
-        axisType = m_children[dataIndex]->_getAxisType( index );
-    }
+    //int dataIndex = _getIndexCurrent();
+    //if ( dataIndex >= 0 ){
+    //    axisType = m_children[dataIndex]->_getAxisType( index );
+    //}
     return axisType;
 }
 

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -247,7 +247,8 @@ std::vector<int> Stack::_getImageSlice() const {
         Carta::Lib::AxisInfo::KnownType axisXType = _getAxisXType();
         Carta::Lib::AxisInfo::KnownType axisYType = _getAxisYType();
         for ( int i = 0; i < dimensions; i++ ){
-            Carta::Lib::AxisInfo::KnownType type  = _getAxisType( i );
+            //Carta::Lib::AxisInfo::KnownType type  = _getAxisType( i ); // call the function LayerGroup::_getAxisType( int )
+            Carta::Lib::AxisInfo::KnownType type  = m_children[dataIndex]->_getAxisType( i ); // call the function LayerData::_getAxisType( int )
             if ( type == axisXType || type == axisYType ){
                 result[i] = -1;
             }

--- a/carta/cpp/plugins/ImageStatistics/RegionRecordFactory.cpp
+++ b/carta/cpp/plugins/ImageStatistics/RegionRecordFactory.cpp
@@ -294,7 +294,9 @@ casacore::Record RegionRecordFactory::_getRegionRecordPoint(
     	Carta::Lib::Regions::Point* pointRegion = dynamic_cast<Carta::Lib::Regions::Point*>( region.get());
     	QRectF polygon = pointRegion->outlineBox();
     	QPointF centerVal = polygon.center();
-    	QRectF pointRect( centerVal.x(), centerVal.y(), centerVal.x(), centerVal.y() );
+        int pointWidth = 1;
+        int pointHeight = 1;
+        QRectF pointRect( centerVal.x(), centerVal.y(), pointWidth, pointHeight );
     	typeStr = "Point";
     	casacore::ImageRegion* region = _getRectangle( casaImage, pointRect, slice );
     	if ( region != nullptr ){

--- a/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.cpp
+++ b/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.cpp
@@ -31,7 +31,7 @@ void StatisticsCASARegion::_getStatsFromCalculator( casacore::ImageInterface<cas
     if ( fieldCount == 0 ){
         return;
     }
-    std::shared_ptr<const casacore::ImageInterface<casacore::Float> > imagePtr( image->cloneII() );
+    //std::shared_ptr<const casacore::ImageInterface<casacore::Float> > imagePtr( image->cloneII() );
 
     casacore::CoordinateSystem cs = image->coordinates();
     casacore::Vector<casacore::Int> displayAxes = cs.directionAxesNumbers();
@@ -45,7 +45,7 @@ void StatisticsCASARegion::_getStatsFromCalculator( casacore::ImageInterface<cas
             trcq[i].setValue( shape[i] );
         }
         else {
-            blcq[i].setValue( slice[i] );
+            //blcq[i].setValue( slice[i] );
             trcq[i].setValue( slice[i] );
         }
     }
@@ -55,7 +55,7 @@ void StatisticsCASARegion::_getStatsFromCalculator( casacore::ImageInterface<cas
     std::shared_ptr<casacore::SubImage<casacore::Float> > boxImage( new casacore::SubImage<Float>(*image, *imgBox ) );
 
     casa::ImageStatsCalculator calc( boxImage, &region, "", true);
-    calc.setList(False);
+    calc.setList(false);
     Record result = calc.calculate();
     const casacore::String blcKey( "blc");
     const casacore::String trcKey( "trc");

--- a/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.cpp
+++ b/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.cpp
@@ -42,19 +42,24 @@ void StatisticsCASARegion::_getStatsFromCalculator( casacore::ImageInterface<cas
     casacore::Vector<casacore::Quantum<casacore::Double> > trcq( nAxes, pix0);
     for ( int i = 0; i < nAxes; i++ ){
         if ( i == displayAxes[0] || i == displayAxes[1]){
-            trcq[i].setValue( shape[i] );
+            trcq[i].setValue( shape[i] - 1 );
         }
         else {
-            //blcq[i].setValue( slice[i] );
+            // select the current spectral or stoke channel
+            blcq[i].setValue( slice[i] );
             trcq[i].setValue( slice[i] );
         }
     }
 
-    // This is for "rectangle" or "Point" type regions
+    /**
+     * We get Rectangle, Polygon, Ellipse or Point region first.
+     * Rectangle and Point objects can select the range of spectral or stoke channel (frame),
+     * by default we select the current channel. They are defined in the "RegionRecordFactory.cpp".
+     * On the other hand, Polygon and Ellipse objects can not select the range of spectral or stoke channel.
+     * So we need the second stage of the box region process,
+     * which is used to select the range of spectral or stoke channel.
+     */
     casacore::WCBox box( blcq, trcq, cs, casacore::Vector<casacore::Int>());
-
-    // TODO: for "ellipse" or "polygon" type regions, we have to apply "casacore::WCEllipsoid" or "casacore::WCPolygon" classes !!
-
     casacore::ImageRegion* imgBox = new casacore::ImageRegion( box );
     std::shared_ptr<casacore::SubImage<casacore::Float> > boxImage( new casacore::SubImage<Float>(*image, *imgBox ) );
 
@@ -72,10 +77,10 @@ void StatisticsCASARegion::_getStatsFromCalculator( casacore::ImageInterface<cas
     _insertScalar( result, "sigma", Carta::Lib::StatInfo::StatType::Sigma, stats );
     _insertScalar( result, "rms", Carta::Lib::StatInfo::StatType::RMS, stats );
     _insertScalar( result, "flux", Carta::Lib::StatInfo::StatType::FluxDensity, stats );
-    _insertList( result, blcKey, Carta::Lib::StatInfo::StatType::Blc, stats );
-    _insertList( result, trcKey, Carta::Lib::StatInfo::StatType::Trc, stats );
-    _insertList( result, "minpos", Carta::Lib::StatInfo::StatType::MinPos, stats );
-    _insertList( result, "maxpos", Carta::Lib::StatInfo::StatType::MaxPos, stats );
+    _insertList( result, blcKey, Carta::Lib::StatInfo::StatType::Blc, stats, slice );
+    _insertList( result, trcKey, Carta::Lib::StatInfo::StatType::Trc, stats, slice );
+    _insertList( result, "minpos", Carta::Lib::StatInfo::StatType::MinPos, stats, slice );
+    _insertList( result, "maxpos", Carta::Lib::StatInfo::StatType::MaxPos, stats, slice );
     _insertString( result, "blcf", Carta::Lib::StatInfo::StatType::Blcf, stats );
     _insertString( result, "trcf", Carta::Lib::StatInfo::StatType::Trcf, stats );
     _insertString( result, "minposf", Carta::Lib::StatInfo::StatType::MinPosf, stats );
@@ -84,16 +89,13 @@ void StatisticsCASARegion::_getStatsFromCalculator( casacore::ImageInterface<cas
     //Put in an identifier.
     if ( result.isDefined( blcKey ) && result.isDefined( trcKey ) ){
         casacore::Vector<int> blcArray = result.asArrayInt( blcKey );
-        QString blcVal = _vectorToString( blcArray );
+        QString blcVal = _vectorToString( blcArray, slice );
         casacore::Vector<int> trcArray = result.asArrayInt( trcKey );
-        QString trcVal = _vectorToString( trcArray );
-        QString idVal = regionType + ":";
-        if ( regionType == "Point" ) {
-            idVal = idVal + blcVal;
-        } else {
-            if ( blcVal != trcVal ){
-            idVal = idVal + blcVal + " x " + trcVal;
-            }
+        QString trcVal = _vectorToString( trcArray, slice );
+        QString idVal = regionType + ": ";
+        // Note: It is meaningless to show the statistics for a "Point" region, this may need to correct in future.
+        if ( blcVal != trcVal ){
+            idVal = idVal + blcVal + " -> " + trcVal;
         }
         Carta::Lib::StatInfo info( Carta::Lib::StatInfo::StatType::Name );
         info.setValue( idVal );
@@ -106,10 +108,11 @@ void StatisticsCASARegion::_getStatsFromCalculator( casacore::ImageInterface<cas
 
 void
 StatisticsCASARegion::_insertList( const casacore::Record& result, const casacore::String& key,
-        Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats ){
+        Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats,
+        const std::vector<int>& slice ){
     if ( result.isDefined( key) ){
         casacore::Vector<int> valArray = result.asArrayInt( key );
-        QString val = _vectorToString( valArray );
+        QString val = _vectorToString( valArray, slice );
         if ( !val.isEmpty()){
             Carta::Lib::StatInfo info( statType );
             info.setValue( val );
@@ -143,11 +146,16 @@ StatisticsCASARegion::_insertString( const casacore::Record& result, const casac
     }
 }
 
-QString StatisticsCASARegion::_vectorToString( const casacore::Vector<int>& valArray ){
+QString StatisticsCASARegion::_vectorToString( const casacore::Vector<int>& valArray,
+        const std::vector<int>& slice ){
     int elementCount = valArray.nelements();
     QString val("[");
     for ( int i = 0; i < elementCount; i++ ){
-        val = val + QString::number(valArray[i]);
+        if ( slice[i] == -1 ) {
+            val = val + QString::number(valArray[i]);
+        } else {
+            val = val + QString::number(slice[i]);
+        }
         if ( i < elementCount - 1 ){
             val = val + ", ";
         }

--- a/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.cpp
+++ b/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.cpp
@@ -50,7 +50,11 @@ void StatisticsCASARegion::_getStatsFromCalculator( casacore::ImageInterface<cas
         }
     }
 
+    // This is for "rectangle" or "Point" type regions
     casacore::WCBox box( blcq, trcq, cs, casacore::Vector<casacore::Int>());
+
+    // TODO: for "ellipse" or "polygon" type regions, we have to apply "casacore::WCEllipsoid" or "casacore::WCPolygon" classes !!
+
     casacore::ImageRegion* imgBox = new casacore::ImageRegion( box );
     std::shared_ptr<casacore::SubImage<casacore::Float> > boxImage( new casacore::SubImage<Float>(*image, *imgBox ) );
 
@@ -83,9 +87,13 @@ void StatisticsCASARegion::_getStatsFromCalculator( casacore::ImageInterface<cas
         QString blcVal = _vectorToString( blcArray );
         casacore::Vector<int> trcArray = result.asArrayInt( trcKey );
         QString trcVal = _vectorToString( trcArray );
-        QString idVal = regionType + ":" + blcVal;
-        if ( blcVal != trcVal ){
-            idVal = idVal + " x " + trcVal;
+        QString idVal = regionType + ":";
+        if ( regionType == "Point" ) {
+            idVal = idVal + blcVal;
+        } else {
+            if ( blcVal != trcVal ){
+            idVal = idVal + blcVal + " x " + trcVal;
+            }
         }
         Carta::Lib::StatInfo info( Carta::Lib::StatInfo::StatType::Name );
         info.setValue( idVal );

--- a/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.h
+++ b/carta/cpp/plugins/ImageStatistics/StatisticsCASARegion.h
@@ -36,11 +36,12 @@ private:
 
     static void _insertScalar( const casacore::Record& result, const casacore::String& key,
             Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats );
-    static void _insertList( const casacore::Record& result, const casacore::String& key,
-            Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats );
+    static void _insertList(const casacore::Record& result, const casacore::String& key,
+            Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats,
+            const std::vector<int> &slice);
     static void _insertString( const casacore::Record& result, const casacore::String& key,
             Carta::Lib::StatInfo::StatType statType, QList<Carta::Lib::StatInfo>& stats );
-    static QString _vectorToString( const casacore::Vector<int>& valArray );
+    static QString _vectorToString(const casacore::Vector<int>& valArray, const std::vector<int> &slice);
 
     virtual ~StatisticsCASARegion();
 


### PR DESCRIPTION
This PR solves the first item of issue #142. The statistics information now can be updated for the selecting region including the current spectral or stoke channel. The `Rectangle` region performs well. However, the other region types, `Polygon`, `Ellipse` and `Point` need further checks.