### PR TITLE
Show contours with different smoothness types on the same image

### DIFF
--- a/carta/cpp/CartaLib/IContourGeneratorService.h
+++ b/carta/cpp/CartaLib/IContourGeneratorService.h
@@ -92,10 +92,6 @@ public:
 //    typedef std::vector < std::vector < QPolygonF > > Result;
     typedef ContourSet Result;
 
-    /// request contour type for which to generate contours
-    virtual void
-    setContourType( const QString & contourType ) = 0;
-
     /// request a vector of contour types for which to generate contours
     virtual void
     setContourTypesVector( const QStringList & contourTypesVector ) = 0;
@@ -107,10 +103,6 @@ public:
     /// request a vector of levels for which to generate the contours
     virtual void
     setLevelsVector( const std::vector < std::vector < double > > & levelsVector ) = 0;
-
-    /// set if contours contain different types
-    virtual void
-    setHasDifferentContourTypes (const bool & hasDifferentContourTypes) = 0;
 
     /// set the input on which to generate the contours
     virtual void

--- a/carta/cpp/CartaLib/IContourGeneratorService.h
+++ b/carta/cpp/CartaLib/IContourGeneratorService.h
@@ -108,6 +108,10 @@ public:
     virtual void
     setLevelsVector( const std::vector < std::vector < double > > & levelsVector ) = 0;
 
+    /// set if contours contain different types
+    virtual void
+    setHasDifferentContourTypes (const bool & hasDifferentContourTypes) = 0;
+
     /// set the input on which to generate the contours
     virtual void
     setInput( NdArray::RawViewInterface::SharedPtr rawView ) = 0;

--- a/carta/cpp/CartaLib/IContourGeneratorService.h
+++ b/carta/cpp/CartaLib/IContourGeneratorService.h
@@ -92,13 +92,21 @@ public:
 //    typedef std::vector < std::vector < QPolygonF > > Result;
     typedef ContourSet Result;
 
-    /// request name for which to generate the contours
+    /// request contour type for which to generate contours
     virtual void
-    setName( const QString & name ) = 0;
+    setContourType( const QString & contourType ) = 0;
+
+    /// request a vector of contour types for which to generate contours
+    virtual void
+    setContourTypesVector( const QStringList & contourTypesVector ) = 0;
 
     /// request levels for which to generate the contours
     virtual void
     setLevels( const std::vector < double > & levels ) = 0;
+
+    /// request a vector of levels for which to generate the contours
+    virtual void
+    setLevelsVector( const std::vector < std::vector < double > > & levelsVector ) = 0;
 
     /// set the input on which to generate the contours
     virtual void

--- a/carta/cpp/CartaLib/IContourGeneratorService.h
+++ b/carta/cpp/CartaLib/IContourGeneratorService.h
@@ -96,10 +96,6 @@ public:
     virtual void
     setContourTypesVector( const QStringList & contourTypesVector ) = 0;
 
-    /// request levels for which to generate the contours
-    virtual void
-    setLevels( const std::vector < double > & levels ) = 0;
-
     /// request a vector of levels for which to generate the contours
     virtual void
     setLevelsVector( const std::vector < std::vector < double > > & levelsVector ) = 0;

--- a/carta/cpp/core/Data/Image/Draw/DrawSynchronizer.cpp
+++ b/carta/cpp/core/Data/Image/Draw/DrawSynchronizer.cpp
@@ -88,11 +88,13 @@ void DrawSynchronizer::setInput( std::shared_ptr<Carta::Lib::NdArray::RawViewInt
 }
 
 void DrawSynchronizer::setContours( const std::set<std::shared_ptr<DataContours> > & contours ){
-    //std::vector<double> levels;
+    std::vector<double> levels;
     std::vector<std::vector<double>> levelsVector;
     QStringList contourTypesVector;
     QString contourType;
     bool drawing = false;
+    bool hasDifferentContourType = false;
+    QString tmpContourType1, tmpContourType2;
     m_pens.clear();
     for( std::set< std::shared_ptr<DataContours> >::iterator it = contours.begin();
             it != contours.end(); it++ ){
@@ -101,19 +103,30 @@ void DrawSynchronizer::setContours( const std::set<std::shared_ptr<DataContours>
             std::vector<QPen> setPens = (*it)->getPens();
             m_pens.insert( m_pens.end(), setPens.begin(), setPens.end());
             std::vector<double> setLevels = (*it)->getLevels();
-            //levels.insert( levels.end(), setLevels.begin(), setLevels.end());
+            levels.insert( levels.end(), setLevels.begin(), setLevels.end());
             levelsVector.push_back(setLevels);
             contourType = (*it)->getContourType();
             contourTypesVector.push_back(contourType);
         }
         //qDebug() << "[contour] contour set name:"<< (*it)->getName() << "contour type:" << (*it)->getContourType();
     }
-    if ( drawing ){
-        //m_cec->setContourType(contourType);
+    if (contourTypesVector.size() > 1) {
+        for (int i = 0; i < contourTypesVector.size(); i++) {
+            tmpContourType1 = tmpContourType2;
+            tmpContourType2 = contourTypesVector[i];
+            if (i > 0 && tmpContourType1 != tmpContourType2) {
+                hasDifferentContourType = true;
+                break;
+            }
+        }
+    }
+    m_cec->setHasDifferentContourTypes(hasDifferentContourType);
+    if (drawing && hasDifferentContourType){
         m_cec->setContourTypesVector(contourTypesVector);
-        //m_cec->setLevels(levels);
         m_cec->setLevelsVector(levelsVector);
-
+    } else if (drawing) {
+        m_cec->setContourType(contourType);
+        m_cec->setLevels(levels);
     }
 }
 

--- a/carta/cpp/core/Data/Image/Draw/DrawSynchronizer.cpp
+++ b/carta/cpp/core/Data/Image/Draw/DrawSynchronizer.cpp
@@ -88,7 +88,9 @@ void DrawSynchronizer::setInput( std::shared_ptr<Carta::Lib::NdArray::RawViewInt
 }
 
 void DrawSynchronizer::setContours( const std::set<std::shared_ptr<DataContours> > & contours ){
-    std::vector<double> levels;
+    //std::vector<double> levels;
+    std::vector<std::vector<double>> levelsVector;
+    QStringList contourTypesVector;
     QString contourType;
     bool drawing = false;
     m_pens.clear();
@@ -99,15 +101,19 @@ void DrawSynchronizer::setContours( const std::set<std::shared_ptr<DataContours>
             std::vector<QPen> setPens = (*it)->getPens();
             m_pens.insert( m_pens.end(), setPens.begin(), setPens.end());
             std::vector<double> setLevels = (*it)->getLevels();
-            levels.insert( levels.end(), setLevels.begin(), setLevels.end());
-            // get the contour type (Todo: map different contour types to their specific contour levels)
+            //levels.insert( levels.end(), setLevels.begin(), setLevels.end());
+            levelsVector.push_back(setLevels);
             contourType = (*it)->getContourType();
+            contourTypesVector.push_back(contourType);
         }
         //qDebug() << "[contour] contour set name:"<< (*it)->getName() << "contour type:" << (*it)->getContourType();
     }
     if ( drawing ){
-        m_cec->setName(contourType);
-        m_cec->setLevels( levels );
+        //m_cec->setContourType(contourType);
+        m_cec->setContourTypesVector(contourTypesVector);
+        //m_cec->setLevels(levels);
+        m_cec->setLevelsVector(levelsVector);
+
     }
 }
 

--- a/carta/cpp/core/Data/Image/Draw/DrawSynchronizer.cpp
+++ b/carta/cpp/core/Data/Image/Draw/DrawSynchronizer.cpp
@@ -117,13 +117,16 @@ void DrawSynchronizer::setContours( const std::set<std::shared_ptr<DataContours>
         }
         //qDebug() << "[contour] contour set name:"<< (*it)->getName() << "contour type:" << (*it)->getContourType();
     }
-    m_cec->setHasDifferentContourTypes(hasDifferentContourType);
-    if (drawing && hasDifferentContourType){
+    if (!hasDifferentContourType) {
+        // replace contourTypesVector and levelsVector with single vectors (.i.e, contourType and levels), respectively.
+        contourTypesVector.erase(contourTypesVector.begin(), contourTypesVector.end());
+        contourTypesVector.push_back(contourType);
+        levelsVector.erase(levelsVector.begin(), levelsVector.end());
+        levelsVector.push_back(levels);
+    }
+    if (drawing) {
         m_cec->setContourTypesVector(contourTypesVector);
         m_cec->setLevelsVector(levelsVector);
-    } else if (drawing) {
-        m_cec->setContourType(contourType);
-        m_cec->setLevels(levels);
     }
 }
 

--- a/carta/cpp/core/Data/Image/Draw/DrawSynchronizer.cpp
+++ b/carta/cpp/core/Data/Image/Draw/DrawSynchronizer.cpp
@@ -95,7 +95,6 @@ void DrawSynchronizer::setContours( const std::set<std::shared_ptr<DataContours>
     bool drawing = false;
     bool hasDifferentContourType = false;
     QString tmpContourType = "null";
-    int count = 0;
     m_pens.clear();
     for( std::set< std::shared_ptr<DataContours> >::iterator it = contours.begin();
             it != contours.end(); it++ ){
@@ -108,12 +107,11 @@ void DrawSynchronizer::setContours( const std::set<std::shared_ptr<DataContours>
             levelsVector.push_back(setLevels);
             // deal with the multiple contour types
             contourType = (*it)->getContourType();
-            if (count > 0 && contourType != tmpContourType) {
+            if (contourType != tmpContourType && tmpContourType != "null") {
                 hasDifferentContourType = true;
             }
             tmpContourType = contourType;
             contourTypesVector.push_back(contourType);
-            count++;
         }
         //qDebug() << "[contour] contour set name:"<< (*it)->getName() << "contour type:" << (*it)->getContourType();
     }

--- a/carta/cpp/core/Data/Image/Draw/DrawSynchronizer.cpp
+++ b/carta/cpp/core/Data/Image/Draw/DrawSynchronizer.cpp
@@ -94,7 +94,8 @@ void DrawSynchronizer::setContours( const std::set<std::shared_ptr<DataContours>
     QString contourType;
     bool drawing = false;
     bool hasDifferentContourType = false;
-    QString tmpContourType1, tmpContourType2;
+    QString tmpContourType = "null";
+    int count = 0;
     m_pens.clear();
     for( std::set< std::shared_ptr<DataContours> >::iterator it = contours.begin();
             it != contours.end(); it++ ){
@@ -105,20 +106,16 @@ void DrawSynchronizer::setContours( const std::set<std::shared_ptr<DataContours>
             std::vector<double> setLevels = (*it)->getLevels();
             levels.insert( levels.end(), setLevels.begin(), setLevels.end());
             levelsVector.push_back(setLevels);
+            // deal with the multiple contour types
             contourType = (*it)->getContourType();
+            if (count > 0 && contourType != tmpContourType) {
+                hasDifferentContourType = true;
+            }
+            tmpContourType = contourType;
             contourTypesVector.push_back(contourType);
+            count++;
         }
         //qDebug() << "[contour] contour set name:"<< (*it)->getName() << "contour type:" << (*it)->getContourType();
-    }
-    if (contourTypesVector.size() > 1) {
-        for (int i = 0; i < contourTypesVector.size(); i++) {
-            tmpContourType1 = tmpContourType2;
-            tmpContourType2 = contourTypesVector[i];
-            if (i > 0 && tmpContourType1 != tmpContourType2) {
-                hasDifferentContourType = true;
-                break;
-            }
-        }
     }
     m_cec->setHasDifferentContourTypes(hasDifferentContourType);
     if (drawing && hasDifferentContourType){

--- a/carta/cpp/core/DefaultContourGeneratorService.cpp
+++ b/carta/cpp/core/DefaultContourGeneratorService.cpp
@@ -26,12 +26,6 @@ DefaultContourGeneratorService::setContourTypesVector( const QStringList & conto
 }
 
 void
-DefaultContourGeneratorService::setLevels( const std::vector < double > & levels )
-{
-    m_levels = levels;
-}
-
-void
 DefaultContourGeneratorService::setLevelsVector( const std::vector < std::vector < double > > & levelsVector )
 {
     m_levelsVector = levelsVector;

--- a/carta/cpp/core/DefaultContourGeneratorService.cpp
+++ b/carta/cpp/core/DefaultContourGeneratorService.cpp
@@ -62,13 +62,9 @@ DefaultContourGeneratorService::timerCB()
     // set the output result
     Result result;
 
-    if (m_contourTypesVector.size() > 1) {
-        qDebug() << "++++++++ [contour] build the result for different contour types";
-    } else {
-        qDebug() << "++++++++ [contour] build the result for a single contour type";
-    }
     // run the contour algorithm
     for (int i = 0; i < m_contourTypesVector.size(); i++) {
+        qDebug() << "++++++++ [contour] build the contour for" << m_contourTypesVector.size() << "smoothness type(s)";
         Carta::Lib::Algorithms::ContourConrec cc;
         cc.setLevels(m_levelsVector[i]);
         auto rawContours = cc.compute(m_rawView.get(), m_contourTypesVector[i]);

--- a/carta/cpp/core/DefaultContourGeneratorService.cpp
+++ b/carta/cpp/core/DefaultContourGeneratorService.cpp
@@ -20,12 +20,6 @@ DefaultContourGeneratorService::DefaultContourGeneratorService( QObject * parent
 }
 
 void
-DefaultContourGeneratorService::setContourType( const QString & contourType )
-{
-    m_contourType = contourType;
-}
-
-void
 DefaultContourGeneratorService::setContourTypesVector( const QStringList & contourTypesVector )
 {
     m_contourTypesVector = contourTypesVector;
@@ -41,12 +35,6 @@ void
 DefaultContourGeneratorService::setLevelsVector( const std::vector < std::vector < double > > & levelsVector )
 {
     m_levelsVector = levelsVector;
-}
-
-void
-DefaultContourGeneratorService::setHasDifferentContourTypes(const bool & hasDifferentContourTypes )
-{
-    m_hasDifferentContourTypes = hasDifferentContourTypes;
 }
 
 void
@@ -80,30 +68,20 @@ DefaultContourGeneratorService::timerCB()
     // set the output result
     Result result;
 
-    // run the contour algorithm
-    if (m_hasDifferentContourTypes) {
-        // build the result for different contour types
+    if (m_contourTypesVector.size() > 1) {
         qDebug() << "++++++++ [contour] build the result for different contour types";
-        for (int i = 0; i < m_contourTypesVector.size(); i++) {
-            Carta::Lib::Algorithms::ContourConrec cc;
-            cc.setLevels(m_levelsVector[i]);
-            auto rawContours = cc.compute(m_rawView.get(), m_contourTypesVector[i]);
-            for (size_t j = 0; j < m_levelsVector[i].size(); ++ j) {
-                Carta::Lib::Contour contour( m_levelsVector[i][j], rawContours[j]);
-                result.add(contour);
-            }
-        }
     } else {
-        // build the result for a single contour type
         qDebug() << "++++++++ [contour] build the result for a single contour type";
+    }
+    // run the contour algorithm
+    for (int i = 0; i < m_contourTypesVector.size(); i++) {
         Carta::Lib::Algorithms::ContourConrec cc;
-        cc.setLevels(m_levels);
-        auto rawContours = cc.compute(m_rawView.get(), m_contourType);
-        for(size_t i = 0; i < m_levels.size(); ++ i) {
-            Carta::Lib::Contour contour( m_levels[i], rawContours[i]);
+        cc.setLevels(m_levelsVector[i]);
+        auto rawContours = cc.compute(m_rawView.get(), m_contourTypesVector[i]);
+        for (size_t j = 0; j < m_levelsVector[i].size(); ++ j) {
+            Carta::Lib::Contour contour( m_levelsVector[i][j], rawContours[j]);
             result.add(contour);
         }
-
     }
 
     int elapsedTime = timer.elapsed();

--- a/carta/cpp/core/DefaultContourGeneratorService.cpp
+++ b/carta/cpp/core/DefaultContourGeneratorService.cpp
@@ -20,15 +20,27 @@ DefaultContourGeneratorService::DefaultContourGeneratorService( QObject * parent
 }
 
 void
-DefaultContourGeneratorService::setName( const QString & name )
+DefaultContourGeneratorService::setContourType( const QString & contourType )
 {
-    m_name = name;
+    m_contourType = contourType;
+}
+
+void
+DefaultContourGeneratorService::setContourTypesVector( const QStringList & contourTypesVector )
+{
+    m_contourTypesVector = contourTypesVector;
 }
 
 void
 DefaultContourGeneratorService::setLevels( const std::vector < double > & levels )
 {
     m_levels = levels;
+}
+
+void
+DefaultContourGeneratorService::setLevelsVector( const std::vector < std::vector < double > > & levelsVector )
+{
+    m_levelsVector = levelsVector;
 }
 
 void
@@ -60,10 +72,22 @@ DefaultContourGeneratorService::timerCB()
     timer.start();
 
     // run the contour algorithm
-    Carta::Lib::Algorithms::ContourConrec cc;
+    //Carta::Lib::Algorithms::ContourConrec cc;
 
-    cc.setLevels(m_levels);
-    auto rawContours = cc.compute(m_rawView.get(), m_name);
+    //cc.setLevels(m_levels);
+    //auto rawContours = cc.compute(m_rawView.get(), m_name);
+
+    // build the result for different contour types
+    Result result;
+    for (int i = 0; i < m_contourTypesVector.size(); i++) {
+        Carta::Lib::Algorithms::ContourConrec cc;
+        cc.setLevels(m_levelsVector[i]);
+        auto rawContours = cc.compute(m_rawView.get(), m_contourTypesVector[i]);
+        for (size_t j = 0 ; j < m_levelsVector[i].size() ; ++ j) {
+            Carta::Lib::Contour contour( m_levelsVector[i][j], rawContours[j]);
+            result.add( contour);
+        }
+    }
 
     int elapsedTime = timer.elapsed();
     if (CARTA_RUNTIME_CHECKS) {
@@ -72,11 +96,11 @@ DefaultContourGeneratorService::timerCB()
     }
 
     // build the result
-    Result result;
-    for( size_t i = 0 ; i < m_levels.size() ; ++ i) {
-        Carta::Lib::Contour contour( m_levels[i], rawContours[i]);
-        result.add( contour);
-    }
+    //Result result;
+    //for( size_t i = 0 ; i < m_levels.size() ; ++ i) {
+    //    Carta::Lib::Contour contour( m_levels[i], rawContours[i]);
+    //    result.add( contour);
+    //}
 
     emit done( result, m_lastJobId );
 }

--- a/carta/cpp/core/DefaultContourGeneratorService.h
+++ b/carta/cpp/core/DefaultContourGeneratorService.h
@@ -24,10 +24,16 @@ public:
     DefaultContourGeneratorService( QObject * parent = 0 );
 
     virtual void
-    setName( const QString & name ) override;
+    setContourType(const QString & contourType ) override;
+
+    virtual void
+    setContourTypesVector(const QStringList & contourTypesVector ) override;
 
     virtual void
     setLevels( const std::vector < double > & levels ) override;
+
+    virtual void
+    setLevelsVector( const std::vector < std::vector < double > > & levelsVector ) override;
 
     virtual void
     setInput( Carta::Lib::NdArray::RawViewInterface::SharedPtr rawView ) override;
@@ -44,7 +50,9 @@ private slots:
 private:
 
     std::vector < double > m_levels;
-    QString m_name;
+    std::vector < std::vector < double > > m_levelsVector;
+    QString m_contourType;
+    QStringList m_contourTypesVector;
     JobId m_lastJobId = - 1;
     Carta::Lib::NdArray::RawViewInterface::SharedPtr m_rawView = nullptr;
     QTimer m_timer;

--- a/carta/cpp/core/DefaultContourGeneratorService.h
+++ b/carta/cpp/core/DefaultContourGeneratorService.h
@@ -24,9 +24,6 @@ public:
     DefaultContourGeneratorService( QObject * parent = 0 );
 
     virtual void
-    setContourType(const QString & contourType ) override;
-
-    virtual void
     setContourTypesVector(const QStringList & contourTypesVector ) override;
 
     virtual void
@@ -34,9 +31,6 @@ public:
 
     virtual void
     setLevelsVector( const std::vector < std::vector < double > > & levelsVector ) override;
-
-    virtual void
-    setHasDifferentContourTypes( const bool & hasDifferentContourTypes ) override;
 
     virtual void
     setInput( Carta::Lib::NdArray::RawViewInterface::SharedPtr rawView ) override;
@@ -56,7 +50,6 @@ private:
     std::vector < std::vector < double > > m_levelsVector;
     QString m_contourType;
     QStringList m_contourTypesVector;
-    bool m_hasDifferentContourTypes = false;
     JobId m_lastJobId = - 1;
     Carta::Lib::NdArray::RawViewInterface::SharedPtr m_rawView = nullptr;
     QTimer m_timer;

--- a/carta/cpp/core/DefaultContourGeneratorService.h
+++ b/carta/cpp/core/DefaultContourGeneratorService.h
@@ -36,6 +36,9 @@ public:
     setLevelsVector( const std::vector < std::vector < double > > & levelsVector ) override;
 
     virtual void
+    setHasDifferentContourTypes( const bool & hasDifferentContourTypes ) override;
+
+    virtual void
     setInput( Carta::Lib::NdArray::RawViewInterface::SharedPtr rawView ) override;
 
     virtual JobId
@@ -53,6 +56,7 @@ private:
     std::vector < std::vector < double > > m_levelsVector;
     QString m_contourType;
     QStringList m_contourTypesVector;
+    bool m_hasDifferentContourTypes = false;
     JobId m_lastJobId = - 1;
     Carta::Lib::NdArray::RawViewInterface::SharedPtr m_rawView = nullptr;
     QTimer m_timer;

--- a/carta/cpp/core/DefaultContourGeneratorService.h
+++ b/carta/cpp/core/DefaultContourGeneratorService.h
@@ -44,7 +44,6 @@ private slots:
 private:
 
     std::vector < std::vector < double > > m_levelsVector;
-    QString m_contourType;
     QStringList m_contourTypesVector;
     JobId m_lastJobId = - 1;
     Carta::Lib::NdArray::RawViewInterface::SharedPtr m_rawView = nullptr;

--- a/carta/cpp/core/DefaultContourGeneratorService.h
+++ b/carta/cpp/core/DefaultContourGeneratorService.h
@@ -27,9 +27,6 @@ public:
     setContourTypesVector(const QStringList & contourTypesVector ) override;
 
     virtual void
-    setLevels( const std::vector < double > & levels ) override;
-
-    virtual void
     setLevelsVector( const std::vector < std::vector < double > > & levelsVector ) override;
 
     virtual void
@@ -46,7 +43,6 @@ private slots:
 
 private:
 
-    std::vector < double > m_levels;
     std::vector < std::vector < double > > m_levelsVector;
     QString m_contourType;
     QStringList m_contourTypesVector;

--- a/carta/cpp/core/Hacks/ContourEditorController.cpp
+++ b/carta/cpp/core/Hacks/ContourEditorController.cpp
@@ -142,6 +142,7 @@ ContourEditorController::stdVarCB()
     qDebug() << "decoded string var:" << text;
 
     std::vector<double> levels;
+    std::vector<std::vector<double>> levelsVector;
     m_pens.resize( 0);
     double width = 1.0;
     QColor color = QColor( "green");
@@ -211,7 +212,8 @@ ContourEditorController::stdVarCB()
             qWarning() << "Error parsing contour UI:" << line;
         }
     }
-    m_contourSvc-> setLevels( levels);
+    levelsVector.push_back(levels);
+    m_contourSvc->setLevelsVector(levelsVector);
     emit updated();
 
 //    text.replace( ',',' ');


### PR DESCRIPTION
As shown in the figure below. We can now plot contours in the same intensity region and with different smoothness types. Currently, CARTA has six types of smoothness options, which are `w/ line combine optimization`, `w/o line combine optimization`, `Gaussian blur 3x3`, `Gaussian blur 5x5`, `Box blur 3x3` and `Box blur 5x5`. Different types of contour smoothness can be compared on the same image viewer.

![screenshot from 2017-11-20 16-31-08](https://user-images.githubusercontent.com/5379602/33051614-c9389330-cea5-11e7-8c5a-2ba4261cb9dd.png)
