### PR TITLE
Update colored histogram with different percentile or colormap settings

### DIFF
--- a/carta/cpp/core/Data/Histogram/Histogram.cpp
+++ b/carta/cpp/core/Data/Histogram/Histogram.cpp
@@ -145,6 +145,8 @@ QString Histogram::addLink( CartaObject*  target){
             if ( linkAdded ){
                 connect(controller, SIGNAL(dataChanged(Controller*)),
                 		this, SLOT(_createHistogram(Controller*)));
+                connect(controller, SIGNAL(colorChanged(Controller*)),
+                        this, SLOT(updateColorMap()));
                 connect(controller, SIGNAL(dataChangedRegion(Controller*)),
                                		this, SLOT(_createHistogram(Controller*)));
                 connect( controller,SIGNAL(frameChanged(Controller*, Carta::Lib::AxisInfo::KnownType)),
@@ -2126,12 +2128,15 @@ void Histogram::_updateChannel( Controller* controller, Carta::Lib::AxisInfo::Kn
 
 
 void Histogram::updateColorMap(){
-    Controller* controller = _getControllerSelected();
-    if ( controller ){
-        std::shared_ptr<DataSource> dataSource = controller->getDataSource();
-        if ( dataSource ){
-            std::shared_ptr<Carta::Lib::PixelPipeline::CustomizablePixelPipeline> pipeline = dataSource->_getPipeline();
-            m_plotManager->setPipeline( pipeline );
+    bool isColored = getColored();
+    if (isColored) {
+        Controller* controller = _getControllerSelected();
+        if ( controller ){
+            std::shared_ptr<DataSource> dataSource = controller->getDataSource();
+            if ( dataSource ){
+                std::shared_ptr<Carta::Lib::PixelPipeline::CustomizablePixelPipeline> pipeline = dataSource->_getPipeline();
+                m_plotManager->setPipeline( pipeline );
+            }
         }
     }
 }
@@ -2147,6 +2152,7 @@ void Histogram::_updateColorClips(double colorMinPercent, double colorMaxPercent
         //double colorMax = m_stateData.getValue<double>(COLOR_MAX);
         //emit colorIntensityBoundsChanged( colorMin, colorMax, autoClip );
         qDebug() << "++++++++ [Histogram] autoClip=" << autoClip;
+        updateColorMap();
         m_stateData.flushState();
     }
 }
@@ -2180,10 +2186,7 @@ void Histogram::_updatePlots( ){
 	m_plotManager->setLogScale( m_state.getValue<bool>( GRAPH_LOG_COUNT ) );
 	m_plotManager->setStyle( m_state.getValue<QString>( GRAPH_STYLE ) );
 	m_plotManager->setColored( m_state.getValue<bool>( GRAPH_COLORED ) );
-	bool isColored = getColored();
-	if (isColored) {
-	    updateColorMap();
-	}
+    updateColorMap();
 	m_plotManager->updatePlot();
 }
 

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -88,6 +88,7 @@ Controller::Controller( const QString& path, const QString& id ) :
 	connect( m_stack.get(), SIGNAL(contourSetRemoved(const QString&)),
 			this, SLOT(_contourSetRemoved(const QString&)));
 	connect( m_stack.get(), SIGNAL(colorStateChanged()), this, SLOT( _loadViewQueued() ));
+    connect( m_stack.get(), SIGNAL(colorStateChanged()), this, SLOT(_emitColorChanged()));
 	connect( m_stack.get(), SIGNAL(saveImageResult( bool)), this, SIGNAL(saveImageResult(bool)));
 	connect( m_stack.get(), SIGNAL(inputEvent(  InputEvent)), this,
 			SLOT( _onInputEvent( InputEvent )));
@@ -961,6 +962,10 @@ bool Controller::isStackSelectAuto() const {
 
 void Controller::_loadViewQueued( ){
     QMetaObject::invokeMethod( this, "_loadView", Qt::QueuedConnection );
+}
+
+void Controller::_emitColorChanged() {
+    emit colorChanged(this);
 }
 
 void Controller::_loadView(){

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -87,7 +87,6 @@ Controller::Controller( const QString& path, const QString& id ) :
 			this, SLOT(_contourSetAdded(Layer*, const QString&)));
 	connect( m_stack.get(), SIGNAL(contourSetRemoved(const QString&)),
 			this, SLOT(_contourSetRemoved(const QString&)));
-	connect( m_stack.get(), SIGNAL(colorStateChanged()), this, SLOT( _loadViewQueued() ));
     connect( m_stack.get(), SIGNAL(colorStateChanged()), this, SLOT(_emitColorChanged()));
 	connect( m_stack.get(), SIGNAL(saveImageResult( bool)), this, SIGNAL(saveImageResult(bool)));
 	connect( m_stack.get(), SIGNAL(inputEvent(  InputEvent)), this,
@@ -965,6 +964,7 @@ void Controller::_loadViewQueued( ){
 }
 
 void Controller::_emitColorChanged() {
+    _loadViewQueued();
     emit colorChanged(this);
 }
 

--- a/carta/cpp/core/Data/Image/Controller.h
+++ b/carta/cpp/core/Data/Image/Controller.h
@@ -644,6 +644,7 @@ private slots:
 	//Refresh the view based on the latest data selection information.
 	void _loadView(  );
 	void _loadViewQueued( );
+    void _emitColorChanged();
 	void _notifyFrameChange( Carta::Lib::AxisInfo::KnownType axis );
 	void _regionsChanged();
 


### PR DESCRIPTION
Let colored histogram can be updated with different percentile or colormap settings, as shown below:
![2017-12-12 4 54 12](https://user-images.githubusercontent.com/5379602/33875805-75c388bc-df5e-11e7-9756-b76d5cee51fe.png)
