### PR TITLE
Cjhsu/new arch grid control

### DIFF
--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1062,13 +1062,8 @@ void Controller::_initializeCallbacks(){
     //
     addCommandCallback( "setCoordinateSystem", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) -> QString {
-        // std::set<QString> keys = {DataGrid::COORD_SYSTEM};
-        // std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        // QString showAxisStr = dataValues[DataGrid::SHOW_AXIS];
-        // QString result = setCoordinateSystem( dataValues[DataGrid::COORD_SYSTEM] );
-        // Util::commandPostProcess( result );
-        QString stateName = DataGrid::COORD_SYSTEM;
-        QString result = m_stack->_setDataGridState( stateName, params );
+
+        QString result = m_stack->_setCoordinateSystem( params );
         return result;
     });
     //

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1382,28 +1382,18 @@ void Controller::_initializeCallbacks(){
     //         return result;
     //     });
     //
-    // addCommandCallback( "setTickThickness", [=] (const QString & /*cmd*/,
-    //                         const QString & params, const QString & /*sessionId*/) -> QString {
-    //                     QString result;
-    //                     std::set<QString> keys = {DataGrid::TICK};
-    //                     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //                     QString thicknessStr = dataValues[DataGrid::TICK];
-    //                     bool validInt = false;
-    //                     int thickness = thicknessStr.toInt( &validInt );
-    //                     if ( validInt ){
-    //                         result = setTickThickness( thickness  );
-    //                     }
-    //                     else {
-    //                         result = "Tick thickness must be a number:"+params;
-    //                     }
-    //                     Util::commandPostProcess( result );
-    //                     return result;
-    //                 });
-    //
+    addCommandCallback( "setTickThickness", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::TICK_WIDTH;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
     addCommandCallback( "setTickTransparency", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) -> QString {
 
-        QString stateName = Carta::State::UtilState::getLookup( DataGrid::TICK, Util::ALPHA );
+        QString stateName = DataGrid::TICK_ALPHA;
         QString result = m_stack->_setDataGridState( stateName, params );
         return result;
     });

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -137,7 +137,7 @@ QString Controller::_addDataImage(const QString& fileName, bool* success ) {
             _setLayersSelected( selectedLayers );
         }
         // _setSkyCSName();
-        _updateDisplayAxes();
+        // _updateDisplayAxes();
         emit dataChanged( this );
     }
     return result;
@@ -1767,19 +1767,19 @@ void Controller::_updateCursorText(bool notifyClients ){
 }
 
 
-void Controller::_updateDisplayAxes(){
-    // if ( m_gridControls ){
-    //     std::vector<AxisInfo> supportedAxes = m_stack->_getAxisInfos();
-    //     m_gridControls->_setAxisInfos( supportedAxes );
-    //     AxisInfo::KnownType xType = m_stack->_getAxisXType();
-    //     AxisInfo::KnownType yType = m_stack->_getAxisYType();
-    //     //const Carta::Lib::KnownSkyCS cs = getCoordinateSystem();
-    //     QString xPurpose = AxisMapper::getPurpose( xType );
-    //     QString yPurpose = AxisMapper::getPurpose( yType );
-    //     m_gridControls->setAxis( AxisMapper::AXIS_X, xPurpose );
-    //     m_gridControls->setAxis( AxisMapper::AXIS_Y, yPurpose );
-    // }
-}
+// void Controller::_updateDisplayAxes(){
+//     if ( m_gridControls ){
+//         std::vector<AxisInfo> supportedAxes = m_stack->_getAxisInfos();
+//         m_gridControls->_setAxisInfos( supportedAxes );
+//         AxisInfo::KnownType xType = m_stack->_getAxisXType();
+//         AxisInfo::KnownType yType = m_stack->_getAxisYType();
+//         //const Carta::Lib::KnownSkyCS cs = getCoordinateSystem();
+//         QString xPurpose = AxisMapper::getPurpose( xType );
+//         QString yPurpose = AxisMapper::getPurpose( yType );
+//         m_gridControls->setAxis( AxisMapper::AXIS_X, xPurpose );
+//         m_gridControls->setAxis( AxisMapper::AXIS_Y, yPurpose );
+//     }
+// }
 
 void Controller::updatePanZoomLevelJS( double centerX, double centerY, double zoomLevel, double layerId ){
     m_stack->_updatePanZoom( centerX, centerY, -1, false, zoomLevel, layerId);

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1113,24 +1113,6 @@ void Controller::_initializeCallbacks(){
     //                 return result;
     //             });
     //
-    // addCommandCallback( "setGridSpacing", [=] (const QString & /*cmd*/,
-    //                         const QString & params, const QString & /*sessionId*/) -> QString {
-    //                     QString result;
-    //                     std::set<QString> keys = {DataGrid::SPACING};
-    //                     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //                     QString spacingStr = dataValues[DataGrid::SPACING];
-    //                     bool validDouble = false;
-    //                     double spacing = spacingStr.toDouble( &validDouble );
-    //                     if ( validDouble ){
-    //                         result = setGridSpacing( spacing  );
-    //                     }
-    //                     else {
-    //                         result = "Grid spacing must be a number:"+params;
-    //                     }
-    //                     Util::commandPostProcess( result );
-    //                     return result;
-    //                 });
-    //
     addCommandCallback( "setFontSize", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) -> QString {
 
@@ -1143,6 +1125,14 @@ void Controller::_initializeCallbacks(){
             const QString & params, const QString & /*sessionId*/) -> QString {
 
         QString stateName = DataGrid::GRID_WIDTH;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
+    addCommandCallback( "setGridSpacing", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::SPACING;
         QString result = m_stack->_setDataGridState( stateName, params );
         return result;
     });
@@ -1203,25 +1193,15 @@ void Controller::_initializeCallbacks(){
         QString result = m_stack->_setDataGridState( stateName, params );
         return result;
     });
-    //
-    // addCommandCallback( "setShowInternalLabels", [=] (const QString & /*cmd*/,
-    //                     const QString & params, const QString & /*sessionId*/) -> QString {
-    //                 QString result;
-    //                 std::set<QString> keys = {DataGrid::SHOW_INTERNAL_LABELS};
-    //                 std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //                 QString showLabelsStr = dataValues[DataGrid::SHOW_INTERNAL_LABELS];
-    //                 bool validBool = false;
-    //                 bool showLabels = Util::toBool( showLabelsStr, &validBool );
-    //                 if ( validBool ){
-    //                     result = setShowInternalLabels( showLabels  );
-    //                 }
-    //                 else {
-    //                     result = "Showing internal axis labels must be true/false:"+params;
-    //                 }
-    //                 Util::commandPostProcess( result );
-    //                 return result;
-    //             });
-    //
+
+    addCommandCallback( "setShowInternalLabels", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::SHOW_INTERNAL_LABELS;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
     addCommandCallback( "setShowTicks", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) -> QString {
 

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1400,23 +1400,13 @@ void Controller::_initializeCallbacks(){
     //                     return result;
     //                 });
     //
-    // addCommandCallback( "setTickTransparency", [=] (const QString & /*cmd*/,
-    //                                     const QString & params, const QString & /*sessionId*/) -> QString {
-    //         QString result;
-    //         std::set<QString> keys = {Util::ALPHA};
-    //         std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //         QString transparencyStr = dataValues[Util::ALPHA];
-    //         bool validInt = false;
-    //         int transparency = transparencyStr.toInt( &validInt );
-    //         if ( validInt ){
-    //             result = setTickTransparency( transparency );
-    //         }
-    //         else {
-    //             result = "Tick transparency must be an integer:"+params;
-    //         }
-    //         Util::commandPostProcess( result );
-    //         return result;
-    //     });
+    addCommandCallback( "setTickTransparency", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = Carta::State::UtilState::getLookup( DataGrid::TICK, Util::ALPHA );
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
     //
     // addCommandCallback( "setTheme", [=] (const QString & /*cmd*/,
     //                         const QString & params, const QString & /*sessionId*/) -> QString {

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1080,15 +1080,17 @@ void Controller::_initializeCallbacks(){
     //     return result;
     // });
     //
-    // addCommandCallback( "setCoordinateSystem", [=] (const QString & /*cmd*/,
-    //                 const QString & params, const QString & /*sessionId*/) -> QString {
-    //             std::set<QString> keys = {DataGrid::COORD_SYSTEM};
-    //             std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //             QString showAxisStr = dataValues[DataGrid::SHOW_AXIS];
-    //             QString result = setCoordinateSystem( dataValues[DataGrid::COORD_SYSTEM] );
-    //             Util::commandPostProcess( result );
-    //             return result;
-    //         });
+    addCommandCallback( "setCoordinateSystem", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+        // std::set<QString> keys = {DataGrid::COORD_SYSTEM};
+        // std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+        // QString showAxisStr = dataValues[DataGrid::SHOW_AXIS];
+        // QString result = setCoordinateSystem( dataValues[DataGrid::COORD_SYSTEM] );
+        // Util::commandPostProcess( result );
+        QString stateName = DataGrid::COORD_SYSTEM;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
     //
     // addCommandCallback( "setGridLabelFormat", [=] (const QString & /*cmd*/,
     //                     const QString & params, const QString & /*sessionId*/) -> QString {
@@ -1238,60 +1240,29 @@ void Controller::_initializeCallbacks(){
     //         return errors;
     //     });
     //
-    // addCommandCallback( "setShowAxis", [=] (const QString & /*cmd*/,
-    //             const QString & params, const QString & /*sessionId*/) -> QString {
-    //         QString result;
-    //         std::set<QString> keys = {DataGrid::SHOW_AXIS};
-    //         std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //         QString showAxisStr = dataValues[DataGrid::SHOW_AXIS];
-    //         bool validBool = false;
-    //         bool showAxis = Util::toBool( showAxisStr, &validBool );
-    //         if ( validBool ){
-    //             result = setShowAxis( showAxis  );
-    //         }
-    //         else {
-    //             result = "Making an axis visible/invisible must be true/false:"+params;
-    //         }
-    //         Util::commandPostProcess( result );
-    //         return result;
-    //     });
-    //
-    // addCommandCallback( "setShowCoordinateSystem", [=] (const QString & /*cmd*/,
-    //                 const QString & params, const QString & /*sessionId*/) -> QString {
-    //             QString result;
-    //             std::set<QString> keys = {DataGrid::SHOW_COORDS};
-    //             std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //             QString showCoordsStr = dataValues[DataGrid::SHOW_COORDS];
-    //             bool validBool = false;
-    //             bool showCoord = Util::toBool( showCoordsStr, &validBool );
-    //             if ( validBool ){
-    //                 result = setShowCoordinateSystem( showCoord );
-    //             }
-    //             else {
-    //                 result = "Whether or not to show the coordinate system must be true/false:"+params;
-    //             }
-    //             Util::commandPostProcess( result );
-    //             return result;
-    //         });
-    //
-    //
-    // addCommandCallback( "setShowGridLines", [=] (const QString & /*cmd*/,
-    //                 const QString & params, const QString & /*sessionId*/) -> QString {
-    //             QString result;
-    //             std::set<QString> keys = {DataGrid::SHOW_GRID_LINES};
-    //             std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //             QString showLinesStr = dataValues[DataGrid::SHOW_GRID_LINES];
-    //             bool validBool = false;
-    //             bool showLines = Util::toBool( showLinesStr, &validBool );
-    //             if ( validBool ){
-    //                 result = setShowGridLines( showLines  );
-    //             }
-    //             else {
-    //                 result = "Setting axis grid lines visible/invisible must be true/false:"+params;
-    //             }
-    //             Util::commandPostProcess( result );
-    //             return result;
-    //         });
+    addCommandCallback( "setShowAxis", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::SHOW_AXIS;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
+    addCommandCallback( "setShowCoordinateSystem", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::SHOW_COORDS;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
+    addCommandCallback( "setShowGridLines", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::SHOW_GRID_LINES;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
     //
     // addCommandCallback( "setShowInternalLabels", [=] (const QString & /*cmd*/,
     //                     const QString & params, const QString & /*sessionId*/) -> QString {
@@ -1354,24 +1325,14 @@ void Controller::_initializeCallbacks(){
     //            return errors;
     //        });
     //
-    // addCommandCallback( "setTickLength", [=] (const QString & /*cmd*/,
-    //                             const QString & params, const QString & /*sessionId*/) -> QString {
-    //         QString result;
-    //         std::set<QString> keys = {DataGrid::TICK_LENGTH};
-    //         std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //         QString lengthStr = dataValues[DataGrid::TICK_LENGTH];
-    //         bool validInt = false;
-    //         int length = lengthStr.toInt( &validInt );
-    //         if ( validInt ){
-    //             result = setTickLength( length  );
-    //         }
-    //         else {
-    //             result = "Tick length must be a number:"+params;
-    //         }
-    //         Util::commandPostProcess( result );
-    //         return result;
-    //     });
-    //
+    addCommandCallback( "setTickLength", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::TICK_LENGTH;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
     addCommandCallback( "setTickThickness", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) -> QString {
 

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1043,23 +1043,18 @@ void Controller::_initializeCallbacks(){
 
     addCommandCallback( "setAxisX", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) ->QString {
-        // std::set<QString> keys = {AxisMapper::AXIS_X};
-        // std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-        // QString axisName = dataValues[AxisMapper::AXIS_X];
-        // QString result = setAxis( AxisMapper::AXIS_X, axisName );
-        QString result = m_stack->_setAxisX( params );
+
+        QString result = m_stack->_setAxis( AxisMapper::AXIS_X, params );
         return result;
     });
-    //
-    // addCommandCallback( "setAxisY", [=] (const QString & /*cmd*/,
-    //                     const QString & params, const QString & /*sessionId*/) ->QString {
-    //     std::set<QString> keys = {AxisMapper::AXIS_Y};
-    //     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //     QString axisName = dataValues[AxisMapper::AXIS_Y];
-    //     QString result = setAxis( AxisMapper::AXIS_Y, axisName );
-    //     return result;
-    // });
-    //
+
+    addCommandCallback( "setAxisY", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) ->QString {
+
+        QString result = m_stack->_setAxis( AxisMapper::AXIS_Y, axisName );
+        return result;
+    });
+
     addCommandCallback( "setCoordinateSystem", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) -> QString {
 
@@ -1099,15 +1094,15 @@ void Controller::_initializeCallbacks(){
     //         return errors;
     //     });
     //
-    // addCommandCallback( "setFontFamily", [=] (const QString & /*cmd*/,
-    //                     const QString & params, const QString & /*sessionId*/) -> QString {
-    //                 std::set<QString> keys = {Fonts::FONT_FAMILY};
-    //                 std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //                 QString result = setFontFamily( dataValues[Fonts::FONT_FAMILY] );
-    //                 Util::commandPostProcess( result );
-    //                 return result;
-    //             });
-    //
+    addCommandCallback( "setFontFamily", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        // TODO: the function is unfinished
+        QString stateName = DataGrid::FONT_FAMILY;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
     addCommandCallback( "setFontSize", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) -> QString {
 

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1186,6 +1186,22 @@ void Controller::_initializeCallbacks(){
         return result;
     });
 
+    addCommandCallback( "setShowDefaultCoordinateSystem", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::SHOW_DEFAULT_COORDS;
+        QString result = m_stack->_setDataGridState( stateName, params );
+
+        Carta::State::StateInterface stackDataGridState = m_stack->_getDataGridState();
+        bool useDefault = stackDataGridState.getValue<bool>( DataGrid::SHOW_DEFAULT_COORDS );
+        if ( useDefault ){
+            CoordinateSystems* m_coords = Util::findSingletonObject<CoordinateSystems>();
+            QString defaultName = m_coords->getDefault();
+            result = m_stack->_setCoordinateSystem( defaultName );
+        }
+        return result;
+    });
+
     addCommandCallback( "setShowGridLines", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) -> QString {
 

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1062,7 +1062,7 @@ void Controller::_initializeCallbacks(){
     // });
     //
     addCommandCallback( "setAxisX", [=] (const QString & /*cmd*/,
-                        const QString & params, const QString & /*sessionId*/) ->QString {
+            const QString & params, const QString & /*sessionId*/) ->QString {
         // std::set<QString> keys = {AxisMapper::AXIS_X};
         // std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
         // QString axisName = dataValues[AxisMapper::AXIS_X];

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1025,42 +1025,22 @@ void Controller::_initializeCallbacks(){
     //     return errors;
     // });
     //
-    // addCommandCallback( "setAxesThickness", [=] (const QString & /*cmd*/,
-    //                                 const QString & params, const QString & /*sessionId*/) -> QString {
-    //    QString result;
-    //    std::set<QString> keys = {DataGrid::AXES};
-    //    std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //    QString thicknessStr = dataValues[DataGrid::AXES];
-    //    bool validInt = false;
-    //    int thickness = thicknessStr.toInt( &validInt );
-    //    if ( validInt ){
-    //        result = setAxesThickness( thickness  );
-    //    }
-    //    else {
-    //        result = "Axes thickness must be a number:"+params;
-    //    }
-    //     Util::commandPostProcess( result );
-    //     return result;
-    // });
-    //
-    // addCommandCallback( "setAxesTransparency", [=] (const QString & /*cmd*/,
-    //                                 const QString & params, const QString & /*sessionId*/) -> QString {
-    //     QString result;
-    //     std::set<QString> keys = {Util::ALPHA};
-    //     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //     QString transparencyStr = dataValues[Util::ALPHA];
-    //     bool validInt = false;
-    //     int transparency = transparencyStr.toInt( &validInt );
-    //     if ( validInt ){
-    //         result = setAxesTransparency( transparency );
-    //     }
-    //     else {
-    //         result = "Axes transparency must be an integer:"+params;
-    //     }
-    //     Util::commandPostProcess( result );
-    //     return result;
-    // });
-    //
+    addCommandCallback( "setAxesThickness", [=] (const QString & /*cmd*/,
+                                    const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::AXES_WIDTH;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
+    addCommandCallback( "setAxesTransparency", [=] (const QString & /*cmd*/,
+                                    const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::AXES_ALPHA;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
     addCommandCallback( "setAxisX", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) ->QString {
         // std::set<QString> keys = {AxisMapper::AXIS_X};
@@ -1133,42 +1113,6 @@ void Controller::_initializeCallbacks(){
     //                 return result;
     //             });
     //
-    // addCommandCallback( "setFontSize", [=] (const QString & /*cmd*/,
-    //                         const QString & params, const QString & /*sessionId*/) -> QString {
-    //                     QString result;
-    //                     std::set<QString> keys = {Fonts::FONT_SIZE};
-    //                     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //                     QString fontSizeStr = dataValues[Fonts::FONT_SIZE];
-    //                     bool validInt = false;
-    //                     int fontSize = fontSizeStr.toInt(&validInt);
-    //                     if ( validInt ){
-    //                         result = setFontSize( fontSize );
-    //                     }
-    //                     else {
-    //                         result = "Font size must be a nonnegative integer: "+fontSizeStr;
-    //                     }
-    //                     Util::commandPostProcess( result );
-    //                     return result;
-    //                 });
-    //
-    // addCommandCallback( "setGridThickness", [=] (const QString & /*cmd*/,
-    //                     const QString & params, const QString & /*sessionId*/) -> QString {
-    //                 QString result;
-    //                 std::set<QString> keys = {DataGrid::GRID};
-    //                 std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //                 QString thicknessStr = dataValues[DataGrid::GRID];
-    //                 bool validInt = false;
-    //                 int thickness = thicknessStr.toInt( &validInt );
-    //                 if ( validInt ){
-    //                     result = setGridThickness( thickness  );
-    //                 }
-    //                 else {
-    //                     result = "Grid thickness must be a number:"+params;
-    //                 }
-    //                 Util::commandPostProcess( result );
-    //                 return result;
-    //             });
-    //
     // addCommandCallback( "setGridSpacing", [=] (const QString & /*cmd*/,
     //                         const QString & params, const QString & /*sessionId*/) -> QString {
     //                     QString result;
@@ -1187,42 +1131,38 @@ void Controller::_initializeCallbacks(){
     //                     return result;
     //                 });
     //
-    // addCommandCallback( "setGridTransparency", [=] (const QString & /*cmd*/,
-    //                             const QString & params, const QString & /*sessionId*/) -> QString {
-    //         QString result;
-    //         std::set<QString> keys = {Util::ALPHA};
-    //         std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //         QString transparencyStr = dataValues[Util::ALPHA];
-    //         bool validInt = false;
-    //         int transparency = transparencyStr.toInt( &validInt );
-    //         if ( validInt ){
-    //             result = setGridTransparency( transparency );
-    //         }
-    //         else {
-    //             result = "Grid transparency must be an integer:"+params;
-    //         }
-    //         Util::commandPostProcess( result );
-    //         return result;
-    //     });
-    //
-    // addCommandCallback( "setLabelDecimals", [=] (const QString & /*cmd*/,
-    //                                 const QString & params, const QString & /*sessionId*/) -> QString {
-    //     QString result;
-    //     std::set<QString> keys = {DataGrid::LABEL_DECIMAL_PLACES};
-    //     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //     QString decimalsStr = dataValues[DataGrid::LABEL_DECIMAL_PLACES];
-    //     bool validInt = false;
-    //     int decimalPlaces = decimalsStr.toInt( &validInt );
-    //     if ( validInt ){
-    //         result = setLabelDecimals( decimalPlaces );
-    //     }
-    //     else {
-    //         result = "Grid label decimal places must be an integer:"+params;
-    //     }
-    //     Util::commandPostProcess( result );
-    //     return result;
-    // });
-    //
+    addCommandCallback( "setFontSize", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::FONT_SIZE;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
+    addCommandCallback( "setGridThickness", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::GRID_WIDTH;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
+    addCommandCallback( "setGridTransparency", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::GRID_ALPHA;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
+    addCommandCallback( "setLabelDecimals", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::LABEL_DECIMAL_PLACES;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
+
     // addCommandCallback( "setLabelColor", [=] (const QString & /*cmd*/,
     //                             const QString & params, const QString & /*sessionId*/) -> QString {
     //         int redAmount = 0;

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -92,8 +92,8 @@ Controller::Controller( const QString& path, const QString& id ) :
 	connect( m_stack.get(), SIGNAL(inputEvent(  InputEvent)), this,
 			SLOT( _onInputEvent( InputEvent )));
 
-	GridControls* gridObj = objMan->createObject<GridControls>();
-	m_gridControls.reset( gridObj );
+	// GridControls* gridObj = objMan->createObject<GridControls>();
+	// m_gridControls.reset( gridObj );
 	// connect( m_gridControls.get(), SIGNAL(gridChanged( const Carta::State::StateInterface&,bool)),
 	// 		this, SLOT(_gridChanged( const Carta::State::StateInterface&, bool )));
 	// connect( m_gridControls.get(), SIGNAL(displayAxesChanged(std::vector<Carta::Lib::AxisInfo::KnownType>,bool )),
@@ -135,7 +135,7 @@ QString Controller::_addDataImage(const QString& fileName, bool* success ) {
             selectedLayers.append( stackId );
             _setLayersSelected( selectedLayers );
         }
-        _setSkyCSName();
+        // _setSkyCSName();
         _updateDisplayAxes();
         emit dataChanged( this );
     }
@@ -816,9 +816,9 @@ void Controller::_initializeCallbacks(){
     addCommandCallback( "registerGridControls", [=] (const QString & /*cmd*/,
                         const QString & /*params*/, const QString & /*sessionId*/) -> QString {
         QString result;
-        if ( m_gridControls.get() != nullptr ){
-            result = m_gridControls->getPath();
-        }
+        // if ( m_gridControls.get() != nullptr ){
+        //     result = m_gridControls->getPath();
+        // }
         return result;
     });
 
@@ -984,6 +984,448 @@ void Controller::_initializeCallbacks(){
         Util::commandPostProcess( result );
         return result;
     });
+
+
+
+////////// Copy the callback functions in gridcontrol here. A note for unfinished commands.
+
+    // addCommandCallback( "setApplyAll", [=] (const QString & /*cmd*/,
+    //                const QString & params, const QString & /*sessionId*/) -> QString {
+    //            QString result;
+    //            std::set<QString> keys = {ALL};
+    //            std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //            QString applyAllStr = dataValues[ALL];
+    //            bool validBool = false;
+    //            bool applyAll = Util::toBool( applyAllStr, &validBool );
+    //            if ( validBool ){
+    //                setApplyAll( applyAll  );
+    //            }
+    //            else {
+    //                result = "Whether or not to apply grid changes to all images must be true/false:"+params;
+    //            }
+    //            Util::commandPostProcess( result );
+    //            return result;
+    //        });
+    //
+    //
+    // addCommandCallback( "setAxesColor", [=] (const QString & /*cmd*/,
+    //                                 const QString & params, const QString & /*sessionId*/) -> QString {
+    //     int redAmount = 0;
+    //     int greenAmount = 0;
+    //     int blueAmount = 0;
+    //     QStringList result = _parseColorParams( params, "Axes", &redAmount, &greenAmount, &blueAmount);
+    //     if ( result.size() == 0 ){
+    //         result = setAxesColor( redAmount, greenAmount, blueAmount );
+    //     }
+    //     QString errors;
+    //     if ( result.size() > 0 ){
+    //         errors = result.join( ",");
+    //     }
+    //     Util::commandPostProcess( errors );
+    //     return errors;
+    // });
+    //
+    // addCommandCallback( "setAxesThickness", [=] (const QString & /*cmd*/,
+    //                                 const QString & params, const QString & /*sessionId*/) -> QString {
+    //    QString result;
+    //    std::set<QString> keys = {DataGrid::AXES};
+    //    std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //    QString thicknessStr = dataValues[DataGrid::AXES];
+    //    bool validInt = false;
+    //    int thickness = thicknessStr.toInt( &validInt );
+    //    if ( validInt ){
+    //        result = setAxesThickness( thickness  );
+    //    }
+    //    else {
+    //        result = "Axes thickness must be a number:"+params;
+    //    }
+    //     Util::commandPostProcess( result );
+    //     return result;
+    // });
+    //
+    // addCommandCallback( "setAxesTransparency", [=] (const QString & /*cmd*/,
+    //                                 const QString & params, const QString & /*sessionId*/) -> QString {
+    //     QString result;
+    //     std::set<QString> keys = {Util::ALPHA};
+    //     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //     QString transparencyStr = dataValues[Util::ALPHA];
+    //     bool validInt = false;
+    //     int transparency = transparencyStr.toInt( &validInt );
+    //     if ( validInt ){
+    //         result = setAxesTransparency( transparency );
+    //     }
+    //     else {
+    //         result = "Axes transparency must be an integer:"+params;
+    //     }
+    //     Util::commandPostProcess( result );
+    //     return result;
+    // });
+    //
+    // addCommandCallback( "setAxisX", [=] (const QString & /*cmd*/,
+    //                     const QString & params, const QString & /*sessionId*/) ->QString {
+    //     std::set<QString> keys = {AxisMapper::AXIS_X};
+    //     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //     QString axisName = dataValues[AxisMapper::AXIS_X];
+    //     QString result = setAxis( AxisMapper::AXIS_X, axisName );
+    //     return result;
+    // });
+    //
+    // addCommandCallback( "setAxisY", [=] (const QString & /*cmd*/,
+    //                     const QString & params, const QString & /*sessionId*/) ->QString {
+    //     std::set<QString> keys = {AxisMapper::AXIS_Y};
+    //     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //     QString axisName = dataValues[AxisMapper::AXIS_Y];
+    //     QString result = setAxis( AxisMapper::AXIS_Y, axisName );
+    //     return result;
+    // });
+    //
+    // addCommandCallback( "setCoordinateSystem", [=] (const QString & /*cmd*/,
+    //                 const QString & params, const QString & /*sessionId*/) -> QString {
+    //             std::set<QString> keys = {DataGrid::COORD_SYSTEM};
+    //             std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //             QString showAxisStr = dataValues[DataGrid::SHOW_AXIS];
+    //             QString result = setCoordinateSystem( dataValues[DataGrid::COORD_SYSTEM] );
+    //             Util::commandPostProcess( result );
+    //             return result;
+    //         });
+    //
+    // addCommandCallback( "setGridLabelFormat", [=] (const QString & /*cmd*/,
+    //                     const QString & params, const QString & /*sessionId*/) -> QString {
+    //                 std::set<QString> keys = {DataGrid::FORMAT, DataGrid::LABEL_SIDE};
+    //                 std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //                 QString format = dataValues[DataGrid::FORMAT];
+    //                 //Because the map expects colons and the label format has colons,
+    //                 //the format colons are replaced with a - before sending from the
+    //                 //client and the server must restore the colons.
+    //                 format = format.replace( "-", ":");
+    //                 QString labelSide = dataValues[DataGrid::LABEL_SIDE];
+    //                 QString result = setLabelFormat( labelSide, format );
+    //                 Util::commandPostProcess( result );
+    //                 return result;
+    //             });
+    //
+    // addCommandCallback( "setGridColor", [=] (const QString & /*cmd*/,
+    //                                     const QString & params, const QString & /*sessionId*/) -> QString {
+    //         int redAmount = 0;
+    //         int greenAmount = 0;
+    //         int blueAmount = 0;
+    //         QStringList result = _parseColorParams( params, DataGrid::GRID, &redAmount, &greenAmount, &blueAmount);
+    //         if ( result.size() == 0 ){
+    //             result = setGridColor( redAmount, greenAmount, blueAmount );
+    //         }
+    //         QString errors;
+    //         if ( result.size() > 0 ){
+    //             errors = result.join( ",");
+    //         }
+    //         Util::commandPostProcess( errors );
+    //         return errors;
+    //     });
+    //
+    // addCommandCallback( "setFontFamily", [=] (const QString & /*cmd*/,
+    //                     const QString & params, const QString & /*sessionId*/) -> QString {
+    //                 std::set<QString> keys = {Fonts::FONT_FAMILY};
+    //                 std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //                 QString result = setFontFamily( dataValues[Fonts::FONT_FAMILY] );
+    //                 Util::commandPostProcess( result );
+    //                 return result;
+    //             });
+    //
+    // addCommandCallback( "setFontSize", [=] (const QString & /*cmd*/,
+    //                         const QString & params, const QString & /*sessionId*/) -> QString {
+    //                     QString result;
+    //                     std::set<QString> keys = {Fonts::FONT_SIZE};
+    //                     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //                     QString fontSizeStr = dataValues[Fonts::FONT_SIZE];
+    //                     bool validInt = false;
+    //                     int fontSize = fontSizeStr.toInt(&validInt);
+    //                     if ( validInt ){
+    //                         result = setFontSize( fontSize );
+    //                     }
+    //                     else {
+    //                         result = "Font size must be a nonnegative integer: "+fontSizeStr;
+    //                     }
+    //                     Util::commandPostProcess( result );
+    //                     return result;
+    //                 });
+    //
+    // addCommandCallback( "setGridThickness", [=] (const QString & /*cmd*/,
+    //                     const QString & params, const QString & /*sessionId*/) -> QString {
+    //                 QString result;
+    //                 std::set<QString> keys = {DataGrid::GRID};
+    //                 std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //                 QString thicknessStr = dataValues[DataGrid::GRID];
+    //                 bool validInt = false;
+    //                 int thickness = thicknessStr.toInt( &validInt );
+    //                 if ( validInt ){
+    //                     result = setGridThickness( thickness  );
+    //                 }
+    //                 else {
+    //                     result = "Grid thickness must be a number:"+params;
+    //                 }
+    //                 Util::commandPostProcess( result );
+    //                 return result;
+    //             });
+    //
+    // addCommandCallback( "setGridSpacing", [=] (const QString & /*cmd*/,
+    //                         const QString & params, const QString & /*sessionId*/) -> QString {
+    //                     QString result;
+    //                     std::set<QString> keys = {DataGrid::SPACING};
+    //                     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //                     QString spacingStr = dataValues[DataGrid::SPACING];
+    //                     bool validDouble = false;
+    //                     double spacing = spacingStr.toDouble( &validDouble );
+    //                     if ( validDouble ){
+    //                         result = setGridSpacing( spacing  );
+    //                     }
+    //                     else {
+    //                         result = "Grid spacing must be a number:"+params;
+    //                     }
+    //                     Util::commandPostProcess( result );
+    //                     return result;
+    //                 });
+    //
+    // addCommandCallback( "setGridTransparency", [=] (const QString & /*cmd*/,
+    //                             const QString & params, const QString & /*sessionId*/) -> QString {
+    //         QString result;
+    //         std::set<QString> keys = {Util::ALPHA};
+    //         std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //         QString transparencyStr = dataValues[Util::ALPHA];
+    //         bool validInt = false;
+    //         int transparency = transparencyStr.toInt( &validInt );
+    //         if ( validInt ){
+    //             result = setGridTransparency( transparency );
+    //         }
+    //         else {
+    //             result = "Grid transparency must be an integer:"+params;
+    //         }
+    //         Util::commandPostProcess( result );
+    //         return result;
+    //     });
+    //
+    // addCommandCallback( "setLabelDecimals", [=] (const QString & /*cmd*/,
+    //                                 const QString & params, const QString & /*sessionId*/) -> QString {
+    //     QString result;
+    //     std::set<QString> keys = {DataGrid::LABEL_DECIMAL_PLACES};
+    //     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //     QString decimalsStr = dataValues[DataGrid::LABEL_DECIMAL_PLACES];
+    //     bool validInt = false;
+    //     int decimalPlaces = decimalsStr.toInt( &validInt );
+    //     if ( validInt ){
+    //         result = setLabelDecimals( decimalPlaces );
+    //     }
+    //     else {
+    //         result = "Grid label decimal places must be an integer:"+params;
+    //     }
+    //     Util::commandPostProcess( result );
+    //     return result;
+    // });
+    //
+    // addCommandCallback( "setLabelColor", [=] (const QString & /*cmd*/,
+    //                             const QString & params, const QString & /*sessionId*/) -> QString {
+    //         int redAmount = 0;
+    //         int greenAmount = 0;
+    //         int blueAmount = 0;
+    //         QStringList result = _parseColorParams( params, "Label", &redAmount, &greenAmount, &blueAmount);
+    //         if ( result.size() == 0 ){
+    //             result = setLabelColor( redAmount, greenAmount, blueAmount );
+    //         }
+    //         QString errors;
+    //         if ( result.size() > 0 ){
+    //             errors = result.join( ",");
+    //         }
+    //         Util::commandPostProcess( errors );
+    //         return errors;
+    //     });
+    //
+    // addCommandCallback( "setShowAxis", [=] (const QString & /*cmd*/,
+    //             const QString & params, const QString & /*sessionId*/) -> QString {
+    //         QString result;
+    //         std::set<QString> keys = {DataGrid::SHOW_AXIS};
+    //         std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //         QString showAxisStr = dataValues[DataGrid::SHOW_AXIS];
+    //         bool validBool = false;
+    //         bool showAxis = Util::toBool( showAxisStr, &validBool );
+    //         if ( validBool ){
+    //             result = setShowAxis( showAxis  );
+    //         }
+    //         else {
+    //             result = "Making an axis visible/invisible must be true/false:"+params;
+    //         }
+    //         Util::commandPostProcess( result );
+    //         return result;
+    //     });
+    //
+    // addCommandCallback( "setShowCoordinateSystem", [=] (const QString & /*cmd*/,
+    //                 const QString & params, const QString & /*sessionId*/) -> QString {
+    //             QString result;
+    //             std::set<QString> keys = {DataGrid::SHOW_COORDS};
+    //             std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //             QString showCoordsStr = dataValues[DataGrid::SHOW_COORDS];
+    //             bool validBool = false;
+    //             bool showCoord = Util::toBool( showCoordsStr, &validBool );
+    //             if ( validBool ){
+    //                 result = setShowCoordinateSystem( showCoord );
+    //             }
+    //             else {
+    //                 result = "Whether or not to show the coordinate system must be true/false:"+params;
+    //             }
+    //             Util::commandPostProcess( result );
+    //             return result;
+    //         });
+    //
+    //
+    // addCommandCallback( "setShowGridLines", [=] (const QString & /*cmd*/,
+    //                 const QString & params, const QString & /*sessionId*/) -> QString {
+    //             QString result;
+    //             std::set<QString> keys = {DataGrid::SHOW_GRID_LINES};
+    //             std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //             QString showLinesStr = dataValues[DataGrid::SHOW_GRID_LINES];
+    //             bool validBool = false;
+    //             bool showLines = Util::toBool( showLinesStr, &validBool );
+    //             if ( validBool ){
+    //                 result = setShowGridLines( showLines  );
+    //             }
+    //             else {
+    //                 result = "Setting axis grid lines visible/invisible must be true/false:"+params;
+    //             }
+    //             Util::commandPostProcess( result );
+    //             return result;
+    //         });
+    //
+    // addCommandCallback( "setShowInternalLabels", [=] (const QString & /*cmd*/,
+    //                     const QString & params, const QString & /*sessionId*/) -> QString {
+    //                 QString result;
+    //                 std::set<QString> keys = {DataGrid::SHOW_INTERNAL_LABELS};
+    //                 std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //                 QString showLabelsStr = dataValues[DataGrid::SHOW_INTERNAL_LABELS];
+    //                 bool validBool = false;
+    //                 bool showLabels = Util::toBool( showLabelsStr, &validBool );
+    //                 if ( validBool ){
+    //                     result = setShowInternalLabels( showLabels  );
+    //                 }
+    //                 else {
+    //                     result = "Showing internal axis labels must be true/false:"+params;
+    //                 }
+    //                 Util::commandPostProcess( result );
+    //                 return result;
+    //             });
+    //
+    // addCommandCallback( "setShowTicks", [=] (const QString & /*cmd*/,
+    //                 const QString & params, const QString & /*sessionId*/) -> QString {
+    //             QString result;
+    //             std::set<QString> keys = {DataGrid::SHOW_TICKS};
+    //             std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //             QString showTicksStr = dataValues[DataGrid::SHOW_TICKS];
+    //             bool validBool = false;
+    //             bool showTicks = Util::toBool( showTicksStr, &validBool );
+    //             if ( validBool ){
+    //                 result = setShowTicks( showTicks  );
+    //             }
+    //             else {
+    //                 result = "Making ticks visible/invisible must be true/false:"+params;
+    //             }
+    //             Util::commandPostProcess( result );
+    //             return result;
+    //         });
+    //
+    // addCommandCallback( "setShowStatistics", [=] (const QString & /*cmd*/,
+    //                     const QString & params, const QString & /*sessionId*/) -> QString {
+    //                 QString result;
+    //                 std::set<QString> keys = {DataGrid::SHOW_STATISTICS};
+    //                 std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //                 QString showStatisticsStr = dataValues[DataGrid::SHOW_STATISTICS];
+    //                 bool validBool = false;
+    //                 bool showStatistics = Util::toBool( showStatisticsStr, &validBool );
+    //                 if ( validBool ){
+    //                     result = setShowStatistics( showStatistics  );
+    //                 }
+    //                 else {
+    //                     result = "Making statistics visible/invisible must be true/false:"+params;
+    //                 }
+    //                 Util::commandPostProcess( result );
+    //                 return result;
+    //             });
+    //
+    // addCommandCallback( "setTickColor", [=] (const QString & /*cmd*/,
+    //                                        const QString & params, const QString & /*sessionId*/) -> QString {
+    //            int redAmount = 0;
+    //            int greenAmount = 0;
+    //            int blueAmount = 0;
+    //            QStringList result = _parseColorParams( params, DataGrid::TICK, &redAmount, &greenAmount, &blueAmount);
+    //            if ( result.size() == 0 ){
+    //                result = setTickColor( redAmount, greenAmount, blueAmount );
+    //            }
+    //            QString errors;
+    //            if ( result.size() > 0 ){
+    //                errors = result.join( ",");
+    //            }
+    //            Util::commandPostProcess( errors );
+    //            return errors;
+    //        });
+    //
+    // addCommandCallback( "setTickLength", [=] (const QString & /*cmd*/,
+    //                             const QString & params, const QString & /*sessionId*/) -> QString {
+    //         QString result;
+    //         std::set<QString> keys = {DataGrid::TICK_LENGTH};
+    //         std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //         QString lengthStr = dataValues[DataGrid::TICK_LENGTH];
+    //         bool validInt = false;
+    //         int length = lengthStr.toInt( &validInt );
+    //         if ( validInt ){
+    //             result = setTickLength( length  );
+    //         }
+    //         else {
+    //             result = "Tick length must be a number:"+params;
+    //         }
+    //         Util::commandPostProcess( result );
+    //         return result;
+    //     });
+    //
+    // addCommandCallback( "setTickThickness", [=] (const QString & /*cmd*/,
+    //                         const QString & params, const QString & /*sessionId*/) -> QString {
+    //                     QString result;
+    //                     std::set<QString> keys = {DataGrid::TICK};
+    //                     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //                     QString thicknessStr = dataValues[DataGrid::TICK];
+    //                     bool validInt = false;
+    //                     int thickness = thicknessStr.toInt( &validInt );
+    //                     if ( validInt ){
+    //                         result = setTickThickness( thickness  );
+    //                     }
+    //                     else {
+    //                         result = "Tick thickness must be a number:"+params;
+    //                     }
+    //                     Util::commandPostProcess( result );
+    //                     return result;
+    //                 });
+    //
+    // addCommandCallback( "setTickTransparency", [=] (const QString & /*cmd*/,
+    //                                     const QString & params, const QString & /*sessionId*/) -> QString {
+    //         QString result;
+    //         std::set<QString> keys = {Util::ALPHA};
+    //         std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //         QString transparencyStr = dataValues[Util::ALPHA];
+    //         bool validInt = false;
+    //         int transparency = transparencyStr.toInt( &validInt );
+    //         if ( validInt ){
+    //             result = setTickTransparency( transparency );
+    //         }
+    //         else {
+    //             result = "Tick transparency must be an integer:"+params;
+    //         }
+    //         Util::commandPostProcess( result );
+    //         return result;
+    //     });
+    //
+    // addCommandCallback( "setTheme", [=] (const QString & /*cmd*/,
+    //                         const QString & params, const QString & /*sessionId*/) -> QString {
+    //                     std::set<QString> keys = {DataGrid::THEME};
+    //                     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+    //                     QString themeStr = dataValues[DataGrid::THEME];
+    //                     QString result = setTheme( themeStr );
+    //                     Util::commandPostProcess( result );
+    //                     return result;
+    //                 });
 }
 
 
@@ -1041,7 +1483,7 @@ void Controller::refreshState(){
     CartaObject::refreshState();
     m_settings->refreshState();
     m_regionControls->refreshState();
-    m_gridControls->refreshState();
+    // m_gridControls->refreshState();
     m_contourControls->refreshState();
 }
 
@@ -1098,8 +1540,8 @@ void Controller::resetStateData( const QString& state ){
     emit colorChanged( this );
 
     //Reset the state of the grid controls based on the selected image.
-    StateInterface gridState = m_stack->_getGridState();
-    m_gridControls->_resetState( gridState );
+    // StateInterface gridState = m_stack->_getGridState();
+    // m_gridControls->_resetState( gridState );
     _loadViewQueued();
 }
 
@@ -1210,12 +1652,12 @@ void Controller::recallClipValue() {
 }
 
 
-void Controller::_setSkyCSName(){
-    const Carta::Lib::KnownSkyCS cs = getCoordinateSystem();
-    CoordinateSystems* m_coords = Util::findSingletonObject<CoordinateSystems>();
-    QString csName = m_coords->getName(cs);
-    m_gridControls->_resetCoordinateSystem(csName);
-}
+// void Controller::_setSkyCSName(){
+//     const Carta::Lib::KnownSkyCS cs = getCoordinateSystem();
+//     CoordinateSystems* m_coords = Util::findSingletonObject<CoordinateSystems>();
+//     QString csName = m_coords->getName(cs);
+//     m_gridControls->_resetCoordinateSystem(csName);
+// }
 
 
 void Controller::_setFrameAxis(int value, AxisInfo::KnownType axisType ) {
@@ -1238,7 +1680,7 @@ void Controller::setFrameImage( int val) {
         }
 
         Carta::State::StateInterface gridState = m_stack->_getGridState();
-        m_gridControls->_resetState( gridState );
+        // m_gridControls->_resetState( gridState );
         _updateCursorText( true );
         emit dataChanged( this );
     }
@@ -1458,17 +1900,17 @@ void Controller::_updateCursorText(bool notifyClients ){
 
 
 void Controller::_updateDisplayAxes(){
-    if ( m_gridControls ){
-        std::vector<AxisInfo> supportedAxes = m_stack->_getAxisInfos();
-        m_gridControls->_setAxisInfos( supportedAxes );
-        AxisInfo::KnownType xType = m_stack->_getAxisXType();
-        AxisInfo::KnownType yType = m_stack->_getAxisYType();
-        //const Carta::Lib::KnownSkyCS cs = getCoordinateSystem();
-        QString xPurpose = AxisMapper::getPurpose( xType );
-        QString yPurpose = AxisMapper::getPurpose( yType );
-        m_gridControls->setAxis( AxisMapper::AXIS_X, xPurpose );
-        m_gridControls->setAxis( AxisMapper::AXIS_Y, yPurpose );
-    }
+    // if ( m_gridControls ){
+    //     std::vector<AxisInfo> supportedAxes = m_stack->_getAxisInfos();
+    //     m_gridControls->_setAxisInfos( supportedAxes );
+    //     AxisInfo::KnownType xType = m_stack->_getAxisXType();
+    //     AxisInfo::KnownType yType = m_stack->_getAxisYType();
+    //     //const Carta::Lib::KnownSkyCS cs = getCoordinateSystem();
+    //     QString xPurpose = AxisMapper::getPurpose( xType );
+    //     QString yPurpose = AxisMapper::getPurpose( yType );
+    //     m_gridControls->setAxis( AxisMapper::AXIS_X, xPurpose );
+    //     m_gridControls->setAxis( AxisMapper::AXIS_Y, yPurpose );
+    // }
 }
 
 void Controller::updatePanZoomLevelJS( double centerX, double centerY, double zoomLevel, double layerId ){

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1051,7 +1051,7 @@ void Controller::_initializeCallbacks(){
     addCommandCallback( "setAxisY", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) ->QString {
 
-        QString result = m_stack->_setAxis( AxisMapper::AXIS_Y, axisName );
+        QString result = m_stack->_setAxis( AxisMapper::AXIS_Y, params );
         return result;
     });
 

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -733,7 +733,7 @@ void Controller::_initializeCallbacks(){
 
 
     addCommandCallback( "getDataGridState", [=] (const QString & /*cmd*/,
-            const QString & params, const QString & /*sessionId*/) ->QString {
+            const QString & /*params*/, const QString & /*sessionId*/) ->QString {
         Carta::State::StateInterface dataGridState = m_stack->_getDataGridState();
         QString result = dataGridState.toString();
         return result;
@@ -1061,14 +1061,15 @@ void Controller::_initializeCallbacks(){
     //     return result;
     // });
     //
-    // addCommandCallback( "setAxisX", [=] (const QString & /*cmd*/,
-    //                     const QString & params, const QString & /*sessionId*/) ->QString {
-    //     std::set<QString> keys = {AxisMapper::AXIS_X};
-    //     std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //     QString axisName = dataValues[AxisMapper::AXIS_X];
-    //     QString result = setAxis( AxisMapper::AXIS_X, axisName );
-    //     return result;
-    // });
+    addCommandCallback( "setAxisX", [=] (const QString & /*cmd*/,
+                        const QString & params, const QString & /*sessionId*/) ->QString {
+        // std::set<QString> keys = {AxisMapper::AXIS_X};
+        // std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
+        // QString axisName = dataValues[AxisMapper::AXIS_X];
+        // QString result = setAxis( AxisMapper::AXIS_X, axisName );
+        QString result = m_stack->_setAxisX( params );
+        return result;
+    });
     //
     // addCommandCallback( "setAxisY", [=] (const QString & /*cmd*/,
     //                     const QString & params, const QString & /*sessionId*/) ->QString {

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -94,10 +94,10 @@ Controller::Controller( const QString& path, const QString& id ) :
 
 	GridControls* gridObj = objMan->createObject<GridControls>();
 	m_gridControls.reset( gridObj );
-	connect( m_gridControls.get(), SIGNAL(gridChanged( const Carta::State::StateInterface&,bool)),
-			this, SLOT(_gridChanged( const Carta::State::StateInterface&, bool )));
-	connect( m_gridControls.get(), SIGNAL(displayAxesChanged(std::vector<Carta::Lib::AxisInfo::KnownType>,bool )),
-			this, SLOT( _displayAxesChanged(std::vector<Carta::Lib::AxisInfo::KnownType>,bool )));
+	// connect( m_gridControls.get(), SIGNAL(gridChanged( const Carta::State::StateInterface&,bool)),
+	// 		this, SLOT(_gridChanged( const Carta::State::StateInterface&, bool )));
+	// connect( m_gridControls.get(), SIGNAL(displayAxesChanged(std::vector<Carta::Lib::AxisInfo::KnownType>,bool )),
+	// 		this, SLOT( _displayAxesChanged(std::vector<Carta::Lib::AxisInfo::KnownType>,bool )));
 
 	ContourControls* contourObj = objMan->createObject<ContourControls>();
 	m_contourControls.reset( contourObj );
@@ -236,12 +236,12 @@ void Controller::_contourSetRemoved( const QString setName ){
 }
 
 
-void Controller::_displayAxesChanged(std::vector<AxisInfo::KnownType> displayAxisTypes,
-        bool applyAll ){
-    m_stack->_displayAxesChanged( displayAxisTypes, applyAll );
-    emit axesChanged(); //animator has this signal axesChanged, also frameChanged
-    _updateCursorText( true );
-}
+// void Controller::_displayAxesChanged(std::vector<AxisInfo::KnownType> displayAxisTypes,
+//         bool applyAll ){
+//     m_stack->_displayAxesChanged( displayAxisTypes, applyAll );
+//     emit axesChanged(); //animator has this signal axesChanged, also frameChanged
+//     _updateCursorText( true );
+// }
 
 
 std::vector<Carta::Lib::AxisInfo::KnownType> Controller::_getAxisZTypes() const {
@@ -339,9 +339,9 @@ int Controller::getFrame( AxisInfo::KnownType axisType ) const {
 }
 
 
-std::shared_ptr<GridControls> Controller::getGridControls() {
-    return m_gridControls;
-}
+// std::shared_ptr<GridControls> Controller::getGridControls() {
+//     return m_gridControls;
+// }
 
 
 std::vector<int> Controller::getImageDimensions( ) const {
@@ -512,10 +512,10 @@ double Controller::getZoomLevel( ) const {
     return m_stack->_getZoom();
 }
 
-void Controller::_gridChanged( const StateInterface& state, bool applyAll ){
-    m_stack->_gridChanged( state, applyAll );
-    _setSkyCSName();
-}
+// void Controller::_gridChanged( const StateInterface& state, bool applyAll ){
+//     m_stack->_gridChanged( state, applyAll );
+//     _setSkyCSName();
+// }
 
 void Controller::_onInputEvent( InputEvent  ev ){
 
@@ -731,6 +731,13 @@ void Controller::_initializeCallbacks(){
         return "";
     });
 
+
+    addCommandCallback( "getDataGridState", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) ->QString {
+        Carta::State::StateInterface dataGridState = m_stack->_getDataGridState();
+        QString result = dataGridState.toString();
+        return result;
+    });
 
     addCommandCallback( "newzoom", [=] (const QString & /*cmd*/,
             const QString & params, const QString & /*sessionId*/) ->QString {

--- a/carta/cpp/core/Data/Image/Controller.cpp
+++ b/carta/cpp/core/Data/Image/Controller.cpp
@@ -1311,23 +1311,13 @@ void Controller::_initializeCallbacks(){
     //                 return result;
     //             });
     //
-    // addCommandCallback( "setShowTicks", [=] (const QString & /*cmd*/,
-    //                 const QString & params, const QString & /*sessionId*/) -> QString {
-    //             QString result;
-    //             std::set<QString> keys = {DataGrid::SHOW_TICKS};
-    //             std::map<QString,QString> dataValues = Carta::State::UtilState::parseParamMap( params, keys );
-    //             QString showTicksStr = dataValues[DataGrid::SHOW_TICKS];
-    //             bool validBool = false;
-    //             bool showTicks = Util::toBool( showTicksStr, &validBool );
-    //             if ( validBool ){
-    //                 result = setShowTicks( showTicks  );
-    //             }
-    //             else {
-    //                 result = "Making ticks visible/invisible must be true/false:"+params;
-    //             }
-    //             Util::commandPostProcess( result );
-    //             return result;
-    //         });
+    addCommandCallback( "setShowTicks", [=] (const QString & /*cmd*/,
+            const QString & params, const QString & /*sessionId*/) -> QString {
+
+        QString stateName = DataGrid::SHOW_TICKS;
+        QString result = m_stack->_setDataGridState( stateName, params );
+        return result;
+    });
     //
     // addCommandCallback( "setShowStatistics", [=] (const QString & /*cmd*/,
     //                     const QString & params, const QString & /*sessionId*/) -> QString {

--- a/carta/cpp/core/Data/Image/Controller.h
+++ b/carta/cpp/core/Data/Image/Controller.h
@@ -183,7 +183,7 @@ public:
      * Return a shared pointer to the grid controls.
      * @return - a shared pointer to the grid controls.
      */
-    std::shared_ptr<GridControls> getGridControls();
+    // std::shared_ptr<GridControls> getGridControls();
 
     /**
      * Return the point in image coordinates that is currently under the cursor.
@@ -649,12 +649,12 @@ protected:
 
 private slots:
 
-	void _displayAxesChanged(std::vector<Carta::Lib::AxisInfo::KnownType> displayAxisTypes, bool applyAll);
+	// void _displayAxesChanged(std::vector<Carta::Lib::AxisInfo::KnownType> displayAxisTypes, bool applyAll);
 
 	void _contourSetAdded( Layer* cData, const QString& setName );
 	void _contourSetRemoved( const QString setName );
 
-	void _gridChanged( const Carta::State::StateInterface& state, bool applyAll );
+	// void _gridChanged( const Carta::State::StateInterface& state, bool applyAll );
 	void _onInputEvent( InputEvent ev );
 
 	//Refresh the view based on the latest data selection information.

--- a/carta/cpp/core/Data/Image/Controller.h
+++ b/carta/cpp/core/Data/Image/Controller.h
@@ -712,7 +712,7 @@ private:
 
     // Set the AxisMapper::axisMap to use
     void _setAxisMap();
-    void _setSkyCSName();
+    // void _setSkyCSName();
 
 	/**
 	 * Make a frame selection.
@@ -744,7 +744,7 @@ private:
 	static const QString CENTER;
 	static const QString STACK_SELECT_AUTO;
 
-	std::shared_ptr<GridControls> m_gridControls;
+	// std::shared_ptr<GridControls> m_gridControls;
 	std::shared_ptr<ContourControls> m_contourControls;
 	std::shared_ptr<RegionControls> m_regionControls;
 

--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -136,11 +136,23 @@ std::vector<AxisInfo::KnownType> DataSource::_getAxisTypes() const {
 }
 
 
-std::vector<AxisInfo> DataSource::_getAxisInfos() const {
+std::vector<AxisInfo> DataSource::_getAxisInfos( Carta::Lib::KnownSkyCS cs ) const {
     std::vector<AxisInfo> Infos;
     casa_mutex.lock();
     CoordinateFormatterInterface::SharedPtr cf(
                    m_image-> metaData()-> coordinateFormatter()-> clone() );
+
+    if ( cs == Carta::Lib::KnownSkyCS::Unknown ) {
+        qWarning() << "Unknown celestial coordinate system.";
+    }
+    else if ( cs == Carta::Lib::KnownSkyCS::Error ){
+        qCritical() << "Error celestial coordinate system.";
+        CARTA_ASSERT("There are something wrong when trying get axisinfo.");
+    }
+    else if ( cs != Carta::Lib::KnownSkyCS::Default ) {
+        cf->setSkyCS( cs );
+    }
+
     int axisCount = cf->nAxes();
     for ( int axis = 0 ; axis < axisCount; axis++ ) {
         const AxisInfo & axisInfo = cf-> axisInfo( axis );

--- a/carta/cpp/core/Data/Image/DataSource.cpp
+++ b/carta/cpp/core/Data/Image/DataSource.cpp
@@ -42,6 +42,7 @@ CoordinateSystems* DataSource::m_coords = nullptr;
 DataSource::DataSource() :
     m_image( nullptr ),
     m_permuteImage( nullptr),
+    m_coordinateFormatter( nullptr ),
     m_axisIndexX( 0 ),
     m_axisIndexY( 1 ){
         m_cmapCacheSize = 1000;
@@ -135,31 +136,24 @@ std::vector<AxisInfo::KnownType> DataSource::_getAxisTypes() const {
     return types;
 }
 
+void DataSource::_setCoordinateSystem( Carta::Lib::KnownSkyCS cs ){
+    casa_mutex.lock();
+    m_coordinateFormatter->setSkyCS( cs );
+    casa_mutex.unlock();
+}
 
-std::vector<AxisInfo> DataSource::_getAxisInfos( Carta::Lib::KnownSkyCS cs ) const {
+std::vector<AxisInfo> DataSource::_getAxisInfos() const {
     std::vector<AxisInfo> Infos;
     casa_mutex.lock();
-    CoordinateFormatterInterface::SharedPtr cf(
-                   m_image-> metaData()-> coordinateFormatter()-> clone() );
 
-    if ( cs == Carta::Lib::KnownSkyCS::Unknown ) {
-        qWarning() << "Unknown celestial coordinate system.";
-    }
-    else if ( cs == Carta::Lib::KnownSkyCS::Error ){
-        qCritical() << "Error celestial coordinate system.";
-        CARTA_ASSERT("There are something wrong when trying get axisinfo.");
-    }
-    else if ( cs != Carta::Lib::KnownSkyCS::Default ) {
-        cf->setSkyCS( cs );
-    }
-
-    int axisCount = cf->nAxes();
+    int axisCount = m_coordinateFormatter->nAxes();
     for ( int axis = 0 ; axis < axisCount; axis++ ) {
-        const AxisInfo & axisInfo = cf-> axisInfo( axis );
+        const AxisInfo & axisInfo = m_coordinateFormatter-> axisInfo( axis );
         if ( axisInfo.knownType() != AxisInfo::KnownType::OTHER ){
             Infos.push_back( axisInfo );
         }
     }
+
     casa_mutex.unlock();
 
     return Infos;
@@ -231,7 +225,7 @@ QStringList DataSource::_getCoordinates( double x, double y,
     return list;
 }
 
-QString DataSource::_getSkyCS(){
+QString DataSource::_getDefaultCoordinateSystem() const{
 
     casa_mutex.lock();
 
@@ -1311,6 +1305,9 @@ QString DataSource::_setFileName( const QString& fileName, bool* success ){
                 if (!res.isNull()){
                     m_image = res.val();
                     m_permuteImage = m_image;
+                    std::shared_ptr<CoordinateFormatterInterface> cf(
+                        m_image->metaData()->coordinateFormatter()->clone() );
+                    m_coordinateFormatter = cf;
                     // reset zoom/pan
                     _resetZoom();
                     _resetPan();

--- a/carta/cpp/core/Data/Image/DataSource.h
+++ b/carta/cpp/core/Data/Image/DataSource.h
@@ -83,7 +83,7 @@ private:
     std::vector<Carta::Lib::AxisInfo::KnownType> _getAxisTypes() const;
 
 
-    std::vector<Carta::Lib::AxisInfo> _getAxisInfos() const;
+    std::vector<Carta::Lib::AxisInfo> _getAxisInfos( Carta::Lib::KnownSkyCS cs = Carta::Lib::KnownSkyCS::Default ) const;
 
     /**
      * Returns the type of the axis with the given index in the image.

--- a/carta/cpp/core/Data/Image/DataSource.h
+++ b/carta/cpp/core/Data/Image/DataSource.h
@@ -82,8 +82,11 @@ private:
      */
     std::vector<Carta::Lib::AxisInfo::KnownType> _getAxisTypes() const;
 
-
-    std::vector<Carta::Lib::AxisInfo> _getAxisInfos( Carta::Lib::KnownSkyCS cs = Carta::Lib::KnownSkyCS::Default ) const;
+    /**
+     * Return a list of axes in the image, containing the type and name of axes.
+     * @return - a list of axes that are present in the image.
+     */
+    std::vector<Carta::Lib::AxisInfo> _getAxisInfos() const;
 
     /**
      * Returns the type of the axis with the given index in the image.
@@ -128,8 +131,11 @@ private:
     QStringList _getCoordinates( double x, double y, Carta::Lib::KnownSkyCS system,
             const std::vector<int>& frames) const;
 
-
-    QString _getSkyCS();
+    /**
+     * Get the name of the default celestial coordinate system of image.
+     * @return the name of the default coordinate coordinate system
+     */
+    QString _getDefaultCoordinateSystem() const;
 
     /**
      * Returns information about the image at the current location of the cursor.
@@ -461,6 +467,13 @@ private:
     void _setColorNan( double red, double green, double blue );
 
     /**
+     * Set the coordinate system in the duplicated coordinateformatter,
+     * i.e. m_coordinateFormatter.
+     * @param cs - the target coordinate system (defined in CartaLib::KnownSkyCS)
+     */
+    void _setCoordinateSystem( Carta::Lib::KnownSkyCS cs );
+
+    /**
      * Set the x-, y-, and z- axes that are to be displayed.
      * @param displayAxisTypes - the list of display axes.
      * @param frames - a list of current image frames.
@@ -562,10 +575,10 @@ private:
 
     ///pixel pipeline
     std::shared_ptr<Carta::Lib::PixelPipeline::CustomizablePixelPipeline> m_pixelPipeline;
-    
+
     // disk cache
     std::shared_ptr<Carta::Lib::IPCache> m_diskCache;
-    
+
     //Indices of the display axes.
     int m_axisIndexX;
     int m_axisIndexY;

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -505,6 +505,7 @@ QString DataGrid::_setAxis( const QString& axisId, const QString& purpose, bool*
                 std::vector<AxisInfo::KnownType> AxisTypeArray = _getDisplayAxes();
                 m_formats->setAxisformat(&AxisTypeArray[0]);
 
+                // TODO: simplify the return value(only the xAxis and the yAxis are necessary)
                 result = m_state.toString();
             }
         }

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -25,6 +25,8 @@ const QString DataGrid::AXES = "axes";
 const QString DataGrid::COORD_SYSTEM = "skyCS";
 const QString DataGrid::DIRECTION = "direction";
 const QString DataGrid::FONT = "font";
+const QString DataGrid::FONT_SIZE = "font/size";
+const QString DataGrid::FONT_FAMILY = "font/family";
 const QString DataGrid::LABEL_COLOR = "labels";
 const QString DataGrid::LABEL_DECIMAL_PLACES = "decimals";
 const QString DataGrid::LABEL_DECIMAL_PLACES_MAX = "decimalsMax";
@@ -51,6 +53,62 @@ const int DataGrid::MARGIN_LABEL = 50;
 const int DataGrid::TICK_LENGTH_MAX = 50;
 const int DataGrid::PEN_FACTOR = 10;
 const int DataGrid::LABEL_DECIMAL_MAX = 10;
+
+const QString DataGrid::AXES_ALPHA = "axes/alpha";
+const QString DataGrid::AXES_BLUE = "axes/blue";
+const QString DataGrid::AXES_GREEN = "axes/greeen";
+const QString DataGrid::AXES_RED = "axes/red";
+const QString DataGrid::AXES_WIDTH = "axes/width";
+const QString DataGrid::GRID_ALPHA = "grid/alpha";
+const QString DataGrid::GRID_BLUE = "grid/blue";
+const QString DataGrid::GRID_GREEN = "grid/green";
+const QString DataGrid::GRID_RED = "grid/red";
+const QString DataGrid::GRID_WIDTH = "grid/width";
+const QString DataGrid::TICK_ALPHA = "tick/alpha";
+const QString DataGrid::TICK_BLUE = "tick/blue";
+const QString DataGrid::TICK_GREEN = "tick/green";
+const QString DataGrid::TICK_RED = "tick/red";
+const QString DataGrid::TICK_WIDTH = "tick/width";
+const QString DataGrid::LABEL_COLOR_BLUE = "labels/blue";
+const QString DataGrid::LABEL_COLOR_GREEN = "labels/green";
+const QString DataGrid::LABEL_COLOR_RED = "labels/red";
+
+const std::map< QString, DataGrid::ConvertType > DataGrid::typeTable = {
+    // TODO: label format, coordinate system
+    { DataGrid::SHOW_AXIS, DataGrid::ConvertType::BOOL },
+    { DataGrid::SHOW_COORDS, DataGrid::ConvertType::BOOL },
+    { DataGrid::SHOW_GRID_LINES, DataGrid::ConvertType::BOOL },
+    { DataGrid::SHOW_INTERNAL_LABELS, DataGrid::ConvertType::BOOL },
+    { DataGrid::SHOW_STATISTICS, DataGrid::ConvertType::BOOL },
+    { DataGrid::SHOW_TICKS, DataGrid::ConvertType::BOOL },
+
+    { DataGrid::AXES_ALPHA, DataGrid::ConvertType::INT },
+    { DataGrid::AXES_BLUE, DataGrid::ConvertType::INT },
+    { DataGrid::AXES_GREEN, DataGrid::ConvertType::INT },
+    { DataGrid::AXES_RED, DataGrid::ConvertType::INT },
+    { DataGrid::AXES_WIDTH, DataGrid::ConvertType::INT },
+    { DataGrid::FONT_SIZE, DataGrid::ConvertType::INT },
+    { DataGrid::GRID_ALPHA, DataGrid::ConvertType::INT },
+    { DataGrid::GRID_BLUE, DataGrid::ConvertType::INT },
+    { DataGrid::GRID_GREEN, DataGrid::ConvertType::INT },
+    { DataGrid::GRID_RED, DataGrid::ConvertType::INT },
+    { DataGrid::GRID_WIDTH, DataGrid::ConvertType::INT },
+    { DataGrid::LABEL_COLOR_BLUE, DataGrid::ConvertType::INT },
+    { DataGrid::LABEL_COLOR_GREEN, DataGrid::ConvertType::INT },
+    { DataGrid::LABEL_COLOR_RED, DataGrid::ConvertType::INT },
+    { DataGrid::LABEL_DECIMAL_PLACES, DataGrid::ConvertType::INT },
+    { DataGrid::SPACING, DataGrid::ConvertType::INT },
+    { DataGrid::TICK_ALPHA, DataGrid::ConvertType::INT },
+    { DataGrid::TICK_BLUE, DataGrid::ConvertType::INT },
+    { DataGrid::TICK_GREEN, DataGrid::ConvertType::INT },
+    { DataGrid::TICK_RED, DataGrid::ConvertType::INT },
+    { DataGrid::TICK_WIDTH, DataGrid::ConvertType::INT },
+    { DataGrid::TICK_LENGTH, DataGrid::ConvertType::INT },
+
+    { DataGrid::FONT_FAMILY, DataGrid::ConvertType::NOCONVERT },
+    { DataGrid::THEME, DataGrid::ConvertType::NOCONVERT }
+    // { Carta::State::UtilState::getLookup( DataGrid::TICK, Util::ALPHA ), DataGrid::ConvertType::INT }
+};
 
 using Carta::Lib::AxisInfo;
 
@@ -998,6 +1056,38 @@ QString DataGrid::_setTheme( const QString& theme, bool* themeChanged ){
         result = "The theme "+theme+" was not recognized";
     }
     return result;
+}
+
+QString DataGrid::_setState( const QString stateName, const QString stateValue ){
+    // ConvertType convertType = _typeClassifier( stateName, stateValue );
+    // ConvertType convertType = typeTable[stateName];
+    ConvertType convertType = ConvertType::UNKNOWN;
+    if ( typeTable.find(stateName) != typeTable.end() ){
+        convertType = typeTable.find(stateName)->second;
+    }
+
+    switch (convertType) {
+        case ConvertType::BOOL:{
+            bool valid = false;
+            bool boolValue = Util::toBool( stateValue, &valid);
+            m_state.setValue<bool>( stateName, boolValue );
+        }
+        break;
+        case ConvertType::INT:{
+            int intValue = stateValue.toInt();
+            m_state.setValue<int>( stateName, intValue );
+        }
+        break;
+        case ConvertType::NOCONVERT:{
+            m_state.setValue<QString>( stateName, stateValue );
+        }
+        break;
+        default:
+            qCritical() << "Unknown type to convert.";
+        break;
+    }
+    _resetGridRenderer();
+    return m_state.toString();
 }
 
 DataGrid::~DataGrid(){

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -307,6 +307,7 @@ void DataGrid::_initializeDefaultState(){
     QString yName = AxisMapper::getDefaultPurpose( AxisMapper::AXIS_Y, cs );
     m_state.insertValue<QString>( AxisMapper::AXIS_Y, yName );
 
+    // Provide the list of supported coordinate systems to javascript
     QStringList coordinateSystems = m_coordSystems->getCoordinateSystems();
     m_state.insertArray( SUPPORTED_COORDINATE_SYSTEMS, coordinateSystems.length() );
     for( int i=0; i<coordinateSystems.length(); i++ ){
@@ -503,6 +504,8 @@ QString DataGrid::_setAxis( const QString& axisId, const QString& purpose, bool*
                 // update Label format
                 std::vector<AxisInfo::KnownType> AxisTypeArray = _getDisplayAxes();
                 m_formats->setAxisformat(&AxisTypeArray[0]);
+
+                result = m_state.toString();
             }
         }
         else {

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -45,6 +45,7 @@ const QString DataGrid::THEME = "theme";
 const QString DataGrid::TICK = "tick";
 const QString DataGrid::TICK_LENGTH = "tickLength";
 const QString DataGrid::SUPPORTED_AXES = "supportedAxes";
+const QString DataGrid::SUPPORTED_COORDINATE_SYSTEMS = "supportedCS";
 const int DataGrid::MARGIN_DEFAULT = 10;
 const int DataGrid::MARGIN_LABEL = 50;
 const int DataGrid::TICK_LENGTH_MAX = 50;
@@ -305,6 +306,14 @@ void DataGrid::_initializeDefaultState(){
     m_state.insertValue<QString>( AxisMapper::AXIS_X, xName );
     QString yName = AxisMapper::getDefaultPurpose( AxisMapper::AXIS_Y, cs );
     m_state.insertValue<QString>( AxisMapper::AXIS_Y, yName );
+
+    QStringList coordinateSystems = m_coordSystems->getCoordinateSystems();
+    m_state.insertArray( SUPPORTED_COORDINATE_SYSTEMS, coordinateSystems.length() );
+    for( int i=0; i<coordinateSystems.length(); i++ ){
+        QString name = coordinateSystems[i];
+        QString lookup = Carta::State::UtilState::getLookup( SUPPORTED_COORDINATE_SYSTEMS, i );
+        m_state.setValue<QString>( lookup, name );
+    }
 
     m_state.flushState();
 }

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -37,6 +37,7 @@ const QString DataGrid::FORMAT = "format";
 const QString DataGrid::LABEL_SIDE = "side";
 const QString DataGrid::SHOW_AXIS = "showAxis";
 const QString DataGrid::SHOW_COORDS = "showCoordinateSystem";
+const QString DataGrid::SHOW_DEFAULT_COORDS = "showDefaultCS";
 const QString DataGrid::SHOW_INTERNAL_LABELS = "showInternalLabels";
 const QString DataGrid::SHOW_GRID_LINES = "showGridLines";
 const QString DataGrid::SHOW_STATISTICS = "showStatistics";
@@ -81,6 +82,7 @@ const std::map< QString, DataGrid::ConvertType > DataGrid::typeTable = {
     // TODO: label format, coordinate system
     { DataGrid::SHOW_AXIS, DataGrid::ConvertType::BOOL },
     { DataGrid::SHOW_COORDS, DataGrid::ConvertType::BOOL },
+    { DataGrid::SHOW_DEFAULT_COORDS, DataGrid::ConvertType::BOOL },
     { DataGrid::SHOW_GRID_LINES, DataGrid::ConvertType::BOOL },
     { DataGrid::SHOW_INTERNAL_LABELS, DataGrid::ConvertType::BOOL },
     { DataGrid::SHOW_STATISTICS, DataGrid::ConvertType::BOOL },
@@ -333,6 +335,7 @@ void DataGrid::_initializeDefaultState(){
     m_state.insertValue<bool>( SHOW_TICKS, true );
     m_state.insertValue<bool>( SHOW_INTERNAL_LABELS, false );
     m_state.insertValue<bool>( SHOW_COORDS, true );
+    m_state.insertValue<bool>( SHOW_DEFAULT_COORDS, true );
 
     m_state.insertValue<bool>( SHOW_STATISTICS, true );
 

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -97,13 +97,14 @@ const std::map< QString, DataGrid::ConvertType > DataGrid::typeTable = {
     { DataGrid::LABEL_COLOR_GREEN, DataGrid::ConvertType::INT },
     { DataGrid::LABEL_COLOR_RED, DataGrid::ConvertType::INT },
     { DataGrid::LABEL_DECIMAL_PLACES, DataGrid::ConvertType::INT },
-    { DataGrid::SPACING, DataGrid::ConvertType::INT },
     { DataGrid::TICK_ALPHA, DataGrid::ConvertType::INT },
     { DataGrid::TICK_BLUE, DataGrid::ConvertType::INT },
     { DataGrid::TICK_GREEN, DataGrid::ConvertType::INT },
     { DataGrid::TICK_RED, DataGrid::ConvertType::INT },
     { DataGrid::TICK_WIDTH, DataGrid::ConvertType::INT },
     { DataGrid::TICK_LENGTH, DataGrid::ConvertType::INT },
+
+    { DataGrid::SPACING, DataGrid::ConvertType::DOUBLE },
 
     { DataGrid::COORD_SYSTEM, DataGrid::ConvertType::NOCONVERT },
     { DataGrid::FONT_FAMILY, DataGrid::ConvertType::NOCONVERT },
@@ -1077,6 +1078,11 @@ QString DataGrid::_setState( const QString stateName, const QString stateValue )
         case ConvertType::INT:{
             int intValue = stateValue.toInt();
             m_state.setValue<int>( stateName, intValue );
+        }
+        break;
+        case ConvertType::DOUBLE:{
+            double doubleValue = stateValue.toDouble();
+            m_state.setValue<double>( stateName, doubleValue);
         }
         break;
         case ConvertType::NOCONVERT:{

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -105,6 +105,7 @@ const std::map< QString, DataGrid::ConvertType > DataGrid::typeTable = {
     { DataGrid::TICK_WIDTH, DataGrid::ConvertType::INT },
     { DataGrid::TICK_LENGTH, DataGrid::ConvertType::INT },
 
+    { DataGrid::COORD_SYSTEM, DataGrid::ConvertType::NOCONVERT },
     { DataGrid::FONT_FAMILY, DataGrid::ConvertType::NOCONVERT },
     { DataGrid::THEME, DataGrid::ConvertType::NOCONVERT }
     // { Carta::State::UtilState::getLookup( DataGrid::TICK, Util::ALPHA ), DataGrid::ConvertType::INT }

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -564,10 +564,9 @@ QString DataGrid::_setAxis( const QString& axisId, const QString& purpose, bool*
                 // update Label format
                 std::vector<AxisInfo::KnownType> AxisTypeArray = _getDisplayAxes();
                 m_formats->setAxisformat(&AxisTypeArray[0]);
-
-                // TODO: simplify the return value(only the xAxis and the yAxis are necessary)
-                result = m_state.toString();
             }
+            // TODO: simplify the return value(only the xAxis and the yAxis are necessary)
+            result = m_state.toString();
         }
         else {
             result = "Unrecognized axis type: "+purpose;

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -577,39 +577,55 @@ bool DataGrid::_setAxisTypes( std::vector<AxisInfo::KnownType> supportedAxes){
 bool DataGrid::_setAxisInfos( std::vector<AxisInfo> supportedAxes){
     int axisCount = supportedAxes.size();
     bool axisTypesChanged = false;
-    int oldCount = m_state.getArraySize( SUPPORTED_AXES );
-    m_state.resizeArray( SUPPORTED_AXES, axisCount, Carta::State::StateInterface::PreserveAll );
+    m_state.resizeArray( SUPPORTED_AXES, axisCount );
 
     int axisIndex = 0;
     for( int i=0; i<axisCount; i++ ){
         QString name = supportedAxes[i].longLabel().plain();
         QString lookup = Carta::State::UtilState::getLookup( SUPPORTED_AXES, axisIndex );
-        QString oldName;
-        if ( i < oldCount ){
-            oldName = m_state.getValue<QString>( lookup );
+
+        axisTypesChanged = true;
+        if ( AxisMapper::getType(name)==Carta::Lib::AxisInfo::KnownType::STOKES ){
+            m_state.resizeArray( SUPPORTED_AXES, axisCount-1, Carta::State::StateInterface::PreserveAll);
+            continue;
         }
-        if ( name != oldName ){
-            //_setAxis( AxisMapper::AXIS_X, supportedAxes[0].longLabel().plain(), &axisTypesChanged);
-            //_setAxis( AxisMapper::AXIS_Y, supportedAxes[1].longLabel().plain(), &axisTypesChanged);
-            //if(i==0){
-            //    _setAxis( AxisMapper::AXIS_X, name, &axisTypesChanged);
-            //}
-            //else if(i==1){
-            //    _setAxis( AxisMapper::AXIS_Y, name, &axisTypesChanged);
-            //}
-            axisTypesChanged = true;
-            if ( AxisMapper::getType(name)==Carta::Lib::AxisInfo::KnownType::STOKES ){
-                m_state.resizeArray( SUPPORTED_AXES, axisCount-1, Carta::State::StateInterface::PreserveAll);
-                continue;
-            }
-            m_state.setValue<QString>( lookup, name );
-        }
+        m_state.setValue<QString>( lookup, name );
         axisIndex++;
     }
-
-    if ( axisTypesChanged ){
-        m_state.flushState();
-    }
+    // Deprecated. This part is designed for GridControls
+    // int oldCount = m_state.getArraySize( SUPPORTED_AXES );
+    // m_state.resizeArray( SUPPORTED_AXES, axisCount, Carta::State::StateInterface::PreserveAll );
+    //
+    // int axisIndex = 0;
+    // for( int i=0; i<axisCount; i++ ){
+    //     QString name = supportedAxes[i].longLabel().plain();
+    //     QString lookup = Carta::State::UtilState::getLookup( SUPPORTED_AXES, axisIndex );
+    //     QString oldName;
+    //     if ( i < oldCount ){
+    //         oldName = m_state.getValue<QString>( lookup );
+    //     }
+    //     if ( name != oldName ){
+    //         //_setAxis( AxisMapper::AXIS_X, supportedAxes[0].longLabel().plain(), &axisTypesChanged);
+    //         //_setAxis( AxisMapper::AXIS_Y, supportedAxes[1].longLabel().plain(), &axisTypesChanged);
+    //         //if(i==0){
+    //         //    _setAxis( AxisMapper::AXIS_X, name, &axisTypesChanged);
+    //         //}
+    //         //else if(i==1){
+    //         //    _setAxis( AxisMapper::AXIS_Y, name, &axisTypesChanged);
+    //         //}
+    //         axisTypesChanged = true;
+    //         if ( AxisMapper::getType(name)==Carta::Lib::AxisInfo::KnownType::STOKES ){
+    //             m_state.resizeArray( SUPPORTED_AXES, axisCount-1, Carta::State::StateInterface::PreserveAll);
+    //             continue;
+    //         }
+    //         m_state.setValue<QString>( lookup, name );
+    //     }
+    //     axisIndex++;
+    // }
+    //
+    // if ( axisTypesChanged ){
+    //     m_state.flushState();
+    // }
     return axisTypesChanged;
 }
 

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -654,10 +654,11 @@ bool DataGrid::_setAxisInfos( std::vector<AxisInfo> supportedAxes){
     int axisIndex = 0;
     for( int i=0; i<axisCount; i++ ){
         QString name = supportedAxes[i].longLabel().plain();
+        Carta::Lib::AxisInfo::KnownType type = supportedAxes[i].knownType();
         QString lookup = Carta::State::UtilState::getLookup( SUPPORTED_AXES, axisIndex );
 
         axisTypesChanged = true;
-        if ( AxisMapper::getType(name)==Carta::Lib::AxisInfo::KnownType::STOKES ){
+        if ( type == Carta::Lib::AxisInfo::KnownType::STOKES ){
             m_state.resizeArray( SUPPORTED_AXES, axisCount-1, Carta::State::StateInterface::PreserveAll);
             continue;
         }

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -72,6 +72,10 @@ const QString DataGrid::TICK_WIDTH = "tick/width";
 const QString DataGrid::LABEL_COLOR_BLUE = "labels/blue";
 const QString DataGrid::LABEL_COLOR_GREEN = "labels/green";
 const QString DataGrid::LABEL_COLOR_RED = "labels/red";
+const QString DataGrid::LABEL_FORMAT_LEFT = "labelFormats/left/format";
+const QString DataGrid::LABEL_FORMAT_RIGHT = "labelFormats/right/format";
+const QString DataGrid::LABEL_FORMAT_TOP = "labelFormats/top/format";
+const QString DataGrid::LABEL_FORMAT_BOTTOM = "labelFormats/bottom/format";
 
 const std::map< QString, DataGrid::ConvertType > DataGrid::typeTable = {
     // TODO: label format, coordinate system
@@ -108,7 +112,11 @@ const std::map< QString, DataGrid::ConvertType > DataGrid::typeTable = {
 
     { DataGrid::COORD_SYSTEM, DataGrid::ConvertType::NOCONVERT },
     { DataGrid::FONT_FAMILY, DataGrid::ConvertType::NOCONVERT },
-    { DataGrid::THEME, DataGrid::ConvertType::NOCONVERT }
+    { DataGrid::THEME, DataGrid::ConvertType::NOCONVERT },
+    { DataGrid::LABEL_FORMAT_LEFT, DataGrid::ConvertType::NOCONVERT },
+    { DataGrid::LABEL_FORMAT_RIGHT, DataGrid::ConvertType::NOCONVERT },
+    { DataGrid::LABEL_FORMAT_TOP, DataGrid::ConvertType::NOCONVERT },
+    { DataGrid::LABEL_FORMAT_BOTTOM, DataGrid::ConvertType::NOCONVERT }
     // { Carta::State::UtilState::getLookup( DataGrid::TICK, Util::ALPHA ), DataGrid::ConvertType::INT }
 };
 

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.cpp
@@ -749,19 +749,11 @@ QStringList DataGrid::_setColor( const QString& key, int redAmount, int greenAmo
 }
 
 QString DataGrid::_setCoordinateSystem( const QString& coordSystem, bool* coordChanged ){
-    QString result;
-    *coordChanged = false;
-    QString recognizedSystem = m_coordSystems->getCoordinateSystem( coordSystem );
-    if ( !recognizedSystem.isEmpty() ){
-        if ( m_state.getValue<QString>( COORD_SYSTEM) != recognizedSystem ){
-            m_state.setValue<QString>( COORD_SYSTEM, recognizedSystem );
-            *coordChanged = true;
-        }
-    }
-    else {
-        result= "The coordinate system "+coordSystem+" is not supported.";
-    }
-    return result;
+
+    *coordChanged = true;
+    m_state.setValue<QString>( COORD_SYSTEM, coordSystem );
+    _resetGridRenderer();
+    return m_state.toString();
 }
 
 QString DataGrid::_setFontFamily( const QString& fontFamily, bool* familyChanged ){

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.h
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.h
@@ -128,6 +128,7 @@ private:
     const static QString SHOW_TICKS;
     const static QString SPACING;
     const static QString SUPPORTED_AXES;
+    const static QString SUPPORTED_COORDINATE_SYSTEMS;
     const static QString THEME;
     const static QString TICK;
     const static QString TICK_LENGTH;

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.h
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.h
@@ -32,6 +32,7 @@ class DataGrid : public Carta::State::CartaObject {
 friend class LayerData;
 friend class LayerGroup;
 friend class Stack;
+// For controller to use const string in callback.
 friend class Controller;
 friend class GridControls;
 

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.h
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.h
@@ -137,6 +137,7 @@ private:
     const static QString FORMAT;
     const static QString SHOW_AXIS;
     const static QString SHOW_COORDS;
+    const static QString SHOW_DEFAULT_COORDS;
     const static QString SHOW_INTERNAL_LABELS;
     const static QString SHOW_GRID_LINES;
     const static QString SHOW_STATISTICS;

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.h
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.h
@@ -47,6 +47,7 @@ private:
     enum class ConvertType {
         BOOL,
         INT,
+        DOUBLE,
         NOCONVERT,
         UNKNOWN
     };

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.h
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.h
@@ -171,6 +171,10 @@ private:
     const static QString LABEL_COLOR_BLUE;
     const static QString LABEL_COLOR_GREEN;
     const static QString LABEL_COLOR_RED;
+    const static QString LABEL_FORMAT_LEFT;
+    const static QString LABEL_FORMAT_RIGHT;
+    const static QString LABEL_FORMAT_TOP;
+    const static QString LABEL_FORMAT_BOTTOM;
 
     const static std::map< QString, ConvertType > typeTable;
 

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.h
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.h
@@ -42,6 +42,14 @@ public:
     const static QString CLASS_NAME;
     const static QString GRID;
 private:
+
+    enum class ConvertType {
+        BOOL,
+        INT,
+        NOCONVERT,
+        UNKNOWN
+    };
+
     void _addUsedPurpose( const QString& key, const QString& targetPurpose,
         QList<QString>& usedPurposes, QString& usedPurposeKey );
     int _getMargin( const QString& direction ) const;
@@ -95,12 +103,7 @@ private:
     QString _setTickTransparency( int transparency, bool* transparencyChanged );
     QString _setTheme( const QString& theme, bool* themeChanged );
 
-    // template function should be defined in header file
-    template < typename T > QString _setState( const QString stateName, const T stateValue ){
-        m_state.setValue<T>( stateName, stateValue );
-        _resetGridRenderer();
-        return m_state.toString();
-    };
+    QString _setState( const QString stateName, const QString stateValue );
 
     Carta::State::StateInterface _getState();
     QPen _getPen( const QString& key, const Carta::State::StateInterface& state );
@@ -121,6 +124,8 @@ private:
     const static QString COORD_SYSTEM;
     const static QString DIRECTION;
     const static QString FONT;
+    const static QString FONT_FAMILY;
+    const static QString FONT_SIZE;
     const static QString LABEL_AXIS;
     const static QString LABEL_COLOR;
     const static QString LABEL_DECIMAL_PLACES;
@@ -145,6 +150,27 @@ private:
     const static int MARGIN_LABEL;
     const static int TICK_LENGTH_MAX;
     const static int PEN_FACTOR;
+
+    const static QString AXES_ALPHA;
+    const static QString AXES_BLUE;
+    const static QString AXES_GREEN;
+    const static QString AXES_RED;
+    const static QString AXES_WIDTH;
+    const static QString GRID_ALPHA;
+    const static QString GRID_BLUE;
+    const static QString GRID_GREEN;
+    const static QString GRID_RED;
+    const static QString GRID_WIDTH;
+    const static QString TICK_ALPHA;
+    const static QString TICK_BLUE;
+    const static QString TICK_GREEN;
+    const static QString TICK_RED;
+    const static QString TICK_WIDTH;
+    const static QString LABEL_COLOR_BLUE;
+    const static QString LABEL_COLOR_GREEN;
+    const static QString LABEL_COLOR_RED;
+
+    const static std::map< QString, ConvertType > typeTable;
 
     static bool m_registered;
 

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.h
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.h
@@ -30,6 +30,8 @@ class Themes;
 class DataGrid : public Carta::State::CartaObject {
 
 friend class LayerData;
+friend class LayerGroup;
+friend class Stack;
 friend class GridControls;
 
 public:

--- a/carta/cpp/core/Data/Image/Grid/DataGrid.h
+++ b/carta/cpp/core/Data/Image/Grid/DataGrid.h
@@ -32,6 +32,7 @@ class DataGrid : public Carta::State::CartaObject {
 friend class LayerData;
 friend class LayerGroup;
 friend class Stack;
+friend class Controller;
 friend class GridControls;
 
 public:
@@ -93,6 +94,13 @@ private:
     QStringList _setTickColor( int redAmount, int greenAmount, int blueAmount, bool* colorChanged );
     QString _setTickTransparency( int transparency, bool* transparencyChanged );
     QString _setTheme( const QString& theme, bool* themeChanged );
+
+    // template function should be defined in header file
+    template < typename T > QString _setState( const QString stateName, const T stateValue ){
+        m_state.setValue<T>( stateName, stateValue );
+        _resetGridRenderer();
+        return m_state.toString();
+    };
 
     Carta::State::StateInterface _getState();
     QPen _getPen( const QString& key, const Carta::State::StateInterface& state );

--- a/carta/cpp/core/Data/Image/Grid/GridControls.cpp
+++ b/carta/cpp/core/Data/Image/Grid/GridControls.cpp
@@ -53,13 +53,13 @@ void GridControls::_initializeDefaultState(){
 
 void GridControls::_initializeCallbacks(){
 
-    addCommandCallback( "getDataGridState", [=] (const QString & /*cmd*/,
-                    const QString & /*params*/, const QString & /*sessionId*/) -> QString {
-        QString result;
-        Carta::State::StateInterface gridState = m_dataGrid->_getState();
-        result = gridState.toString();
-        return result;
-    });
+    // addCommandCallback( "getDataGridState", [=] (const QString & /*cmd*/,
+    //                 const QString & /*params*/, const QString & /*sessionId*/) -> QString {
+    //     QString result;
+    //     Carta::State::StateInterface gridState = m_dataGrid->_getState();
+    //     result = gridState.toString();
+    //     return result;
+    // });
 
     addCommandCallback( "setApplyAll", [=] (const QString & /*cmd*/,
                    const QString & params, const QString & /*sessionId*/) -> QString {

--- a/carta/cpp/core/Data/Image/Grid/GridControls.cpp
+++ b/carta/cpp/core/Data/Image/Grid/GridControls.cpp
@@ -53,6 +53,14 @@ void GridControls::_initializeDefaultState(){
 
 void GridControls::_initializeCallbacks(){
 
+    addCommandCallback( "getDataGridState", [=] (const QString & /*cmd*/,
+                    const QString & /*params*/, const QString & /*sessionId*/) -> QString {
+        QString result;
+        Carta::State::StateInterface gridState = m_dataGrid->_getState();
+        result = gridState.toString();
+        return result;
+    });
+
     addCommandCallback( "setApplyAll", [=] (const QString & /*cmd*/,
                    const QString & params, const QString & /*sessionId*/) -> QString {
                QString result;

--- a/carta/cpp/core/Data/Image/Layer.cpp
+++ b/carta/cpp/core/Data/Image/Layer.cpp
@@ -236,6 +236,11 @@ bool Layer::_setCompositionMode( const QString& id, const QString& /*composition
     return stateChanged;
 }
 
+QString Layer::_setDataGridState( const QString stateName, const QString stateValue ){
+    qCritical() << "Not implement";
+    return "";
+}
+
 
 bool Layer::_setLayerName( const QString& id, const QString& name ){
     bool nameChanged = false;

--- a/carta/cpp/core/Data/Image/Layer.h
+++ b/carta/cpp/core/Data/Image/Layer.h
@@ -521,6 +521,8 @@ protected:
      */
     virtual void _resetZoom( ) = 0;
 
+    virtual QString _setAxisX( QString name ) = 0;
+
     /**
      * Set the mode used to compose this layer.
      * @param id - the identifier for the layer group where the composition mode will change.

--- a/carta/cpp/core/Data/Image/Layer.h
+++ b/carta/cpp/core/Data/Image/Layer.h
@@ -428,7 +428,7 @@ protected:
      */
     virtual double _getZoom() const = 0;
 
-    virtual void _gridChanged( const Carta::State::StateInterface& state) = 0;
+    // virtual void _gridChanged( const Carta::State::StateInterface& state) = 0;
 
     /**
      * Returns whether or not the layer can contain other layers.

--- a/carta/cpp/core/Data/Image/Layer.h
+++ b/carta/cpp/core/Data/Image/Layer.h
@@ -532,6 +532,8 @@ protected:
     virtual bool _setCompositionMode( const QString& id, const QString& compositionMode,
             QString& errorMsg );
 
+    virtual QString _setCoordinateSystem( QString csName ) = 0;
+
     virtual QString _setDataGridState( const QString stateName, const QString stateValue );
 
     /**

--- a/carta/cpp/core/Data/Image/Layer.h
+++ b/carta/cpp/core/Data/Image/Layer.h
@@ -31,6 +31,7 @@ class RawViewInterface;
 
 namespace Data {
 
+class DataGrid;
 class ColorState;
 class DataContours;
 class DataSource;
@@ -186,6 +187,12 @@ protected:
     virtual QString _getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY,
             const std::vector<int>& frames, const QSize& outputSize ) = 0;
 
+
+    /**
+     * Return the data grid of the image.
+     * @return - the data grid of the image.
+     */
+    virtual std::shared_ptr<DataGrid> _getDataGrid() = 0;
 
     /**
      * Return the data source of the image.

--- a/carta/cpp/core/Data/Image/Layer.h
+++ b/carta/cpp/core/Data/Image/Layer.h
@@ -521,7 +521,7 @@ protected:
      */
     virtual void _resetZoom( ) = 0;
 
-    virtual QString _setAxisX( QString name ) = 0;
+    virtual QString _setAxis( const QString axis, const QString name ) = 0;
 
     /**
      * Set the mode used to compose this layer.

--- a/carta/cpp/core/Data/Image/Layer.h
+++ b/carta/cpp/core/Data/Image/Layer.h
@@ -532,6 +532,8 @@ protected:
     virtual bool _setCompositionMode( const QString& id, const QString& compositionMode,
             QString& errorMsg );
 
+    virtual QString _setDataGridState( const QString stateName, const QString stateValue );
+
     /**
      * Attempts to load an image file.
      * @param fileName - an identifier for the location of the image file.

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -1039,12 +1039,7 @@ QString LayerData::_setAxisX( QString name ){
 
 QString LayerData::_setDataGridState( const QString stateName, const QString stateValue ){
     QString result;
-    // use setTickTransparency to try
-    // TODO: build a table to decide type of argument for each state element.
-    if( stateName == Carta::State::UtilState::getLookup( DataGrid::TICK, Util::ALPHA ) ){
-        int value = stateValue.toInt();
-        result = m_dataGrid->_setState<int>( stateName, value );
-    }
+    result = m_dataGrid->_setState( stateName, stateValue );
     return result;
 }
 

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -1017,10 +1017,10 @@ QString LayerData::_setFileName( const QString& fileName, bool * success ){
     return result;
 }
 
-QString LayerData::_setAxisX( QString name ){
+QString LayerData::_setAxis( const QString axis, const QString name ){
     // TODO: the variable is used to match the parameter of function, remove it later.
     bool axisChanged = false;
-    QString result = m_dataGrid->_setAxis( AxisMapper::AXIS_X, name, &axisChanged );
+    QString result = m_dataGrid->_setAxis( axis, name, &axisChanged );
     return result;
 }
 

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -240,6 +240,10 @@ QString LayerData::_getCursorText(bool isAutoClip, double minPercent, double max
     return cursorText;
 }
 
+std::shared_ptr<DataGrid> LayerData::_getDataGrid(){
+    return m_dataGrid;
+}
+
 std::shared_ptr<DataSource> LayerData::_getDataSource(){
     return m_dataSource;
 }

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -1030,6 +1030,13 @@ QString LayerData::_setFileName( const QString& fileName, bool * success ){
     return result;
 }
 
+QString LayerData::_setAxisX( QString name ){
+    // TODO: the variable is used to match the parameter of function, remove it later.
+    bool axisChanged = false;
+    QString result = m_dataGrid->_setAxis( AxisMapper::AXIS_X, name, &axisChanged );
+    return result;
+}
+
 bool LayerData::_setLayersGrouped( bool /*grouped*/, const QSize& /*viewSize*/  ){
     return false;
 }

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -998,6 +998,17 @@ QString LayerData::_setFileName( const QString& fileName, bool * success ){
         bool csChanged = false;
         QString initCS = m_dataGrid->_setCoordinateSystem( csName, &csChanged);
 
+        // TODO:the variable is used to match the crietia of _setAxis(), try to remove later.
+        bool axisChanged = false;
+        std::vector<AxisInfo> supportedAxes = m_dataSource->_getAxisInfos();
+        m_dataGrid->_setAxisInfos( supportedAxes );
+        int xIndex = m_dataSource->m_axisIndexX;
+        int yIndex = m_dataSource->m_axisIndexY;
+        QString xPurpose = supportedAxes[xIndex].longLabel().plain();
+        QString yPurpose = supportedAxes[yIndex].longLabel().plain();
+        m_dataGrid->_setAxis( AxisMapper::AXIS_X, xPurpose, &axisChanged );
+        m_dataGrid->_setAxis( AxisMapper::AXIS_Y, yPurpose, &axisChanged );
+
         //Reset the pan and zoom when the image is loaded.
         _resetPan();
         _resetZoom();

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -226,13 +226,6 @@ QString LayerData::_getCursorText(bool isAutoClip, double minPercent, double max
     QString cursorText;
     if ( m_dataSource ){
         Carta::Lib::KnownSkyCS cs = m_dataGrid->_getSkyCS();
-        //if(cs == Carta::Lib::KnownSkyCS::Default){
-            //QString csName = m_dataSource->_getSkyCS();
-            //bool *csChanged;
-            //m_dataGrid->_setCoordinateSystem( csName, csChanged);
-            //cs = m_dataGrid->_getSkyCS();
-            //cs = m_dataGrid->_getSkyCS(csName);
-        //}
         QPointF pan = _getPan();
         double zoom = _getZoom();
         cursorText = m_dataSource->_getCursorText(isAutoClip, minPercent, maxPercent, mouseX, mouseY, cs, frames, zoom, pan, outputSize);
@@ -638,19 +631,19 @@ double LayerData::_getZoom() const {
     return zoom;
 }
 
-void LayerData::_gridChanged( const Carta::State::StateInterface& state ){
-    QString skyCS = Carta::Data::DataGrid::COORD_SYSTEM;
-    QString csName = state.getValue<QString>( skyCS );
-    Carta::State::StateInterface substituteState = state;
-    CoordinateSystems* m_coords = Util::findSingletonObject<CoordinateSystems>();
-    if(m_coords->getIndex(csName) == Carta::Lib::KnownSkyCS::Default){
-        csName = m_dataSource->_getSkyCS();
-        substituteState.setValue<QString>( skyCS, csName );
-        //m_state.setValue<QString>( skyCS, csName );
-        //m_state.flushState();
-    }
-    m_dataGrid->_resetState( substituteState );
-}
+// void LayerData::_gridChanged( const Carta::State::StateInterface& state ){
+//     QString skyCS = Carta::Data::DataGrid::COORD_SYSTEM;
+//     QString csName = state.getValue<QString>( skyCS );
+//     Carta::State::StateInterface substituteState = state;
+//     CoordinateSystems* m_coords = Util::findSingletonObject<CoordinateSystems>();
+//     if(m_coords->getIndex(csName) == Carta::Lib::KnownSkyCS::Default){
+//         csName = m_dataSource->_getSkyCS();
+//         substituteState.setValue<QString>( skyCS, csName );
+//         //m_state.setValue<QString>( skyCS, csName );
+//         //m_state.flushState();
+//     }
+//     m_dataGrid->_resetState( substituteState );
+// }
 
 
 void LayerData::_initializeState() {
@@ -937,7 +930,8 @@ void LayerData::_resetState( const Carta::State::StateInterface& restoreState ){
     QString gridStr = restoreState.toString( DataGrid::GRID );
     Carta::State::StateInterface gridState( "" );
     gridState.setState( gridStr );
-    _gridChanged( gridState);
+    // _gridChanged( gridState);
+    m_dataGrid->_resetState( gridState );
     _resetStateContours( restoreState );
     QString colorState = restoreState.toString( ColorState::CLASS_NAME);
     if ( colorState.length() > 0 ){

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -1024,7 +1024,7 @@ QString LayerData::_setCoordinateSystem( QString csName ){
 
     CoordinateSystems* coordSys = Util::findSingletonObject<CoordinateSystems>();
     if( coordSys->getIndex(csName) == Carta::Lib::KnownSkyCS::Default ){
-        csName = m_dataSource->_getSkyCS();
+        csName = m_dataSource->_getDefaultCoordinateSystem();
     }
 
     Carta::Lib::KnownSkyCS cs = coordSys->getIndex( csName );
@@ -1033,7 +1033,8 @@ QString LayerData::_setCoordinateSystem( QString csName ){
 
     // TODO:the variable is used to match the crietia of _setAxis(), try to remove later.
     bool axisChanged = false;
-    std::vector<AxisInfo> supportedAxes = m_dataSource->_getAxisInfos( cs );
+    m_dataSource->_setCoordinateSystem( cs );
+    std::vector<AxisInfo> supportedAxes = m_dataSource->_getAxisInfos();
     m_dataGrid->_setAxisInfos( supportedAxes );
     int xIndex = m_dataSource->m_axisIndexX;
     int yIndex = m_dataSource->m_axisIndexY;

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -993,21 +993,8 @@ QString LayerData::_setFileName( const QString& fileName, bool * success ){
     QString result = m_dataSource->_setFileName( fileName, success );
     if ( *success){
 
-        Carta::Lib::KnownSkyCS cs;
-        QString csName = m_dataSource->_getSkyCS();
-        bool csChanged = false;
-        QString initCS = m_dataGrid->_setCoordinateSystem( csName, &csChanged);
-
-        // TODO:the variable is used to match the crietia of _setAxis(), try to remove later.
-        bool axisChanged = false;
-        std::vector<AxisInfo> supportedAxes = m_dataSource->_getAxisInfos();
-        m_dataGrid->_setAxisInfos( supportedAxes );
-        int xIndex = m_dataSource->m_axisIndexX;
-        int yIndex = m_dataSource->m_axisIndexY;
-        QString xPurpose = supportedAxes[xIndex].longLabel().plain();
-        QString yPurpose = supportedAxes[yIndex].longLabel().plain();
-        m_dataGrid->_setAxis( AxisMapper::AXIS_X, xPurpose, &axisChanged );
-        m_dataGrid->_setAxis( AxisMapper::AXIS_Y, yPurpose, &axisChanged );
+        CoordinateSystems* coordSys = Util::findSingletonObject<CoordinateSystems>();
+        _setCoordinateSystem( coordSys->getDefault() );
 
         //Reset the pan and zoom when the image is loaded.
         _resetPan();
@@ -1034,6 +1021,33 @@ QString LayerData::_setAxisX( QString name ){
     // TODO: the variable is used to match the parameter of function, remove it later.
     bool axisChanged = false;
     QString result = m_dataGrid->_setAxis( AxisMapper::AXIS_X, name, &axisChanged );
+    return result;
+}
+
+QString LayerData::_setCoordinateSystem( QString csName ){
+
+    QString result;
+
+    CoordinateSystems* coordSys = Util::findSingletonObject<CoordinateSystems>();
+    if( coordSys->getIndex(csName) == Carta::Lib::KnownSkyCS::Default ){
+        csName = m_dataSource->_getSkyCS();
+    }
+
+    Carta::Lib::KnownSkyCS cs = coordSys->getIndex( csName );
+    bool csChanged = false; // useless variable
+    result = m_dataGrid->_setCoordinateSystem( csName, &csChanged);
+
+    // TODO:the variable is used to match the crietia of _setAxis(), try to remove later.
+    bool axisChanged = false;
+    std::vector<AxisInfo> supportedAxes = m_dataSource->_getAxisInfos( cs );
+    m_dataGrid->_setAxisInfos( supportedAxes );
+    int xIndex = m_dataSource->m_axisIndexX;
+    int yIndex = m_dataSource->m_axisIndexY;
+    QString xPurpose = supportedAxes[xIndex].longLabel().plain();
+    QString yPurpose = supportedAxes[yIndex].longLabel().plain();
+    result = m_dataGrid->_setAxis( AxisMapper::AXIS_X, xPurpose, &axisChanged );
+    result = m_dataGrid->_setAxis( AxisMapper::AXIS_Y, yPurpose, &axisChanged );
+
     return result;
 }
 

--- a/carta/cpp/core/Data/Image/LayerData.cpp
+++ b/carta/cpp/core/Data/Image/LayerData.cpp
@@ -1037,6 +1037,17 @@ QString LayerData::_setAxisX( QString name ){
     return result;
 }
 
+QString LayerData::_setDataGridState( const QString stateName, const QString stateValue ){
+    QString result;
+    // use setTickTransparency to try
+    // TODO: build a table to decide type of argument for each state element.
+    if( stateName == Carta::State::UtilState::getLookup( DataGrid::TICK, Util::ALPHA ) ){
+        int value = stateValue.toInt();
+        result = m_dataGrid->_setState<int>( stateName, value );
+    }
+    return result;
+}
+
 bool LayerData::_setLayersGrouped( bool /*grouped*/, const QSize& /*viewSize*/  ){
     return false;
 }

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -295,7 +295,7 @@ protected:
     virtual double _getZoom() const;
 
 
-    virtual void _gridChanged( const Carta::State::StateInterface& state) Q_DECL_OVERRIDE;
+    // virtual void _gridChanged( const Carta::State::StateInterface& state) Q_DECL_OVERRIDE;
 
     /**
      * Returns whether or not the layer can be loaded with the indicated frames.

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -429,7 +429,7 @@ protected:
      */
     virtual void _resetStateContours(const Carta::State::StateInterface& restoreState );
 
-    virtual QString _setAxisX( QString name ) Q_DECL_OVERRIDE;
+    virtual QString _setAxis( const QString axis, const QString name ) Q_DECL_OVERRIDE;
 
     virtual QString _setCoordinateSystem( QString csName ) Q_DECL_OVERRIDE;
 

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -146,6 +146,12 @@ protected:
             const std::vector<int>& frames, const QSize& outputSize) Q_DECL_OVERRIDE;
 
     /**
+     * Return the data grid of the image.
+     * @return - the data grid of the image.
+     */
+    virtual std::shared_ptr<DataGrid> _getDataGrid() Q_DECL_OVERRIDE;
+
+    /**
      * Return the data source of the image.
      * @return - the data source of the image.
      */
@@ -533,7 +539,8 @@ private:
     static const QString PAN;
 
 
-    std::unique_ptr<DataGrid> m_dataGrid;
+    // std::unique_ptr<DataGrid> m_dataGrid;
+    std::shared_ptr<DataGrid> m_dataGrid;
 
     std::set< std::shared_ptr<DataContours> > m_dataContours;
 

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -429,6 +429,8 @@ protected:
      */
     virtual void _resetStateContours(const Carta::State::StateInterface& restoreState );
 
+    virtual QString _setAxisX( QString name ) Q_DECL_OVERRIDE;
+
     /**
      * Group or ungroup any child layers.
      * @param grouped - true if child layers should be grouped; false, otherwise.

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -431,6 +431,8 @@ protected:
 
     virtual QString _setAxisX( QString name ) Q_DECL_OVERRIDE;
 
+    virtual QString _setDataGridState( const QString stateName, const QString stateValue ) Q_DECL_OVERRIDE;
+
     /**
      * Group or ungroup any child layers.
      * @param grouped - true if child layers should be grouped; false, otherwise.

--- a/carta/cpp/core/Data/Image/LayerData.h
+++ b/carta/cpp/core/Data/Image/LayerData.h
@@ -431,6 +431,8 @@ protected:
 
     virtual QString _setAxisX( QString name ) Q_DECL_OVERRIDE;
 
+    virtual QString _setCoordinateSystem( QString csName ) Q_DECL_OVERRIDE;
+
     virtual QString _setDataGridState( const QString stateName, const QString stateValue ) Q_DECL_OVERRIDE;
 
     /**

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -944,16 +944,10 @@ void LayerGroup::_setColorSupport( Layer* layer ){
     layer->_setSupportAlpha( alphaSupport );
 }
 
-QString LayerGroup::_setAxisX( QString name ){
+QString LayerGroup::_setAxis( const QString axis, const QString name ){
     QString result;
     for ( auto layer : m_children ){
-        // TODO: the variable is used to match the parameter of function, remove it later.
-        bool axisChanged = false;
-        // TODO: should layergroup change all the datagrid of children?
-        // 2017.12.27 make layergroup change all the datagrid
-        std::shared_ptr<DataGrid> dataGrid = layer->_getDataGrid();
-        // The returned statestring is meanless in this layergroup case
-        result = dataGrid->_setAxis( AxisMapper::AXIS_X, name, &axisChanged );
+        layer->_setAxis( axis, name);
     }
 
     int dataIndex = _getIndexCurrent();

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -729,14 +729,14 @@ double LayerGroup::_getZoom() const {
     return zoom;
 }
 
-void LayerGroup::_gridChanged( const Carta::State::StateInterface& state ){
-    int dataCount = m_children.size();
-    for ( int i = 0; i < dataCount; i++ ){
-        if ( m_children[i] != nullptr ){
-            m_children[i]->_gridChanged( state );
-        }
-    }
-}
+// void LayerGroup::_gridChanged( const Carta::State::StateInterface& state ){
+//     int dataCount = m_children.size();
+//     for ( int i = 0; i < dataCount; i++ ){
+//         if ( m_children[i] != nullptr ){
+//             m_children[i]->_gridChanged( state );
+//         }
+//     }
+// }
 
 
 void LayerGroup::_initializeState(){

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -341,6 +341,15 @@ QString LayerGroup::_getCursorText(bool isAutoClip, double minPercent, double ma
 
 }
 
+std::shared_ptr<DataGrid> LayerGroup::_getDataGrid(){
+    std::shared_ptr<DataGrid> dataGrid( nullptr );
+    int dataIndex = _getIndexCurrent();
+    if ( dataIndex >= 0 ){
+        dataGrid = m_children[dataIndex]->_getDataGrid();
+    }
+    return dataGrid;
+}
+
 QString LayerGroup::_getDefaultName( const QString& id ) const {
     return GROUP + " "+id;
 }

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -945,11 +945,23 @@ void LayerGroup::_setColorSupport( Layer* layer ){
 }
 
 QString LayerGroup::_setAxisX( QString name ){
-    // TODO: the variable is used to match the parameter of function, remove it later.
-    bool axisChanged = false;
-    // TODO: should layergroup change all the datagrid of children?
-    std::shared_ptr<DataGrid> dataGrid = _getDataGrid();
-    QString result = dataGrid->_setAxis( AxisMapper::AXIS_X, name, &axisChanged );
+    QString result;
+    for ( auto layer : m_children ){
+        // TODO: the variable is used to match the parameter of function, remove it later.
+        bool axisChanged = false;
+        // TODO: should layergroup change all the datagrid of children?
+        // 2017.12.27 make layergroup change all the datagrid
+        std::shared_ptr<DataGrid> dataGrid = layer->_getDataGrid();
+        // The returned statestring is meanless in this layergroup case
+        result = dataGrid->_setAxis( AxisMapper::AXIS_X, name, &axisChanged );
+    }
+
+    int dataIndex = _getIndexCurrent();
+    if ( dataIndex >= 0 ){
+        std::shared_ptr<DataGrid> dataGrid = m_children[dataIndex]->_getDataGrid();
+        Carta::State::StateInterface dataGridState = dataGrid->_getState();
+        result = dataGridState.toString();
+    }
     return result;
 }
 

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -1,6 +1,8 @@
 #include "LayerGroup.h"
 #include "LayerData.h"
 #include "DataSource.h"
+#include "Grid/AxisMapper.h"
+#include "Grid/DataGrid.h"
 #include "Data/Util.h"
 #include "Data/Image/LayerCompositionModes.h"
 #include "CartaLib/IRemoteVGView.h"
@@ -940,6 +942,15 @@ void LayerGroup::_setColorSupport( Layer* layer ){
     bool alphaSupport = m_compositionModes->isAlphaSupport( compMode );
     layer->_setSupportColor( colorSupport );
     layer->_setSupportAlpha( alphaSupport );
+}
+
+QString LayerGroup::_setAxisX( QString name ){
+    // TODO: the variable is used to match the parameter of function, remove it later.
+    bool axisChanged = false;
+    // TODO: should layergroup change all the datagrid of children?
+    std::shared_ptr<DataGrid> dataGrid = _getDataGrid();
+    QString result = dataGrid->_setAxis( AxisMapper::AXIS_X, name, &axisChanged );
+    return result;
 }
 
 bool LayerGroup::_setCompositionMode( const QString& id, const QString& compositionMode,

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -996,6 +996,22 @@ bool LayerGroup::_setCompositionMode( const QString& id, const QString& composit
     return stateChanged;
 }
 
+QString LayerGroup::_setCoordinateSystem( QString csName ){
+    QString result;
+    for ( auto layer : m_children ){
+        // std::shared_ptr<DataGrid> dataGrid = layer->_getDataGrid();
+        result = layer->_setCoordinateSystem( csName );
+    }
+
+    int dataIndex = _getIndexCurrent();
+    if ( dataIndex >= 0 ){
+        std::shared_ptr<DataGrid> dataGrid = m_children[dataIndex]->_getDataGrid();
+        Carta::State::StateInterface dataGridState = dataGrid->_getState();
+        result = dataGridState.toString();
+    }
+    return result;
+}
+
 QString LayerGroup::_setDataGridState( const QString stateName, const QString stateValue ){
     QString result;
     for ( auto layer : m_children ){

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -996,6 +996,21 @@ bool LayerGroup::_setCompositionMode( const QString& id, const QString& composit
     return stateChanged;
 }
 
+QString LayerGroup::_setDataGridState( const QString stateName, const QString stateValue ){
+    QString result;
+    for ( auto layer : m_children ){
+        std::shared_ptr<DataGrid> dataGrid = layer->_getDataGrid();
+        result = dataGrid->_setState( stateName, stateValue );
+    }
+
+    int dataIndex = _getIndexCurrent();
+    if ( dataIndex >= 0 ){
+        std::shared_ptr<DataGrid> dataGrid = m_children[dataIndex]->_getDataGrid();
+        Carta::State::StateInterface dataGridState = dataGrid->_getState();
+        result = dataGridState.toString();
+    }
+    return result;
+}
 
 bool LayerGroup::_setLayersGrouped( bool grouped, const QSize& clientSize  ){
     bool operationPerformed = false;

--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -999,7 +999,6 @@ bool LayerGroup::_setCompositionMode( const QString& id, const QString& composit
 QString LayerGroup::_setCoordinateSystem( QString csName ){
     QString result;
     for ( auto layer : m_children ){
-        // std::shared_ptr<DataGrid> dataGrid = layer->_getDataGrid();
         result = layer->_setCoordinateSystem( csName );
     }
 

--- a/carta/cpp/core/Data/Image/LayerGroup.h
+++ b/carta/cpp/core/Data/Image/LayerGroup.h
@@ -365,7 +365,7 @@ protected:
     virtual double _getZoom() const Q_DECL_OVERRIDE;
 
 
-    virtual void _gridChanged( const Carta::State::StateInterface& state ) Q_DECL_OVERRIDE;
+    // virtual void _gridChanged( const Carta::State::StateInterface& state ) Q_DECL_OVERRIDE;
 
     /**
      * Returns true since other layers can be added to a group.

--- a/carta/cpp/core/Data/Image/LayerGroup.h
+++ b/carta/cpp/core/Data/Image/LayerGroup.h
@@ -440,6 +440,8 @@ protected:
     virtual bool _setCompositionMode( const QString& id, const QString& compositionMode,
             QString& errorMsg ) Q_DECL_OVERRIDE;
 
+    virtual QString _setDataGridState( const QString stateName, const QString stateValue ) Q_DECL_OVERRIDE;
+
     /**
      * Give the layer (a more user-friendly) name.
      * @param id - an identifier for the layer to rename.

--- a/carta/cpp/core/Data/Image/LayerGroup.h
+++ b/carta/cpp/core/Data/Image/LayerGroup.h
@@ -430,6 +430,8 @@ protected:
     virtual void _resetZoom() Q_DECL_OVERRIDE;
 
 
+    virtual QString _setAxisX( QString name ) Q_DECL_OVERRIDE; 
+
     /**
      * Set the mode used to compose this layer.
      * @param compositionMode - the mode used to compose this layer.

--- a/carta/cpp/core/Data/Image/LayerGroup.h
+++ b/carta/cpp/core/Data/Image/LayerGroup.h
@@ -430,7 +430,7 @@ protected:
     virtual void _resetZoom() Q_DECL_OVERRIDE;
 
 
-    virtual QString _setAxisX( QString name ) Q_DECL_OVERRIDE; 
+    virtual QString _setAxis( const QString axis, const QString name ) Q_DECL_OVERRIDE; 
 
     /**
      * Set the mode used to compose this layer.

--- a/carta/cpp/core/Data/Image/LayerGroup.h
+++ b/carta/cpp/core/Data/Image/LayerGroup.h
@@ -146,6 +146,12 @@ protected:
             const std::vector<int>& frames, const QSize& outputSize ) Q_DECL_OVERRIDE;
 
     /**
+     * Return the data grid of the image.
+     * @return - the data grid of the image.
+     */
+    virtual std::shared_ptr<DataGrid> _getDataGrid() Q_DECL_OVERRIDE;
+
+    /**
      * Return the data source of the image.
      * @return - the data source of the image.
      */

--- a/carta/cpp/core/Data/Image/LayerGroup.h
+++ b/carta/cpp/core/Data/Image/LayerGroup.h
@@ -440,6 +440,8 @@ protected:
     virtual bool _setCompositionMode( const QString& id, const QString& compositionMode,
             QString& errorMsg ) Q_DECL_OVERRIDE;
 
+    virtual QString _setCoordinateSystem( QString csName ) Q_DECL_OVERRIDE;
+
     virtual QString _setDataGridState( const QString stateName, const QString stateValue ) Q_DECL_OVERRIDE;
 
     /**

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -4,6 +4,7 @@
 #include "Data/Image/Draw/DrawStackSynchronizer.h"
 #include "Data/Image/Draw/DrawImageViewsSynchronizer.h"
 #include "Data/Image/Grid/AxisMapper.h"
+#include "Data/Image/Grid/DataGrid.h"
 #include "Data/Image/Save/SaveService.h"
 #include "Data/Preferences/PreferencesSave.h"
 #include "Data/Region/Region.h"
@@ -176,6 +177,12 @@ QString Stack::_getCursorText(bool isAutoClip, double minPercent, double maxPerc
                 frameIndices, outputSize );
     }
     return cursorText;
+}
+
+Carta::State::StateInterface Stack::_getDataGridState(){
+    std::shared_ptr<DataGrid> dataGrid = _getDataGrid();
+    Carta::State::StateInterface dataGridState = dataGrid->_getState();
+    return dataGridState;
 }
 
 QList<std::shared_ptr<Layer> > Stack::_getDrawChildren() const {

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -687,6 +687,16 @@ QString Stack::_setAxisX( QString name ){
     return result;
 }
 
+QString Stack::_setCoordinateSystem( QString csName ){
+    QString result;
+    int dataIndex = _getIndexCurrent();
+    if ( dataIndex >= 0 ){
+        result = m_children[dataIndex]->_setCoordinateSystem( csName );
+        emit viewLoad();
+    }
+    return result;
+}
+
 QString Stack::_setDataGridState( const QString stateName, const QString stateValue ){
     QString result;
     int dataIndex = _getIndexCurrent();

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -653,30 +653,35 @@ void Stack::_saveState( bool flush ) {
 }
 
 QString Stack::_setAxisX( QString name ){
-    bool axisChanged = false;
-    // TODO: should layergroup change all the datagrid of children?
-    std::shared_ptr<DataGrid> dataGrid = _getDataGrid();
-    QString result = dataGrid->_setAxis( AxisMapper::AXIS_X, name, &axisChanged );
-
-    std::vector<AxisInfo::KnownType> displayTypes = dataGrid->_getDisplayAxes();
-    int dataIndex = _getIndexCurrent();
-    if (dataIndex >= 0 ) {
-        if (m_children[dataIndex] != nullptr) {
-            std::vector<int> frames = _getFrameIndices();
-            m_children[dataIndex]->_displayAxesChanged( displayTypes, frames );
-        }
-    }
-    emit viewLoad();
+    // bool axisChanged = false;
+    // // TODO: should layergroup change all the datagrid of children?
+    // std::shared_ptr<DataGrid> dataGrid = _getDataGrid();
+    // QString result = dataGrid->_setAxis( AxisMapper::AXIS_X, name, &axisChanged );
+    //
+    // std::vector<AxisInfo::KnownType> displayTypes = dataGrid->_getDisplayAxes();
+    // int dataIndex = _getIndexCurrent();
+    // if (dataIndex >= 0 ) {
+    //     if (m_children[dataIndex] != nullptr) {
+    //         std::vector<int> frames = _getFrameIndices();
+    //         m_children[dataIndex]->_displayAxesChanged( displayTypes, frames );
+    //     }
+    // }
+    // emit viewLoad();
 
     //TODO: so far the _displayAxesChanged() should be called from Stack
     //due to the _getFrameIndices(), try to simplify this part
-    // int dataIndex = _getIndexCurrent();
-    // if ( dataIndex >= 0 ){
-    //     m_children[dataIndex]->_setAxisX( name );
-    //     std::vector<int> frames = _getFrameIndices();
-    //     m_children[dataIndex]->_displayAxesChanged( displayTypes, frames );
-    //     emit viewLoad();
-    // }
+    QString result = "";
+    int dataIndex = _getIndexCurrent();
+    if ( dataIndex >= 0 ){
+        result = m_children[dataIndex]->_setAxisX( name );
+
+        // Get the updated datagrid to update raster image
+        std::shared_ptr<DataGrid> dataGrid = m_children[dataIndex]->_getDataGrid();
+        std::vector<AxisInfo::KnownType> displayTypes = dataGrid->_getDisplayAxes();
+        std::vector<int> frames = _getFrameIndices();
+        m_children[dataIndex]->_displayAxesChanged( displayTypes, frames );
+        emit viewLoad();
+    }
 
     // TODO: the return value mix with exception, try to seperate them.
     return result;

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -687,6 +687,16 @@ QString Stack::_setAxisX( QString name ){
     return result;
 }
 
+QString Stack::_setDataGridState( const QString stateName, const QString stateValue ){
+    QString result;
+    int dataIndex = _getIndexCurrent();
+    if ( dataIndex >= 0 ){
+        result = m_children[dataIndex]->_setDataGridState( stateName, stateValue );
+        emit viewLoad();
+    }
+    return result;
+}
+
 bool Stack::_setCompositionMode( const QString& id, const QString& compositionMode,
         QString& errorMsg ){
     QString actualCompMode;

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -350,23 +350,23 @@ QString Stack::getStateString() const{
     return result;
 }
 
-void Stack::_gridChanged( const Carta::State::StateInterface& state, bool applyAll ){
-    int dataIndex = _getIndexCurrent();
-    if ( dataIndex >= 0 ){
-        if ( !applyAll ){
-            m_children[dataIndex]->_gridChanged( state );
-        }
-        else {
-            int dataCount = m_children.size();
-            for ( int i = 0; i < dataCount; i++ ){
-                if ( m_children[i] != nullptr ){
-                    m_children[i]->_gridChanged( state );
-                }
-            }
-        }
-        emit viewLoad( );
-    }
-}
+// void Stack::_gridChanged( const Carta::State::StateInterface& state, bool applyAll ){
+//     int dataIndex = _getIndexCurrent();
+//     if ( dataIndex >= 0 ){
+//         if ( !applyAll ){
+//             m_children[dataIndex]->_gridChanged( state );
+//         }
+//         else {
+//             int dataCount = m_children.size();
+//             for ( int i = 0; i < dataCount; i++ ){
+//                 if ( m_children[i] != nullptr ){
+//                     m_children[i]->_gridChanged( state );
+//                 }
+//             }
+//         }
+//         emit viewLoad( );
+//     }
+// }
 
 void Stack::_initializeSelections(){
     Carta::State::ObjectManager* objMan = Carta::State::ObjectManager::objectManager();

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -652,7 +652,7 @@ void Stack::_saveState( bool flush ) {
     }
 }
 
-QString Stack::_setAxisX( QString name ){
+QString Stack::_setAxis( const QString axis, const QString name ){
     // bool axisChanged = false;
     // // TODO: should layergroup change all the datagrid of children?
     // std::shared_ptr<DataGrid> dataGrid = _getDataGrid();
@@ -673,7 +673,7 @@ QString Stack::_setAxisX( QString name ){
     QString result = "";
     int dataIndex = _getIndexCurrent();
     if ( dataIndex >= 0 ){
-        result = m_children[dataIndex]->_setAxisX( name );
+        result = m_children[dataIndex]->_setAxis( axis, name );
 
         // Get the updated datagrid to update raster image
         std::shared_ptr<DataGrid> dataGrid = m_children[dataIndex]->_getDataGrid();

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -652,6 +652,36 @@ void Stack::_saveState( bool flush ) {
     }
 }
 
+QString Stack::_setAxisX( QString name ){
+    bool axisChanged = false;
+    // TODO: should layergroup change all the datagrid of children?
+    std::shared_ptr<DataGrid> dataGrid = _getDataGrid();
+    QString result = dataGrid->_setAxis( AxisMapper::AXIS_X, name, &axisChanged );
+
+    std::vector<AxisInfo::KnownType> displayTypes = dataGrid->_getDisplayAxes();
+    int dataIndex = _getIndexCurrent();
+    if (dataIndex >= 0 ) {
+        if (m_children[dataIndex] != nullptr) {
+            std::vector<int> frames = _getFrameIndices();
+            m_children[dataIndex]->_displayAxesChanged( displayTypes, frames );
+        }
+    }
+    emit viewLoad();
+
+    //TODO: so far the _displayAxesChanged() should be called from Stack
+    //due to the _getFrameIndices(), try to simplify this part
+    // int dataIndex = _getIndexCurrent();
+    // if ( dataIndex >= 0 ){
+    //     m_children[dataIndex]->_setAxisX( name );
+    //     std::vector<int> frames = _getFrameIndices();
+    //     m_children[dataIndex]->_displayAxesChanged( displayTypes, frames );
+    //     emit viewLoad();
+    // }
+
+    // TODO: the return value mix with exception, try to seperate them.
+    return result;
+}
+
 bool Stack::_setCompositionMode( const QString& id, const QString& compositionMode,
         QString& errorMsg ){
     QString actualCompMode;

--- a/carta/cpp/core/Data/Image/Stack.cpp
+++ b/carta/cpp/core/Data/Image/Stack.cpp
@@ -64,6 +64,7 @@ QString Stack::_addDataImage(const QString& fileName, bool* success ) {
         _resetFrames( stackIndex );
         _saveState();
     }
+    emit viewLoad();
     return result;
 }
 

--- a/carta/cpp/core/Data/Image/Stack.h
+++ b/carta/cpp/core/Data/Image/Stack.h
@@ -62,6 +62,8 @@ protected:
 
     virtual QString _setAxisX( QString name ) Q_DECL_OVERRIDE;
 
+    virtual QString _setCoordinateSystem( QString csName ) Q_DECL_OVERRIDE;
+
     virtual QString _setDataGridState( const QString stateName, const QString stateValue ) Q_DECL_OVERRIDE;
 
     /**

--- a/carta/cpp/core/Data/Image/Stack.h
+++ b/carta/cpp/core/Data/Image/Stack.h
@@ -62,6 +62,8 @@ protected:
 
     virtual QString _setAxisX( QString name ) Q_DECL_OVERRIDE;
 
+    virtual QString _setDataGridState( const QString stateName, const QString stateValue ) Q_DECL_OVERRIDE;
+
     /**
      * Give the layer (a more user-friendly) name.
      * @param id - an identifier for the layer to rename.

--- a/carta/cpp/core/Data/Image/Stack.h
+++ b/carta/cpp/core/Data/Image/Stack.h
@@ -60,7 +60,7 @@ protected:
     virtual QStringList _getLayerIds( ) const Q_DECL_OVERRIDE;
 
 
-    virtual QString _setAxisX( QString name ) Q_DECL_OVERRIDE;
+    virtual QString _setAxis( const QString axis, const QString name ) Q_DECL_OVERRIDE;
 
     virtual QString _setCoordinateSystem( QString csName ) Q_DECL_OVERRIDE;
 

--- a/carta/cpp/core/Data/Image/Stack.h
+++ b/carta/cpp/core/Data/Image/Stack.h
@@ -99,6 +99,7 @@ private:
                 Carta::Lib::KnownSkyCS system ) const;
 
     QString _getCursorText(bool isAutoClip, double minPercent, double maxPercent, int mouseX, int mouseY );
+    Carta::State::StateInterface _getDataGridState();
 
     QList<std::shared_ptr<Layer> > _getDrawChildren() const;
     int _getFrame( Carta::Lib::AxisInfo::KnownType axisType ) const;

--- a/carta/cpp/core/Data/Image/Stack.h
+++ b/carta/cpp/core/Data/Image/Stack.h
@@ -60,6 +60,7 @@ protected:
     virtual QStringList _getLayerIds( ) const Q_DECL_OVERRIDE;
 
 
+    virtual QString _setAxisX( QString name ) Q_DECL_OVERRIDE;
 
     /**
      * Give the layer (a more user-friendly) name.

--- a/carta/cpp/core/Data/Profile/Profiler.cpp
+++ b/carta/cpp/core/Data/Profile/Profiler.cpp
@@ -3612,10 +3612,21 @@ bool Profiler::_updateProfiles( Controller* controller ){
     // }
 
     m_plotCurves.clear();
+    bool isCelestial = false;
+    int specCount = 1;
+    int tabCount = 1;
     std::shared_ptr<Layer> currentLayer = controller->getLayer("");
+    if ( currentLayer ){
+        isCelestial = currentLayer->_isOnCelestialPlane();
+        specCount = currentLayer->_getFrameCount( Carta::Lib::AxisInfo::KnownType::SPECTRAL );
+        tabCount = currentLayer->_getFrameCount( Carta::Lib::AxisInfo::KnownType::TABULAR );
+    }
+
     std::shared_ptr<Region> currentRegion = controller->getRegionControls()->getRegion("");
 //    profileChanged = _generateCurve( currentLayer, nullptr );
-    profileChanged = _generateCurve( currentLayer, currentRegion );
+    if ( isCelestial && (specCount > 1 || tabCount > 1) ){
+        profileChanged = _generateCurve( currentLayer, currentRegion );
+    }
 
     return profileChanged;
 }

--- a/carta/cpp/core/ScriptedClient/ScriptFacade.cpp
+++ b/carta/cpp/core/ScriptedClient/ScriptFacade.cpp
@@ -1545,574 +1545,574 @@ QStringList ScriptFacade::saveHistogram( const QString& histogramId, const QStri
     return resultList;
 }
 
-QStringList ScriptFacade::setGridAxesColor( const QString& controlId, int red, int green, int blue ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                resultList = controller->getGridControls()->setAxesColor( red, green, blue );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId );
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
+// QStringList ScriptFacade::setGridAxesColor( const QString& controlId, int red, int green, int blue ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 resultList = controller->getGridControls()->setAxesColor( red, green, blue );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId );
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
 
-QStringList ScriptFacade::setGridAxesThickness( const QString& controlId, int thickness ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setAxesThickness( thickness );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId );
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridAxesTransparency( const QString& controlId, int transparency ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setAxesTransparency( transparency );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId );
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridApplyAll( const QString& controlId, bool applyAll ) {
-    QStringList resultList("");
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                controller->getGridControls()->setApplyAll( applyAll );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId );
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridCoordinateSystem( const QString& controlId, const QString& coordSystem ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setCoordinateSystem( coordSystem );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridFontFamily( const QString& controlId, const QString& fontFamily ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setFontFamily( fontFamily );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridFontSize( const QString& controlId, int fontSize ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setFontSize( fontSize );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                resultList = controller->getGridControls()->setGridColor( redAmount, greenAmount, blueAmount );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridSpacing( const QString& controlId, double spacing ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setGridSpacing( spacing );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridThickness( const QString& controlId, int thickness ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setGridThickness( thickness );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-
-}
-
-QStringList ScriptFacade::setGridTransparency( const QString& controlId, int transparency ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setGridTransparency( transparency );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridLabelColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                resultList = controller->getGridControls()->setLabelColor( redAmount, greenAmount, blueAmount );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setShowGridAxis( const QString& controlId, bool showAxis ) {
-    QStringList resultList("");
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setShowAxis( showAxis );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setShowGridCoordinateSystem( const QString& controlId, bool showCoordinateSystem ) {
-    QStringList resultList("");
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setShowCoordinateSystem( showCoordinateSystem );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setShowGridLines( const QString& controlId, bool showGridLines ) {
-    QStringList resultList("");
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setShowGridLines( showGridLines );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setShowGridInternalLabels( const QString& controlId, bool showInternalLabels ) {
-    QStringList resultList("");
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setShowInternalLabels( showInternalLabels );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setShowGridStatistics( const QString& controlId, bool showStatistics ) {
-    QStringList resultList("");
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setShowStatistics( showStatistics );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setShowGridTicks( const QString& controlId, bool showTicks ) {
-    QStringList resultList("");
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setShowTicks( showTicks );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridTickColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                resultList = controller->getGridControls()->setTickColor( redAmount, greenAmount, blueAmount );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridTickThickness( const QString& controlId, int tickThickness ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setTickThickness( tickThickness );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridTickTransparency( const QString& controlId, int transparency ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setTickTransparency( transparency );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
-
-QStringList ScriptFacade::setGridTheme( const QString& controlId, const QString& theme ) {
-    QStringList resultList;
-    Carta::State::CartaObject* obj = _getObject( controlId );
-    if ( obj != nullptr ){
-        Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
-        if ( controller != nullptr ){
-            if ( controller->getStackedImageCount() > 0 ) {
-                QString result = controller->getGridControls()->setTheme( theme );
-                resultList = QStringList( result );
-            }
-            else {
-                resultList = _logErrorMessage( ERROR, NO_IMAGE );
-            }
-        }
-        else {
-            resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
-        }
-    }
-    else {
-        resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
-    }
-    if ( resultList.length() == 0 ) {
-        resultList = QStringList("");
-    }
-    return resultList;
-}
+// QStringList ScriptFacade::setGridAxesThickness( const QString& controlId, int thickness ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setAxesThickness( thickness );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId );
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridAxesTransparency( const QString& controlId, int transparency ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setAxesTransparency( transparency );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId );
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridApplyAll( const QString& controlId, bool applyAll ) {
+//     QStringList resultList("");
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 controller->getGridControls()->setApplyAll( applyAll );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId );
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridCoordinateSystem( const QString& controlId, const QString& coordSystem ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setCoordinateSystem( coordSystem );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridFontFamily( const QString& controlId, const QString& fontFamily ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setFontFamily( fontFamily );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridFontSize( const QString& controlId, int fontSize ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setFontSize( fontSize );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 resultList = controller->getGridControls()->setGridColor( redAmount, greenAmount, blueAmount );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridSpacing( const QString& controlId, double spacing ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setGridSpacing( spacing );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridThickness( const QString& controlId, int thickness ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setGridThickness( thickness );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+//
+// }
+//
+// QStringList ScriptFacade::setGridTransparency( const QString& controlId, int transparency ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setGridTransparency( transparency );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridLabelColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 resultList = controller->getGridControls()->setLabelColor( redAmount, greenAmount, blueAmount );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setShowGridAxis( const QString& controlId, bool showAxis ) {
+//     QStringList resultList("");
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setShowAxis( showAxis );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setShowGridCoordinateSystem( const QString& controlId, bool showCoordinateSystem ) {
+//     QStringList resultList("");
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setShowCoordinateSystem( showCoordinateSystem );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setShowGridLines( const QString& controlId, bool showGridLines ) {
+//     QStringList resultList("");
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setShowGridLines( showGridLines );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setShowGridInternalLabels( const QString& controlId, bool showInternalLabels ) {
+//     QStringList resultList("");
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setShowInternalLabels( showInternalLabels );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setShowGridStatistics( const QString& controlId, bool showStatistics ) {
+//     QStringList resultList("");
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setShowStatistics( showStatistics );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setShowGridTicks( const QString& controlId, bool showTicks ) {
+//     QStringList resultList("");
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setShowTicks( showTicks );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridTickColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 resultList = controller->getGridControls()->setTickColor( redAmount, greenAmount, blueAmount );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridTickThickness( const QString& controlId, int tickThickness ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setTickThickness( tickThickness );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridTickTransparency( const QString& controlId, int transparency ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setTickTransparency( transparency );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
+//
+// QStringList ScriptFacade::setGridTheme( const QString& controlId, const QString& theme ) {
+//     QStringList resultList;
+//     Carta::State::CartaObject* obj = _getObject( controlId );
+//     if ( obj != nullptr ){
+//         Carta::Data::Controller* controller = dynamic_cast<Carta::Data::Controller*>(obj);
+//         if ( controller != nullptr ){
+//             if ( controller->getStackedImageCount() > 0 ) {
+//                 QString result = controller->getGridControls()->setTheme( theme );
+//                 resultList = QStringList( result );
+//             }
+//             else {
+//                 resultList = _logErrorMessage( ERROR, NO_IMAGE );
+//             }
+//         }
+//         else {
+//             resultList = _logErrorMessage( ERROR, UNKNOWN_ERROR );
+//         }
+//     }
+//     else {
+//         resultList = _logErrorMessage( ERROR, IMAGE_VIEW_NOT_FOUND + controlId);
+//     }
+//     if ( resultList.length() == 0 ) {
+//         resultList = QStringList("");
+//     }
+//     return resultList;
+// }
 
 QStringList ScriptFacade::deleteContourSet( const QString& controlId, const QString& name ) {
     QStringList resultList;

--- a/carta/cpp/core/ScriptedClient/ScriptFacade.h
+++ b/carta/cpp/core/ScriptedClient/ScriptFacade.h
@@ -665,209 +665,209 @@ public:
      */
     QStringList saveHistogram( const QString& histogramId, const QString& filename, int width, int height, const QString& aspectRatioMode );
 
-    /**
-     * Set the grid axes color.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param red- an integer in [0, 255] indicating the amount of red.
-     * @param green - an integer in [0,255] indicating the amount of green.
-     * @param blue - an integer in [0,255] indicating the amount of blue.
-     * @return a list of errors or an empty list if the color was successfully set.
-     */
-    QStringList setGridAxesColor( const QString& controlId, int red, int green, int blue );
-
-    /**
-     * Set grid axis thickness.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param thickness - a positive integer.
-     * @return an error message if the thickness could not be set or an empty string
-     *  if the thickness was successfully set.
-     */
-    QStringList setGridAxesThickness( const QString& controldId, int thickness );
-
-    /**
-     * Set the grid axis transparency.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param transparency - a nonnegative integer between 0 and 255, with 255 opaque.
-     * @return an error message if the transparency could not be set or an empty string
-     *      if it was successfully set.
-     */
-    QStringList setGridAxesTransparency( const QString& controldId, int transparency );
-
-    /**
-     * Set whether or not grid control settings should apply to all images on the set.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param applyAll - true if the settings apply to all images on the stack;
-     *      false otherwise.
-     */
-    QStringList setGridApplyAll( const QString& controlId, bool applyAll );
-
-    /**
-     * Set the grid coordinate system.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param coordSystem - an identifier for a grid coordinate system.
-     * @return an error message if there was a problem setting the coordinate system;
-     *  an empty string otherwise.
-     */
-    QStringList setGridCoordinateSystem( const QString& controlId, const QString& coordSystem );
-
-    /**
-     * Set the font family used for grid labels.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param fontFamily - an identifier for a font family.
-     * @return an error message if there was a problem setting the font family;
-     *  an empty string otherwise.
-     */
-    QStringList setGridFontFamily( const QString& controlId, const QString& fontFamily );
-
-    /**
-     * Set the font size used for grid labels.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param fontSize - an identifier for a font point size.
-     * @return an error message if there was a problem setting the font point size;
-     *  an empty string otherwise.
-     */
-    QStringList setGridFontSize( const QString& controlId, int fontSize );
-
-    /**
-     * Set the grid color.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param redAmount - an integer in [0, 255] indicating the amount of red.
-     * @param greenAmount  an integer in [0,255] indicating the amount of green.
-     * @param blueAmount - an integer in [0,255] indicating the amount of blue.
-     * @return a list of errors or an empty list if the color was successfully set.
-     */
-    QStringList setGridColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount );
-
-    /**
-     * Set the spacing between grid lines.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param spacing - the grid spacing in [0,1] with 1 having the least amount of spacing.
-     * @return an error message if there was a problem setting the grid spacing; an empty
-     *      string otherwise.
-     */
-    QStringList setGridSpacing( const QString& controlId, double spacing );
-
-    /**
-     * Set the thickness of the grid lines.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param thickness -a positive integer.
-     * @return an error message if there was a problem setting the grid line thickness; an empty
-     *      string otherwise.
-     */
-    QStringList setGridThickness( const QString& controlId, int thickness );
-
-    /**
-     * Set the transparency of the grid.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param transparency - the amount of transparency in [0,255] with 255 completely opaque.
-     * @return an error message if there was a problem setting the transparency; an empty
-     *      string otherwise.
-     */
-    QStringList setGridTransparency( const QString& controlId, int transparency );
-
-    /**
-     * Set the color of grid labels color.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param redAmount - an integer in [0, 255] indicating the amount of red.
-     * @param greenAmount  an integer in [0,255] indicating the amount of green.
-     * @param blueAmount - an integer in [0,255] indicating the amount of blue.
-     * @return a list of errors or an empty list if the color was successfully set.
-     */
-    QStringList setGridLabelColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount );
-
-    /**
-     * Set whether or not the grid axes should be shown.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param showAxis - true if the axes should be shown; false otherwise.
-     * @return an error message if there was a problem changing the visibility of the
-     *      axes; an empty string otherwise.
-     */
-    QStringList setShowGridAxis( const QString& controlId, bool showAxis );
-
-    /**
-     * Set whether or not the grid coordinate system should be visible.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param showCoordinateSystem - true if the coordinate system should be shown;
-     *      false otherwise.
-     * @return an error message if there was a problem setting the coordinate system;
-     *      an empty string otherwise.
-     */
-    QStringList setShowGridCoordinateSystem( const QString& controlId, bool showCoordinateSystem );
-
-    /**
-     * Set whether or not the grid lines should be shown.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param showGridLines - true if the grid lines should be shown; false otherwise.
-     * @return an error message if there was a problem changing the visibility of the
-     *     grid; an empty string otherwise.
-     */
-    QStringList setShowGridLines( const QString& controlId, bool showGridLines );
-
-    /**
-     * Set whether or not the grid axis should be internal or external.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param showInternalLabels - true if the axes should be internal; false otherwise.
-     * @return an error message if there was a problem setting the axes internal/external;
-     *      false otherwise.
-     */
-    QStringList setShowGridInternalLabels( const QString& controlId, bool showInternalLabels );
-
-    /**
-     * Sets whether or not cursor position image statistics should be shown.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param showStatistics - true if cursor statistics should be shown; false otherwise.
-     * @return an error message if there was a problem hiding/showing cursor statistics;
-     *      an empty string otherwise.
-     */
-    QStringList setShowGridStatistics( const QString& controlId, bool showStatistics );
-
-    /**
-     * Set whether or not to show grid axis ticks.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param showTicks - true if the grid axis ticks should be shown; false otherwise.
-     * @return an error message if there was a problem setting the visibility of grid axis
-     *      ticks; and empty string otherwise.
-     */
-    QStringList setShowGridTicks( const QString& controldId, bool showTicks );
-
-    /**
-     * Set the color of the grid tick marks.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param redAmount - a nonnegative integer in [0,255].
-     * @param greenAmount - a nonnegative integer in [0,255].
-     * @param blueAmount - a nonnegative integer in [0,255].
-     * @return a list of error message(s) if there was a problem setting the tick
-     *      color; an empty list otherwise.
-     */
-    QStringList setGridTickColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount );
-
-    /**
-     * Set the length of the grid ticks.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param tickThickness - a positive integer.
-     * @return an error message if the tick thickness was not successfully set;
-     *      an empty string otherwise.
-     */
-    QStringList setGridTickThickness( const QString& controlId, int tickThickness );
-
-    /**
-     * Set the transparency of the grid tick marks.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param transparency - a nonnegative integer between 0 and 255 with 255 being
-     *      opaque.
-     * @return an error message if the transparency was not successfully set; an
-     *      empty string otherwise.
-     */
-    QStringList setGridTickTransparency( const QString& controldId, int transparency );
-
-    /**
-     * Set the grid canvas theme.
-     * @param controlId the unique server-side id of an object managing a controller.
-     * @param theme - an identifier for a canvas theme.
-     * @return an error message if the theme was not successfully set; an empty
-     *      string otherwise.
-     */
-    QStringList setGridTheme( const QString& controlId, const QString& theme );
+    // /**
+    //  * Set the grid axes color.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param red- an integer in [0, 255] indicating the amount of red.
+    //  * @param green - an integer in [0,255] indicating the amount of green.
+    //  * @param blue - an integer in [0,255] indicating the amount of blue.
+    //  * @return a list of errors or an empty list if the color was successfully set.
+    //  */
+    // QStringList setGridAxesColor( const QString& controlId, int red, int green, int blue );
+    //
+    // /**
+    //  * Set grid axis thickness.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param thickness - a positive integer.
+    //  * @return an error message if the thickness could not be set or an empty string
+    //  *  if the thickness was successfully set.
+    //  */
+    // QStringList setGridAxesThickness( const QString& controldId, int thickness );
+    //
+    // /**
+    //  * Set the grid axis transparency.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param transparency - a nonnegative integer between 0 and 255, with 255 opaque.
+    //  * @return an error message if the transparency could not be set or an empty string
+    //  *      if it was successfully set.
+    //  */
+    // QStringList setGridAxesTransparency( const QString& controldId, int transparency );
+    //
+    // /**
+    //  * Set whether or not grid control settings should apply to all images on the set.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param applyAll - true if the settings apply to all images on the stack;
+    //  *      false otherwise.
+    //  */
+    // QStringList setGridApplyAll( const QString& controlId, bool applyAll );
+    //
+    // /**
+    //  * Set the grid coordinate system.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param coordSystem - an identifier for a grid coordinate system.
+    //  * @return an error message if there was a problem setting the coordinate system;
+    //  *  an empty string otherwise.
+    //  */
+    // QStringList setGridCoordinateSystem( const QString& controlId, const QString& coordSystem );
+    //
+    // /**
+    //  * Set the font family used for grid labels.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param fontFamily - an identifier for a font family.
+    //  * @return an error message if there was a problem setting the font family;
+    //  *  an empty string otherwise.
+    //  */
+    // QStringList setGridFontFamily( const QString& controlId, const QString& fontFamily );
+    //
+    // /**
+    //  * Set the font size used for grid labels.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param fontSize - an identifier for a font point size.
+    //  * @return an error message if there was a problem setting the font point size;
+    //  *  an empty string otherwise.
+    //  */
+    // QStringList setGridFontSize( const QString& controlId, int fontSize );
+    //
+    // /**
+    //  * Set the grid color.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param redAmount - an integer in [0, 255] indicating the amount of red.
+    //  * @param greenAmount  an integer in [0,255] indicating the amount of green.
+    //  * @param blueAmount - an integer in [0,255] indicating the amount of blue.
+    //  * @return a list of errors or an empty list if the color was successfully set.
+    //  */
+    // QStringList setGridColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount );
+    //
+    // /**
+    //  * Set the spacing between grid lines.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param spacing - the grid spacing in [0,1] with 1 having the least amount of spacing.
+    //  * @return an error message if there was a problem setting the grid spacing; an empty
+    //  *      string otherwise.
+    //  */
+    // QStringList setGridSpacing( const QString& controlId, double spacing );
+    //
+    // /**
+    //  * Set the thickness of the grid lines.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param thickness -a positive integer.
+    //  * @return an error message if there was a problem setting the grid line thickness; an empty
+    //  *      string otherwise.
+    //  */
+    // QStringList setGridThickness( const QString& controlId, int thickness );
+    //
+    // /**
+    //  * Set the transparency of the grid.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param transparency - the amount of transparency in [0,255] with 255 completely opaque.
+    //  * @return an error message if there was a problem setting the transparency; an empty
+    //  *      string otherwise.
+    //  */
+    // QStringList setGridTransparency( const QString& controlId, int transparency );
+    //
+    // /**
+    //  * Set the color of grid labels color.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param redAmount - an integer in [0, 255] indicating the amount of red.
+    //  * @param greenAmount  an integer in [0,255] indicating the amount of green.
+    //  * @param blueAmount - an integer in [0,255] indicating the amount of blue.
+    //  * @return a list of errors or an empty list if the color was successfully set.
+    //  */
+    // QStringList setGridLabelColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount );
+    //
+    // /**
+    //  * Set whether or not the grid axes should be shown.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param showAxis - true if the axes should be shown; false otherwise.
+    //  * @return an error message if there was a problem changing the visibility of the
+    //  *      axes; an empty string otherwise.
+    //  */
+    // QStringList setShowGridAxis( const QString& controlId, bool showAxis );
+    //
+    // /**
+    //  * Set whether or not the grid coordinate system should be visible.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param showCoordinateSystem - true if the coordinate system should be shown;
+    //  *      false otherwise.
+    //  * @return an error message if there was a problem setting the coordinate system;
+    //  *      an empty string otherwise.
+    //  */
+    // QStringList setShowGridCoordinateSystem( const QString& controlId, bool showCoordinateSystem );
+    //
+    // /**
+    //  * Set whether or not the grid lines should be shown.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param showGridLines - true if the grid lines should be shown; false otherwise.
+    //  * @return an error message if there was a problem changing the visibility of the
+    //  *     grid; an empty string otherwise.
+    //  */
+    // QStringList setShowGridLines( const QString& controlId, bool showGridLines );
+    //
+    // /**
+    //  * Set whether or not the grid axis should be internal or external.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param showInternalLabels - true if the axes should be internal; false otherwise.
+    //  * @return an error message if there was a problem setting the axes internal/external;
+    //  *      false otherwise.
+    //  */
+    // QStringList setShowGridInternalLabels( const QString& controlId, bool showInternalLabels );
+    //
+    // /**
+    //  * Sets whether or not cursor position image statistics should be shown.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param showStatistics - true if cursor statistics should be shown; false otherwise.
+    //  * @return an error message if there was a problem hiding/showing cursor statistics;
+    //  *      an empty string otherwise.
+    //  */
+    // QStringList setShowGridStatistics( const QString& controlId, bool showStatistics );
+    //
+    // /**
+    //  * Set whether or not to show grid axis ticks.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param showTicks - true if the grid axis ticks should be shown; false otherwise.
+    //  * @return an error message if there was a problem setting the visibility of grid axis
+    //  *      ticks; and empty string otherwise.
+    //  */
+    // QStringList setShowGridTicks( const QString& controldId, bool showTicks );
+    //
+    // /**
+    //  * Set the color of the grid tick marks.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param redAmount - a nonnegative integer in [0,255].
+    //  * @param greenAmount - a nonnegative integer in [0,255].
+    //  * @param blueAmount - a nonnegative integer in [0,255].
+    //  * @return a list of error message(s) if there was a problem setting the tick
+    //  *      color; an empty list otherwise.
+    //  */
+    // QStringList setGridTickColor( const QString& controlId, int redAmount, int greenAmount, int blueAmount );
+    //
+    // /**
+    //  * Set the length of the grid ticks.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param tickThickness - a positive integer.
+    //  * @return an error message if the tick thickness was not successfully set;
+    //  *      an empty string otherwise.
+    //  */
+    // QStringList setGridTickThickness( const QString& controlId, int tickThickness );
+    //
+    // /**
+    //  * Set the transparency of the grid tick marks.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param transparency - a nonnegative integer between 0 and 255 with 255 being
+    //  *      opaque.
+    //  * @return an error message if the transparency was not successfully set; an
+    //  *      empty string otherwise.
+    //  */
+    // QStringList setGridTickTransparency( const QString& controldId, int transparency );
+    //
+    // /**
+    //  * Set the grid canvas theme.
+    //  * @param controlId the unique server-side id of an object managing a controller.
+    //  * @param theme - an identifier for a canvas theme.
+    //  * @return an error message if the theme was not successfully set; an empty
+    //  *      string otherwise.
+    //  */
+    // QStringList setGridTheme( const QString& controlId, const QString& theme );
 
     /**
      * Delete the contour set with the indicated name.
@@ -1053,4 +1053,3 @@ private:
     const static QString HISTOGRAM_NOT_FOUND;
     const static QString ANIMATOR_NOT_FOUND;
 };
-

--- a/carta/cpp/core/ScriptedClient/ScriptedCommandInterpreter.cpp
+++ b/carta/cpp/core/ScriptedClient/ScriptedCommandInterpreter.cpp
@@ -402,145 +402,145 @@ ScriptedCommandInterpreter::tagMessageReceivedCB( TagMessage tm )
     /// These commands also come from the Python Image class. They allow
     /// the grid to be manipulated.
 
-    else if ( cmd == "setgridaxescolor" ) {
-        QString imageView = args["imageView"].toString();
-        int red = args["red"].toInt();
-        int green = args["green"].toInt();
-        int blue = args["blue"].toInt();
-        result = m_scriptFacade->setGridAxesColor( imageView, red, green, blue );
-    }
-
-    else if ( cmd == "setgridaxesthickness" ) {
-        QString imageView = args["imageView"].toString();
-        int thickness = args["thickness"].toInt();
-        result = m_scriptFacade->setGridAxesThickness( imageView, thickness );
-    }
-
-    else if ( cmd == "setgridaxestransparency" ) {
-        QString imageView = args["imageView"].toString();
-        int transparency = args["transparency"].toInt();
-        result = m_scriptFacade->setGridAxesTransparency( imageView, transparency );
-    }
-
-    else if ( cmd == "setgridapplyall" ) {
-        QString imageView = args["imageView"].toString();
-        bool applyAll = args["applyAll"].toBool();
-        result = m_scriptFacade->setGridApplyAll( imageView, applyAll );
-    }
-
-    else if ( cmd == "setgridcoordinatesystem" ) {
-        QString imageView = args["imageView"].toString();
-        QString coordSystem = args["coordSystem"].toString();
-        result = m_scriptFacade->setGridCoordinateSystem( imageView, coordSystem );
-    }
-
-    else if ( cmd == "setgridfontfamily" ) {
-        QString imageView = args["imageView"].toString();
-        QString fontFamily = args["fontFamily"].toString();
-        result = m_scriptFacade->setGridFontFamily( imageView, fontFamily );
-    }
-
-    else if ( cmd == "setgridfontsize" ) {
-        QString imageView = args["imageView"].toString();
-        int fontSize = args["fontSize"].toInt();
-        result = m_scriptFacade->setGridFontSize( imageView, fontSize );
-    }
-
-    else if ( cmd == "setgridcolor" ) {
-        QString imageView = args["imageView"].toString();
-        int redAmount = args["redAmount"].toInt();
-        int greenAmount = args["greenAmount"].toInt();
-        int blueAmount = args["blueAmount"].toInt();
-        result = m_scriptFacade->setGridColor( imageView, redAmount, greenAmount, blueAmount );
-    }
-
-    else if ( cmd == "setgridspacing" ) {
-        QString imageView = args["imageView"].toString();
-        double spacing = args["spacing"].toDouble();
-        result = m_scriptFacade->setGridSpacing( imageView, spacing );
-    }
-
-    else if ( cmd == "setgridthickness" ) {
-        QString imageView = args["imageView"].toString();
-        int thickness = args["thickness"].toInt();
-        result = m_scriptFacade->setGridThickness( imageView, thickness );
-    }
-
-    else if ( cmd == "setgridtransparency" ) {
-        QString imageView = args["imageView"].toString();
-        int transparency = args["transparency"].toInt();
-        result = m_scriptFacade->setGridTransparency( imageView, transparency );
-    }
-
-    else if ( cmd == "setgridlabelcolor" ) {
-        QString imageView = args["imageView"].toString();
-        int redAmount = args["redAmount"].toInt();
-        int greenAmount = args["greenAmount"].toInt();
-        int blueAmount = args["blueAmount"].toInt();
-        result = m_scriptFacade->setGridLabelColor( imageView, redAmount, greenAmount, blueAmount );
-    }
-
-    else if ( cmd == "setshowgridaxis" ) {
-        QString imageView = args["imageView"].toString();
-        bool showAxis = args["showAxis"].toBool();
-        result = m_scriptFacade->setShowGridAxis( imageView, showAxis );
-    }
-
-    else if ( cmd == "setshowgridcoordinatesystem" ) {
-        QString imageView = args["imageView"].toString();
-        bool showCoordinateSystem = args["showCoordinateSystem"].toBool();
-        result = m_scriptFacade->setShowGridCoordinateSystem( imageView, showCoordinateSystem );
-    }
-
-    else if ( cmd == "setshowgridlines" ) {
-        QString imageView = args["imageView"].toString();
-        bool showGridLines = args["showGridLines"].toBool();
-        result = m_scriptFacade->setShowGridLines( imageView, showGridLines );
-    }
-
-    else if ( cmd == "setshowgridinternallabels" ) {
-        QString imageView = args["imageView"].toString();
-        bool showInternalLabels = args["showInternalLabels"].toBool();
-        result = m_scriptFacade->setShowGridInternalLabels( imageView, showInternalLabels );
-    }
-
-    else if ( cmd == "setshowgridstatistics" ) {
-        QString imageView = args["imageView"].toString();
-        bool showStatistics = args["showStatistics"].toBool();
-        result = m_scriptFacade->setShowGridStatistics( imageView, showStatistics );
-    }
-
-    else if ( cmd == "setshowgridticks" ) {
-        QString imageView = args["imageView"].toString();
-        bool showTicks = args["showTicks"].toBool();
-        result = m_scriptFacade->setShowGridTicks( imageView, showTicks );
-    }
-
-    else if ( cmd == "setgridtickcolor" ) {
-        QString imageView = args["imageView"].toString();
-        int redAmount = args["redAmount"].toInt();
-        int greenAmount = args["greenAmount"].toInt();
-        int blueAmount = args["blueAmount"].toInt();
-        result = m_scriptFacade->setGridTickColor( imageView, redAmount, greenAmount, blueAmount );
-    }
-
-    else if ( cmd == "setgridtickthickness" ) {
-        QString imageView = args["imageView"].toString();
-        int tickThickness = args["tickThickness"].toInt();
-        result = m_scriptFacade->setGridTickThickness( imageView, tickThickness );
-    }
-
-    else if ( cmd == "setgridticktransparency" ) {
-        QString imageView = args["imageView"].toString();
-        int transparency = args["transparency"].toInt();
-        result = m_scriptFacade->setGridTickTransparency( imageView, transparency );
-    }
-
-    else if ( cmd == "setgridtheme" ) {
-        QString imageView = args["imageView"].toString();
-        QString theme = args["theme"].toString();
-        result = m_scriptFacade->setGridTheme( imageView, theme );
-    }
+    // else if ( cmd == "setgridaxescolor" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     int red = args["red"].toInt();
+    //     int green = args["green"].toInt();
+    //     int blue = args["blue"].toInt();
+    //     result = m_scriptFacade->setGridAxesColor( imageView, red, green, blue );
+    // }
+    //
+    // else if ( cmd == "setgridaxesthickness" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     int thickness = args["thickness"].toInt();
+    //     result = m_scriptFacade->setGridAxesThickness( imageView, thickness );
+    // }
+    //
+    // else if ( cmd == "setgridaxestransparency" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     int transparency = args["transparency"].toInt();
+    //     result = m_scriptFacade->setGridAxesTransparency( imageView, transparency );
+    // }
+    //
+    // else if ( cmd == "setgridapplyall" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     bool applyAll = args["applyAll"].toBool();
+    //     result = m_scriptFacade->setGridApplyAll( imageView, applyAll );
+    // }
+    //
+    // else if ( cmd == "setgridcoordinatesystem" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     QString coordSystem = args["coordSystem"].toString();
+    //     result = m_scriptFacade->setGridCoordinateSystem( imageView, coordSystem );
+    // }
+    //
+    // else if ( cmd == "setgridfontfamily" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     QString fontFamily = args["fontFamily"].toString();
+    //     result = m_scriptFacade->setGridFontFamily( imageView, fontFamily );
+    // }
+    //
+    // else if ( cmd == "setgridfontsize" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     int fontSize = args["fontSize"].toInt();
+    //     result = m_scriptFacade->setGridFontSize( imageView, fontSize );
+    // }
+    //
+    // else if ( cmd == "setgridcolor" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     int redAmount = args["redAmount"].toInt();
+    //     int greenAmount = args["greenAmount"].toInt();
+    //     int blueAmount = args["blueAmount"].toInt();
+    //     result = m_scriptFacade->setGridColor( imageView, redAmount, greenAmount, blueAmount );
+    // }
+    //
+    // else if ( cmd == "setgridspacing" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     double spacing = args["spacing"].toDouble();
+    //     result = m_scriptFacade->setGridSpacing( imageView, spacing );
+    // }
+    //
+    // else if ( cmd == "setgridthickness" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     int thickness = args["thickness"].toInt();
+    //     result = m_scriptFacade->setGridThickness( imageView, thickness );
+    // }
+    //
+    // else if ( cmd == "setgridtransparency" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     int transparency = args["transparency"].toInt();
+    //     result = m_scriptFacade->setGridTransparency( imageView, transparency );
+    // }
+    //
+    // else if ( cmd == "setgridlabelcolor" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     int redAmount = args["redAmount"].toInt();
+    //     int greenAmount = args["greenAmount"].toInt();
+    //     int blueAmount = args["blueAmount"].toInt();
+    //     result = m_scriptFacade->setGridLabelColor( imageView, redAmount, greenAmount, blueAmount );
+    // }
+    //
+    // else if ( cmd == "setshowgridaxis" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     bool showAxis = args["showAxis"].toBool();
+    //     result = m_scriptFacade->setShowGridAxis( imageView, showAxis );
+    // }
+    //
+    // else if ( cmd == "setshowgridcoordinatesystem" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     bool showCoordinateSystem = args["showCoordinateSystem"].toBool();
+    //     result = m_scriptFacade->setShowGridCoordinateSystem( imageView, showCoordinateSystem );
+    // }
+    //
+    // else if ( cmd == "setshowgridlines" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     bool showGridLines = args["showGridLines"].toBool();
+    //     result = m_scriptFacade->setShowGridLines( imageView, showGridLines );
+    // }
+    //
+    // else if ( cmd == "setshowgridinternallabels" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     bool showInternalLabels = args["showInternalLabels"].toBool();
+    //     result = m_scriptFacade->setShowGridInternalLabels( imageView, showInternalLabels );
+    // }
+    //
+    // else if ( cmd == "setshowgridstatistics" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     bool showStatistics = args["showStatistics"].toBool();
+    //     result = m_scriptFacade->setShowGridStatistics( imageView, showStatistics );
+    // }
+    //
+    // else if ( cmd == "setshowgridticks" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     bool showTicks = args["showTicks"].toBool();
+    //     result = m_scriptFacade->setShowGridTicks( imageView, showTicks );
+    // }
+    //
+    // else if ( cmd == "setgridtickcolor" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     int redAmount = args["redAmount"].toInt();
+    //     int greenAmount = args["greenAmount"].toInt();
+    //     int blueAmount = args["blueAmount"].toInt();
+    //     result = m_scriptFacade->setGridTickColor( imageView, redAmount, greenAmount, blueAmount );
+    // }
+    //
+    // else if ( cmd == "setgridtickthickness" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     int tickThickness = args["tickThickness"].toInt();
+    //     result = m_scriptFacade->setGridTickThickness( imageView, tickThickness );
+    // }
+    //
+    // else if ( cmd == "setgridticktransparency" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     int transparency = args["transparency"].toInt();
+    //     result = m_scriptFacade->setGridTickTransparency( imageView, transparency );
+    // }
+    //
+    // else if ( cmd == "setgridtheme" ) {
+    //     QString imageView = args["imageView"].toString();
+    //     QString theme = args["theme"].toString();
+    //     result = m_scriptFacade->setGridTheme( imageView, theme );
+    // }
 
     /// Section: Contour Commands
     /// ----------------------------------

--- a/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
+++ b/carta/cpp/plugins/CasaImageLoader/CCCoordinateFormatter.cpp
@@ -480,18 +480,21 @@ CCCoordinateFormatter::parseCasaCSi( int pixelAxis )
                 if ( skycs == KnownSkyCS::B1950 ||
                      skycs == KnownSkyCS::J2000 ||
                      skycs == KnownSkyCS::ICRS ) {
-                    aInfo.setShortLabel( HtmlString( "RA", "&alpha;" ) );
+                    aInfo.setShortLabel( HtmlString( "RA", "&alpha;" ) )
+                        .setLongLabel( HtmlString::fromPlain("Right Ascension") );
                     //precision to 0.001 arcsec
                     m_precisions[pixelAxis] = 5;
                 }
                 else if ( skycs == KnownSkyCS::Ecliptic ) {
-                    aInfo.setShortLabel( HtmlString( "ELon", "&lambda;"));
+                    aInfo.setShortLabel( HtmlString( "ELon", "&lambda;"))
+                        .setLongLabel( HtmlString::fromPlain("Ecliptic Longitude") );
                         //.setShortLabel( HtmlString( "ELon", "l" ) );
                     //precision to 0.001 arcsec
                     m_precisions[pixelAxis] = 7;
                 }
                 else if ( skycs == KnownSkyCS::Galactic ) {
-                    aInfo.setShortLabel( HtmlString( "GLon", "l"));
+                    aInfo.setShortLabel( HtmlString( "GLon", "l"))
+                        .setLongLabel( HtmlString::fromPlain("Galactic Longitude") );
                         //.setShortLabel( HtmlString( "GLon", "&lambda;" ) );
                     //precision to 0.001 arcsec
                     m_precisions[pixelAxis] = 7;
@@ -508,18 +511,21 @@ CCCoordinateFormatter::parseCasaCSi( int pixelAxis )
                 if ( skycs == KnownSkyCS::B1950 ||
                      skycs == KnownSkyCS::J2000 ||
                      skycs == KnownSkyCS::ICRS ) {
-                    aInfo.setShortLabel( HtmlString( "Dec", "&delta;" ) );
+                    aInfo.setShortLabel( HtmlString( "Dec", "&delta;" ) )
+                        .setLongLabel( HtmlString::fromPlain("Declination") );
                     //precision to 0.001 arcsec
                     m_precisions[pixelAxis] = 4;
                 }
                 else if ( skycs == KnownSkyCS::Ecliptic ) {
-                    aInfo.setShortLabel( HtmlString( "Elat", "&beta;"));
+                    aInfo.setShortLabel( HtmlString( "Elat", "&beta;"))
+                        .setLongLabel( HtmlString::fromPlain("Ecliptic Latitude") );
                         //.setShortLabel( HtmlString( "ELat", "b" ) );
                     //precision to 0.001 arcsec
                     m_precisions[pixelAxis] = 7;
                 }
                 else if ( skycs == KnownSkyCS::Galactic ) {
-                    aInfo.setShortLabel( HtmlString( "GLat", "b"));
+                    aInfo.setShortLabel( HtmlString( "GLat", "b"))
+                        .setLongLabel( HtmlString::fromPlain("Galactic Latitude") );
                         //.setShortLabel( HtmlString( "GLat", "&beta;" ) );
                     //precision to 0.001 arcsec
                     m_precisions[pixelAxis] = 7;


### PR DESCRIPTION
This PR discard the original design of gridcontrol, and use the controller to receive the commands from the front-end, and then call stack to deal with the requests. The purpose is to solve the previous sync problem. We don't need to sync the datagrid belonging to the gridcontrol and another one belonging to  the layerdata. The front-end will directly get the state of the datagrid in the layerdate to set the props of the UI elements.
Details:
1. There are some commands still not be transferred (related to the color setting) so the definition of gridcontrol is left as a reference.
2. The transferred commands can be found in the commit description. The left commands also can be found in the comment of controller.
3. The related part in the python interface is disabled/commented.
4. Most of the 'set' function in the datagrid are replaces by the '_setState()', the function will directly set the state value of the datagrid and return the updated state string. Something noticeable is that the setState won't check the value. The check should be done in the front-end. Besides, the '_setState' function doesn't handle exception, which should be added in the future. The original 'set' functions are also left as references.
5. In the PR, the setDataGridState method in LayerGroup will change the datagrid states of all the LayerData members and return the datagrid state of the current layerdata. The behavior should be discussed further.