### PR TITLE
Fix a minor merging bug from PR226

### DIFF
--- a/carta/cpp/core/Data/Image/LayerGroup.cpp
+++ b/carta/cpp/core/Data/Image/LayerGroup.cpp
@@ -242,7 +242,7 @@ void LayerGroup::_displayAxesChanged(std::vector<AxisInfo::KnownType> displayAxi
     }
 }
 
-Carta::Lib::AxisInfo::KnownType LayerGroup::_getAxisType( int /*index*/ ) const {
+Carta::Lib::AxisInfo::KnownType LayerGroup::_getAxisType( int index ) const {
     AxisInfo::KnownType axisType = AxisInfo::KnownType::OTHER;
     int dataIndex = _getIndexCurrent();
     if ( dataIndex >= 0 ){


### PR DESCRIPTION
Fix a minor merging bug from #226. 

Mopdify the file `carta/cpp/core/Data/Image/LayerGroup.cpp` line 245:
```
Carta::Lib::AxisInfo::KnownType LayerGroup::_getAxisType( int /*index*/ ) const {
```
to
```
Carta::Lib::AxisInfo::KnownType LayerGroup::_getAxisType( int index ) const {
```
