### PR TITLE
[new Arch] protocol buffer tester

### DIFF
--- a/carta/cpp/common_config.pri
+++ b/carta/cpp/common_config.pri
@@ -11,6 +11,7 @@ WCSLIBDIR=../../ThirdParty/wcslib
 CFITSIODIR=../../ThirdParty/cfitsio
 IMAGEANALYSISDIR=../../ThirdParty/imageanalysis
 FLEXANDBISONDIR=../../ThirdParty/flex
+PROTOBUFDIR=../../ThirdParty/protobuf
 
 # don't edit these:
 # relative links are replaced by absolute paths
@@ -21,3 +22,4 @@ WCSLIBDIR=$$absolute_path($${WCSLIBDIR})
 CFITSIODIR=$$absolute_path($${CFITSIODIR})
 IMAGEANALYSISDIR=$$absolute_path($${IMAGEANALYSISDIR})
 FLEXANDBISONDIR=$$absolute_path($${FLEXANDBISONDIR})
+PROTOBUFDIR=$$absolute_path($${PROTOBUFDIR})

--- a/carta/cpp/cpp.pro
+++ b/carta/cpp/cpp.pro
@@ -11,7 +11,8 @@ SUBDIRS = \
     Tests \
     testCache \
     testRegion \
-    testPercentile
+    testPercentile \
+    testProtoBuf
 
 isEmpty(NOSERVER) {
 	SUBDIRS +=server
@@ -26,6 +27,7 @@ plugins.depends = core
 testRegion.depends = core
 testCache.depends = core
 testPercentile.depends = core
+testProtoBuf.depends = core
 
 isEmpty(NOSERVER) {
         Tests.depends = core desktop server plugins

--- a/carta/cpp/testProtoBuf/CartaHelper.cpp
+++ b/carta/cpp/testProtoBuf/CartaHelper.cpp
@@ -1,0 +1,375 @@
+#include "core/Globals.h"
+
+// we want to check percentile functions from this code
+#include "core/Algorithms/percentileAlgorithms.h"
+
+// get unit conversion headers
+#include "CartaLib/Hooks/ConversionSpectralHook.h"
+#include "CartaLib/Hooks/ConversionIntensityHook.h"
+
+#include <QDebug>
+#include <cmath>
+
+using namespace std;
+
+const std::vector<double> percentile = {0.0005, 0.0025, 0.005, 0.01, 0.015,
+                                        0.02, 0.025, 0.0375, 0.05, 0.95,
+                                        0.9625, 0.975, 0.98, 0.985, 0.99,
+                                        0.995, 0.9975, 0.9995};
+
+typedef Carta::Lib::AxisInfo AxisInfo;
+
+int getAxisIndex(std::shared_ptr<Carta::Lib::Image::ImageInterface> m_image,
+                 Carta::Lib::AxisInfo::KnownType axisType) {
+    int index = -1;
+    if (m_image){
+        std::shared_ptr<CoordinateFormatterInterface> cf(m_image->metaData()->coordinateFormatter()->clone());
+        int axisCount = cf->nAxes();
+        for ( int i = 0; i < axisCount; i++ ){
+            Carta::Lib::AxisInfo axisInfo = cf->axisInfo(i);
+            if (axisInfo.knownType() == axisType){
+                index = i;
+                break;
+            }
+        }
+    }
+    return index;
+}
+
+Carta::Lib::NdArray::RawViewInterface* getRawData(std::shared_ptr<Carta::Lib::Image::ImageInterface> m_image,
+                                                  int frameStart, int frameEnd, int stokeSliceIndex) {
+    Carta::Lib::NdArray::RawViewInterface* rawData = nullptr;
+    int m_axisIndexX = getAxisIndex(m_image, AxisInfo::KnownType::DIRECTION_LON);
+    int m_axisIndexY = getAxisIndex(m_image, AxisInfo::KnownType::DIRECTION_LAT);
+    int stokeIndex = getAxisIndex(m_image, AxisInfo::KnownType::STOKES);
+    int spectralIndex = getAxisIndex(m_image, AxisInfo::KnownType::SPECTRAL);
+    qDebug() << "++++++++ X Index:" << m_axisIndexX;
+    qDebug() << "++++++++ Y Index:" << m_axisIndexY;
+    qDebug() << "++++++++ Stoke Index:" << stokeIndex;
+    qDebug() << "++++++++ Spectral Index:" << spectralIndex;
+
+    if (m_axisIndexX != 0 || m_axisIndexY != 1) {
+        qFatal("Can not find x or y axises");
+    }
+
+    if (m_image) {
+        int imageDim = m_image->dims().size();
+        qDebug() << "++++++++ the dimension of image:" << imageDim;
+
+        SliceND frameSlice = SliceND().next();
+
+        for (int i = 0; i < imageDim; i++) {
+            if (i != m_axisIndexX && i != m_axisIndexY) {
+
+                // get the number of slice (e.q. channel) in this dimension
+                int sliceSize = m_image -> dims()[i];
+
+                // make slice cuts for the raw data
+                SliceND & slice = frameSlice.next();
+
+                // If it is the spectral axis
+                if (i == spectralIndex) {
+                   if (0 <= frameStart && frameStart < sliceSize &&
+                       0 <= frameEnd && frameEnd < sliceSize){
+                       slice.start(frameStart);
+                       slice.end(frameEnd + 1);
+                   } else {
+                       slice.start(0);
+                       slice.end(sliceSize);
+                   }
+
+                // If it is the stoke axis
+                } else if (i == stokeIndex) {
+                    if (stokeSliceIndex >= 0 && stokeSliceIndex <= 3) {
+                        qDebug() << "++++++++ we only consider the stoke" << stokeSliceIndex <<
+                                    "(-1: no stoke, 0: stoke I, 1: stoke Q, 2: stoke U, 3: stoke V) for percentile calculation" ;
+                        slice.start(stokeSliceIndex);
+                        slice.end(stokeSliceIndex + 1);
+                    } else {
+                        slice.start(0);
+                        slice.end(sliceSize);
+                    }
+
+                // For the other axises
+                } else {
+                    slice.start(0);
+                    slice.end(sliceSize);
+                }
+
+                slice.step(1);
+            }
+        }
+        rawData = m_image->getDataSlice(frameSlice);
+    }
+    return rawData;
+}
+
+std::vector<double> getHertzValues(std::shared_ptr<Carta::Lib::Image::ImageInterface> m_image,
+                                   std::vector<int> dims, int spectralIndex) {
+    std::vector<double> hertzValues;
+
+    if (spectralIndex >= 0) { // multiple frames
+        std::vector<double> Xvalues;
+
+        for (int i = 0; i < dims[spectralIndex]; i++) {
+            Xvalues.push_back((double)i);
+        }
+
+        // convert frame indices to Hz
+        auto result = Globals::instance() -> pluginManager() -> prepare<Carta::Lib::Hooks::ConversionSpectralHook>(m_image, "", "Hz", Xvalues );
+
+        auto lam = [&hertzValues] (const Carta::Lib::Hooks::ConversionSpectralHook::ResultType &data) {
+            hertzValues = data;
+        };
+
+        result.forEach(lam);
+
+    } else {
+        qWarning() << "Could not calculate Hertz values. This image has no spectral axis.";
+    }
+
+    return hertzValues;
+}
+
+void testMinMax(std::shared_ptr<Carta::Lib::Image::ImageInterface> astroImage) {
+    // set stoke index for getting the raw data (0: stoke I, 1: stoke Q, 2: stoke U, 3: stoke V)
+    int stokeIndex = 0;
+
+    // get raw data as the double type
+    Carta::Lib::NdArray::RawViewInterface* rawData = getRawData(astroImage, -1, -1, stokeIndex);
+    std::shared_ptr<Carta::Lib::NdArray::RawViewInterface> view(rawData);
+    Carta::Lib::NdArray::Double doubleView(view.get(), false);
+
+    //get the index of spectral axis
+    int spectralIndex = getAxisIndex(astroImage, AxisInfo::KnownType::SPECTRAL);
+
+    // TODO: set a unit converter for tests
+    // TODO: let the user specify this in parameters;then it becomes the user's responsibility to make it match the file
+    // TODO: pass it in from outside
+    // TODO: one for all files? one per file?
+    //Carta::Lib::IntensityUnitConverter::SharedPtr converter(ConverterIntensity::converters(from_units, to_units, max_value, max_units, BEAM_AREA));
+    Carta::Lib::IntensityUnitConverter::SharedPtr converter=nullptr;
+
+    // get Hertz values
+    std::vector<double> hertzValues = {};
+    if (converter && converter->frameDependent) {
+        hertzValues = getHertzValues(astroImage, doubleView.dims(), spectralIndex);
+    }
+
+    // calculate Min and Max percentiles: new way
+    Carta::Lib::IPercentilesToPixels<double>::SharedPtr minMaxCalc = std::make_shared<Carta::Core::Algorithms::MinMaxPercentiles<double> >();
+    std::map<double, double> clips_MinMax1 = minMaxCalc->percentile2pixels(doubleView, {0, 1}, spectralIndex, converter, hertzValues);
+    double intensity_min_new = clips_MinMax1[0];
+    double intensity_max_new = clips_MinMax1[1];
+
+    // calculate Min and Max percentiles: original way
+    Carta::Lib::IPercentilesToPixels<double>::SharedPtr exactCalc = std::make_shared<Carta::Core::Algorithms::PercentilesToPixels<double> >();
+    std::map<double, double> clips_MinMax2 = exactCalc->percentile2pixels(doubleView, {0, 1}, spectralIndex, converter, hertzValues);
+    double intensity_min_original = clips_MinMax2[0];
+    double intensity_max_original = clips_MinMax2[1];
+
+    // check the difference of Min/Max intensity with new and original algorithms
+    double delta_min = fabs(intensity_min_new-intensity_min_original);
+    double delta_max = fabs(intensity_max_new-intensity_max_original);
+    if (delta_min < 1.0e-9 && delta_max < 1.0e-9) {
+        qCritical() << "[PASS] for Min/Max intensity =" << intensity_min_new << "/" << intensity_max_new;
+    } else {
+        qCritical() << "[FAIL !!] for Min/Max intensity =" << intensity_min_new << "/" << intensity_max_new << "(new way)"
+                    << "!=" << intensity_min_original << "/" << intensity_max_original << "(original way)";
+    }
+}
+
+void testPercentileHistogram(std::shared_ptr<Carta::Lib::Image::ImageInterface> astroImage, Carta::Lib::IPercentilesToPixels<double>::SharedPtr calculator, int numberOfBins) {
+    // set stoke index for getting the raw data (0: stoke I, 1: stoke Q, 2: stoke U, 3: stoke V)
+    int stokeIndex = 0;
+
+    // get raw data as the double type
+    Carta::Lib::NdArray::RawViewInterface* rawData = getRawData(astroImage, -1, -1, stokeIndex);
+    std::shared_ptr<Carta::Lib::NdArray::RawViewInterface> view(rawData);
+    Carta::Lib::NdArray::Double doubleView(view.get(), false);
+
+    //get the index of spectral axis
+    int spectralIndex = getAxisIndex(astroImage, AxisInfo::KnownType::SPECTRAL);
+
+    // TODO: set a unit converter for tests
+    // TODO: let the user specify this in parameters;then it becomes the user's responsibility to make it match the file
+    // TODO: pass it in from outside
+    // TODO: one for all files? one per file?
+    //Carta::Lib::IntensityUnitConverter::SharedPtr converter(ConverterIntensity::converters(from_units, to_units, max_value, max_units, BEAM_AREA));
+    Carta::Lib::IntensityUnitConverter::SharedPtr converter=nullptr;
+
+    // get Hertz values
+    std::vector<double> hertzValues={};
+    if (converter && converter->frameDependent) {
+        hertzValues = getHertzValues(astroImage, doubleView.dims(), spectralIndex);
+    }
+
+    // calculate Min and Max percentiles: new way
+    Carta::Lib::IPercentilesToPixels<double>::SharedPtr minMaxCalc = std::make_shared<Carta::Core::Algorithms::MinMaxPercentiles<double> >();
+    std::map<double, double> clips_MinMax1 = minMaxCalc->percentile2pixels(doubleView, {0, 1}, spectralIndex, converter, hertzValues);
+
+    // calculate the intensity range
+    double intensity_range = fabs(clips_MinMax1[1] - clips_MinMax1[0]);
+
+    // calculate precise percentiles to intensities
+    Carta::Lib::IPercentilesToPixels<double>::SharedPtr exactCalc = std::make_shared<Carta::Core::Algorithms::PercentilesToPixels<double> >();
+    std::map<double, double> clips_map1 = exactCalc->percentile2pixels(doubleView, percentile, spectralIndex, converter, hertzValues);
+
+    calculator->setMinMax({clips_MinMax1[0], clips_MinMax1[1]});
+    // override number of bins
+    QJsonObject config;
+    config["numberOfBins"] = numberOfBins;
+    calculator->reconfigure(config);
+
+    std::map<double, double> clips_map2 = calculator->percentile2pixels(doubleView, percentile, spectralIndex, converter, hertzValues);
+
+    // expected intensity error
+    double expected_error = 100/(double)numberOfBins; // represented as %
+
+    // check the difference of percentile to intensity with new and original algorithms
+    int percentile_number = percentile.size();
+    qCritical() << "HISTOGRAM APPROXIMATION";
+    qCritical() << "--------------------------------------------------------------------------------";
+    qCritical() << "For bin numbers:" << numberOfBins;
+    for (int i = 0; i < percentile_number; i++) {
+        double intensity_precise = clips_map1[percentile[i]];
+        double intensity_approximation = clips_map2[percentile[i]];
+        double error = 100*fabs(intensity_approximation - intensity_precise)/intensity_range; // represented as %
+        if (error <= expected_error) {
+            qCritical() << "[PASS] for percentile" << 100*percentile[i] << "(%), intensity error =" << error << "<=" << expected_error << "(%)";
+        } else {
+            qCritical() << "[FAIL !!] for percentile" << 100*percentile[i] << "(%), intensity error =" << error << ">" << expected_error << "(%)";
+        }
+    }
+
+}
+
+std::vector<double> extractRawData(std::shared_ptr<Carta::Lib::Image::ImageInterface> astroImage) {
+    // set stoke index for getting the raw data (0: stoke I, 1: stoke Q, 2: stoke U, 3: stoke V)
+    int stokeIndex = 0;
+
+    // get raw data as the double type
+    Carta::Lib::NdArray::RawViewInterface* rawData = getRawData(astroImage, 0, 1, stokeIndex);
+    std::shared_ptr<Carta::Lib::NdArray::RawViewInterface> view(rawData);
+    Carta::Lib::NdArray::Double doubleView(view.get(), false);
+
+    //get the index of spectral axis
+    int spectralIndex = getAxisIndex(astroImage, AxisInfo::KnownType::SPECTRAL);
+
+    // TODO: set a unit converter for tests
+    // TODO: let the user specify this in parameters;then it becomes the user's responsibility to make it match the file
+    // TODO: pass it in from outside
+    // TODO: one for all files? one per file?
+    // unit converter
+    Carta::Lib::IntensityUnitConverter::SharedPtr converter = nullptr;
+
+    // get Hertz values
+    std::vector<double> hertzValues={};
+    if (converter && converter->frameDependent) {
+        hertzValues = getHertzValues(astroImage, doubleView.dims(), spectralIndex);
+    }
+
+    // read in all values from the view into memory so that we can do quickselect on it
+    std::vector<double> allValues;
+    double hertzVal;
+
+    if (converter && converter->frameDependent) {
+        // we need to apply the frame-dependent conversion to each intensity value before copying it
+        // to avoid calculating the frame index repeatedly we use slices to iterate over the image one frame at a time
+        for (size_t f = 0; f < hertzValues.size(); f++) {
+            hertzVal = hertzValues[f];
+
+            Carta::Lib::NdArray::Double viewSlice = Carta::Lib::viewSliceForFrame(doubleView, spectralIndex, f);
+
+            // iterate over the frame
+            viewSlice.forEach([&allValues, &converter, &hertzVal](const double & val) {
+                if (std::isfinite(val)) {
+                    allValues.push_back(converter->_frameDependentConvert(val, hertzVal));
+                } else {
+                    allValues.push_back(-1);
+                }
+            });
+        }
+    } else {
+        // we don't have to do any conversions in the loop
+        // and we can loop over the flat image
+        doubleView.forEach([& allValues] (const double & val) {
+            if (std::isfinite(val)) {
+                allValues.push_back(val);
+            } else {
+                allValues.push_back(-1);
+            }
+        });
+    }
+
+    cout << "raw data size: " << allValues.size() << endl;
+    //for (int i = 0; i < allValues.size(); i++) {
+    //    cout << allValues[i] << " ";
+    //}
+    //cout << endl;
+
+    return allValues;
+
+} // end of extractRawData()
+
+void testPercentileManku99(std::shared_ptr<Carta::Lib::Image::ImageInterface> astroImage, Carta::Lib::IPercentilesToPixels<double>::SharedPtr calculator, int numBuffers, int bufferCapacity, int sampleAfter) {
+    // set stoke index for getting the raw data (0: stoke I, 1: stoke Q, 2: stoke U, 3: stoke V)
+    int stokeIndex = 0;
+
+    // get raw data as the double type
+    Carta::Lib::NdArray::RawViewInterface* rawData = getRawData(astroImage, -1, -1, stokeIndex);
+    std::shared_ptr<Carta::Lib::NdArray::RawViewInterface> view(rawData);
+    Carta::Lib::NdArray::Double doubleView(view.get(), false);
+
+    //get the index of spectral axis
+    int spectralIndex = getAxisIndex(astroImage, AxisInfo::KnownType::SPECTRAL);
+
+    // TODO: set a unit converter for tests
+    // TODO: let the user specify this in parameters;then it becomes the user's responsibility to make it match the file
+    // TODO: pass it in from outside
+    // TODO: one for all files? one per file?
+    //Carta::Lib::IntensityUnitConverter::SharedPtr converter(ConverterIntensity::converters(from_units, to_units, max_value, max_units, BEAM_AREA));
+    Carta::Lib::IntensityUnitConverter::SharedPtr converter=nullptr;
+
+    // get Hertz values
+    std::vector<double> hertzValues={};
+    if (converter && converter->frameDependent) {
+        hertzValues = getHertzValues(astroImage, doubleView.dims(), spectralIndex);
+    }
+
+    // calculate Min and Max percentiles: new way
+    Carta::Lib::IPercentilesToPixels<double>::SharedPtr minMaxCalc = std::make_shared<Carta::Core::Algorithms::MinMaxPercentiles<double> >();
+    std::map<double, double> clips_MinMax1 = minMaxCalc->percentile2pixels(doubleView, {0, 1}, spectralIndex, converter, hertzValues);
+
+    // calculate the intensity range
+    double intensity_range = fabs(clips_MinMax1[1] - clips_MinMax1[0]);
+
+    // calculate precise percentiles to intensities
+    Carta::Lib::IPercentilesToPixels<double>::SharedPtr exactCalc = std::make_shared<Carta::Core::Algorithms::PercentilesToPixels<double> >();
+    std::map<double, double> clips_map1 = exactCalc->percentile2pixels(doubleView, percentile, spectralIndex, converter, hertzValues);
+
+    // override parameters
+    QJsonObject config;
+    config["numBuffers"] = numBuffers;
+    config["bufferCapacity"] = bufferCapacity;
+    config["sampleAfter"] = sampleAfter;
+    calculator->reconfigure(config);
+
+    std::map<double, double> clips_map2 = calculator->percentile2pixels(doubleView, percentile, spectralIndex, converter, hertzValues);
+
+    // expected intensity error
+//     double expected_error = ???; // represented as %
+
+    // check the difference of percentile to intensity with new and original algorithms
+    qCritical() << "MANKU 99 APPROXIMATION";
+    qCritical() << "--------------------------------------------------------------------------------";
+    qCritical() << "Parameters: buffers" << numBuffers << "buffer capacity" << bufferCapacity << "sample after" << sampleAfter;
+
+    for (auto& p : percentile) {
+        double intensity_precise = clips_map1[p];
+        double intensity_approximation = clips_map2[p];
+        double error = 100*fabs(intensity_approximation - intensity_precise)/intensity_range; // represented as %
+        qCritical() << "For percentile" << 100*p << "(%), intensity error =" << error << "(%)";
+    }
+
+}

--- a/carta/cpp/testProtoBuf/CartaHelper.h
+++ b/carta/cpp/testProtoBuf/CartaHelper.h
@@ -1,0 +1,24 @@
+#ifndef CartaHelper_h
+#define CartaHelper_h
+
+int getAxisIndex(std::shared_ptr<Carta::Lib::Image::ImageInterface> m_image,
+                 Carta::Lib::AxisInfo::KnownType axisType);
+
+Carta::Lib::NdArray::RawViewInterface* getRawData(std::shared_ptr<Carta::Lib::Image::ImageInterface> m_image,
+                                                  int frameStart, int frameEnd, int stokeSliceIndex);
+
+std::vector<double> getHertzValues(std::shared_ptr<Carta::Lib::Image::ImageInterface> m_image,
+                                   std::vector<int> dims, int spectralIndex);
+
+void testMinMax(std::shared_ptr<Carta::Lib::Image::ImageInterface> astroImage);
+
+void testPercentileHistogram(std::shared_ptr<Carta::Lib::Image::ImageInterface> astroImage,
+                             Carta::Lib::IPercentilesToPixels<double>::SharedPtr calculator, int numberOfBins);
+
+void testPercentileManku99(std::shared_ptr<Carta::Lib::Image::ImageInterface> astroImage,
+                           Carta::Lib::IPercentilesToPixels<double>::SharedPtr calculator,
+                           int numBuffers, int bufferCapacity, int sampleAfter);
+
+std::vector<double> extractRawData(std::shared_ptr<Carta::Lib::Image::ImageInterface> astroImage);
+
+#endif

--- a/carta/cpp/testProtoBuf/ProtoBufHelper.cpp
+++ b/carta/cpp/testProtoBuf/ProtoBufHelper.cpp
@@ -1,0 +1,55 @@
+#include <ctime>
+#include <google/protobuf/util/time_util.h>
+#include <iostream>
+#include <string>
+
+#include "databook.pb.h"
+
+using namespace std;
+
+// This function fills in a RasterImage message based on user input.
+void PromptForRasterImageData(CartaMessage::RasterImage* RasterImage, const std::vector<double> rawdata) {
+    int file_id = 0;
+    RasterImage->set_file_id(file_id);
+
+    int layer_id = 0;
+    RasterImage->set_layer_id(layer_id);
+
+    int image_bound_x = 0;
+    RasterImage->set_image_bound_x(image_bound_x);
+
+    int image_bound_y = 0;
+    RasterImage->set_image_bound_y(image_bound_y);
+
+    int stoke = 0;
+    RasterImage->set_stoke(stoke);
+
+    int channel = 0;
+    RasterImage->set_channel(channel);
+
+    for (int i = 0; i < rawdata.size(); i++) {
+        RasterImage->add_pixel_data(rawdata[i]);
+    }
+}
+
+// Iterates though all raster_image in the databook and prints info about them.
+void ListData(const CartaMessage::DataBook& DataBook) {
+    // list raster image data
+    for (int i = 0; i < DataBook.raster_image_size(); i++) {
+        const CartaMessage::RasterImage& RasterImage = DataBook.raster_image(i);
+
+        cout << "file_id: " << RasterImage.file_id() << endl;
+        cout << "layer_id: " << RasterImage.layer_id() << endl;
+        cout << "image_bound_x: " << RasterImage.image_bound_x() << endl;
+        cout << "image_bound_y: " << RasterImage.image_bound_y() << endl;
+        cout << "stoke: " << RasterImage.stoke() << endl;
+        cout << "channel: " << RasterImage.channel() << endl;
+        cout << "pixel_data size: " << RasterImage.pixel_data_size() << endl;
+
+        //for (int i = 0; i < RasterImage.pixel_data_size(); i++) {
+        //  double tmp = RasterImage.pixel_data(i);
+        //  cout << "pixel_data[" << i << "] = "<< tmp << endl;
+        //}
+    }
+}
+

--- a/carta/cpp/testProtoBuf/ProtoBufHelper.h
+++ b/carta/cpp/testProtoBuf/ProtoBufHelper.h
@@ -1,0 +1,8 @@
+#ifndef ProtoBuffHelper_h
+#define ProtoBuffHelper_h
+
+void PromptForRasterImageData(CartaMessage::RasterImage* RasterImage, const std::vector<double> data);
+
+void ListData(const CartaMessage::DataBook& DataBook);
+
+#endif

--- a/carta/cpp/testProtoBuf/databook.proto
+++ b/carta/cpp/testProtoBuf/databook.proto
@@ -1,0 +1,31 @@
+// See README.txt for information and build instructions.
+//
+// Note: START and END tags are used in comments to define sections used in
+// tutorials.  They are not part of the syntax for Protocol Buffers.
+//
+// To get an in-depth walkthrough of this file and the related examples, see:
+// https://developers.google.com/protocol-buffers/docs/tutorials
+
+// [START declaration]
+syntax = "proto3";
+package CartaMessage;
+
+//import "google/protobuf/timestamp.proto";
+// [END declaration]
+
+// [START messages]
+message RasterImage {
+  int32 file_id = 1;
+  int32 layer_id = 2;
+  int32 image_bound_x = 3;
+  int32 image_bound_y = 4;
+  int32 stoke = 5;
+  int32 channel = 6;
+  repeated double pixel_data = 7 [packed=true];
+}
+
+// Our address book file is just one of these.
+message DataBook {
+  repeated RasterImage raster_image = 1;
+}
+// [END messages]

--- a/carta/cpp/testProtoBuf/example.sh
+++ b/carta/cpp/testProtoBuf/example.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# for Mac exec:
+./testProtoBuf.app/Contents/MacOS/testProtoBuf ../../../carta/scriptedClient/tests/data/aH.fits
+
+# for Linux exec:
+# ./testProtoBuf ../../../carta/scriptedClient/tests/data/aH.fits
+

--- a/carta/cpp/testProtoBuf/main.cpp
+++ b/carta/cpp/testProtoBuf/main.cpp
@@ -1,0 +1,163 @@
+/*
+ * This is the test for percentile algorithms and protocol buffer
+ *
+ * Usage: $./testProtoBuf [the path and name of the image file]
+ *
+ * for example: $./testProtoBuf.app/Contents/MacOS/testProtoBuf ../../../carta/scriptedClient/tests/data/aH.fits
+ *
+ */
+#include "core/MyQApp.h"
+#include "core/CmdLine.h"
+#include "core/MainConfig.h"
+#include "core/Globals.h"
+#include "CartaLib/Hooks/LoadAstroImage.h"
+#include "CartaLib/Hooks/Initialize.h"
+#include "CartaLib/Hooks/PercentileToPixelHook.h"
+#include <QDebug>
+#include <cmath>
+#include <QJsonObject>
+
+#include <ctime>
+#include <fstream>
+#include <google/protobuf/util/time_util.h>
+#include <iostream>
+#include <string>
+
+#include "databook.pb.h"
+
+#include "ProtoBufHelper.h"
+#include "CartaHelper.h"
+
+using namespace std;
+
+namespace testProtoBuff {
+
+typedef Carta::Lib::AxisInfo AxisInfo;
+
+static int coreMainCPP(QString platformString, int argc, char* argv[]) {
+    MyQApp qapp(argc, argv);
+
+    QString appName = "carta-" + platformString;
+    appName += "-verbose";
+
+    if (CARTA_RUNTIME_CHECKS) {
+        appName += "-runtimeChecks";
+    }
+
+    MyQApp::setApplicationName(appName);
+    qDebug() << "Starting" << qapp.applicationName() << qapp.applicationVersion();
+
+    // alias globals
+    auto & globals = * Globals::instance();
+
+    // parse command line arguments & environment variables
+    auto cmdLineInfo = CmdLine::parse(MyQApp::arguments());
+    globals.setCmdLineInfo(& cmdLineInfo);
+
+    int file_num = cmdLineInfo.fileList().size();
+    if (file_num < 1) {
+        qFatal("Usage: ./testestProtoBuff [the path and name of the image file] ...");
+    }
+
+    // load the config file
+    QString configFilePath = cmdLineInfo.configFilePath();
+    MainConfig::ParsedInfo mainConfig = MainConfig::parse(configFilePath);
+    globals.setMainConfig(& mainConfig);
+    qDebug() << "plugin directories:\n - " + mainConfig.pluginDirectories().join( "\n - " );
+
+    // initialize plugin manager
+    globals.setPluginManager(std::make_shared<PluginManager>());
+    auto pm = globals.pluginManager();
+
+    // tell plugin manager where to find plugins
+    pm -> setPluginSearchPaths(globals.mainConfig()->pluginDirectories());
+
+    // find and load plugins
+    pm -> loadPlugins();
+
+    qDebug() << "Loading plugins...";
+    auto infoList = pm -> getInfoList();
+
+    qDebug() << "List of loaded plugins: [" << infoList.size() << "]";
+    for (const auto & entry : infoList) {
+        qDebug() << "  path:" << entry.json.name;
+    }
+    
+    // tell all plugins that the core has initialized
+    pm -> prepare<Carta::Lib::Hooks::Initialize>().executeAll();
+    
+    auto imgRes = pm -> prepare<Carta::Lib::Hooks::LoadAstroImage>(cmdLineInfo.fileList()[0]).first();
+
+    if (imgRes.isNull()) {
+        throw "Could not find any plugin to load astroImage";
+    }
+
+    std::shared_ptr<Carta::Lib::Image::ImageInterface> astroImage = imgRes.val();
+
+    if (!astroImage) {
+        throw "Image read was a nullptr";
+    }
+
+    // extract the raw data
+    std::vector<double> rawdata = extractRawData(astroImage);
+
+    // Verify that the version of the library that we linked against is
+    // compatible with the version of the headers we compiled against.
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+    CartaMessage::DataBook DataBook;
+
+    char const *test = "DataBook.dat";
+    /*{
+      // Read the existing databook.
+      fstream input(test, ios::in | ios::binary);
+      if (!input) {
+        cout << test << ": File not found.  Creating a new file." << endl;
+      } else if (!DataBook.ParseFromIstream(&input)) {
+        cerr << "Failed to parse databook." << endl;
+        return -1;
+      }
+    }*/
+
+    // Add an databook.
+    PromptForRasterImageData(DataBook.add_raster_image(), rawdata);
+
+    {
+      // Write the new databook book back to disk.
+      fstream output(test, ios::out | ios::trunc | ios::binary);
+      if (!DataBook.SerializeToOstream(&output)) {
+        cerr << "Failed to write databook book." << endl;
+        return -1;
+      }
+    }
+
+    // list the DataBook
+    ListData(DataBook);
+
+    // Optional:  Delete all global objects allocated by libprotobuf.
+    google::protobuf::ShutdownProtobufLibrary();
+
+    return 0;
+} // coreMainCPP
+
+} // namespace testProtoBuff
+
+int main(int argc, char* argv[]) {
+    try {
+        return testProtoBuff::coreMainCPP( "testProtoBuff", argc, argv );
+    }
+    catch ( const char * err ) {
+        qCritical() << "Exception(char*):" << err;
+    }
+    catch ( const std::string & err ) {
+        qCritical() << "Exception(std::string &):" << err.c_str();
+    }
+    catch ( const QString & err ) {
+        qCritical() << "Exception(QString &):" << err;
+    }
+    catch ( ... ) {
+        qCritical() << "Exception(unknown type)!";
+    }
+    qFatal( "%s", "...caught in main()" );
+    return - 1;
+} // main

--- a/carta/cpp/testProtoBuf/testProtoBuf.pro
+++ b/carta/cpp/testProtoBuf/testProtoBuf.pro
@@ -1,0 +1,74 @@
+! include(../common.pri) {
+  error( "Could not find the common.pri file!" )
+}
+
+QT      += network widgets xml
+
+HEADERS += \
+    ProtoBufHelper.h \
+    CartaHelper.h
+
+SOURCES += \
+    ProtoBufHelper.cpp \
+    CartaHelper.cpp \
+    main.cpp
+
+RESOURCES =
+
+unix: LIBS += -L$$OUT_PWD/../core/ -lcore
+unix: LIBS += -L$$OUT_PWD/../CartaLib/ -lCartaLib
+
+DEPENDPATH += $$PROJECT_ROOT/core
+DEPENDPATH += $$PROJECT_ROOT/CartaLib
+
+QMAKE_LFLAGS += '-Wl,-rpath,\'\$$ORIGIN/../CartaLib:\$$ORIGIN/../core\''
+
+QWT_ROOT = $$absolute_path("../../../ThirdParty/qwt")
+
+# Copies the given files to the destination directory
+defineTest(copyToDestdir) {
+    files = $$PWD/$$1
+
+    for(FILE, files) {
+        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$FILE) $$quote($$OUT_PWD)
+    }
+
+    message("pwd= $$PWD")
+
+    export(QMAKE_POST_LINK)
+}
+
+copyToDestdir(example.sh)
+
+## make protocol buffer codes .pb.h and .pb.cc
+PROTOS = databook.proto
+protobuf_decl.name = protobuf headers
+protobuf_decl.input = PROTOS
+protobuf_decl.output = ${QMAKE_FILE_IN_PATH}/${QMAKE_FILE_BASE}.pb.h
+protobuf_decl.commands = $${PROTOBUFDIR}/bin/protoc --cpp_out=${QMAKE_FILE_IN_PATH} --proto_path=${QMAKE_FILE_IN_PATH} ${QMAKE_FILE_NAME}
+protobuf_decl.variable_out = HEADERS
+QMAKE_EXTRA_COMPILERS += protobuf_decl
+
+protobuf_impl.name = protobuf sources
+protobuf_impl.input = PROTOS
+protobuf_impl.output = ${QMAKE_FILE_IN_PATH}/${QMAKE_FILE_BASE}.pb.cc
+protobuf_impl.depends = ${QMAKE_FILE_IN_PATH}/${QMAKE_FILE_BASE}.pb.h
+protobuf_impl.commands = $$escape_expand(\n)
+protobuf_impl.variable_out = SOURCES
+QMAKE_EXTRA_COMPILERS += protobuf_impl
+
+## link protocol buffer package headers and lib
+INCLUDEPATH += $${PROTOBUFDIR}/include
+LIBS +=-L$${PROTOBUFDIR}/lib -lprotobuf
+
+unix:macx {
+    QMAKE_LFLAGS += '-F$$QWT_ROOT/lib'
+    LIBS +=-framework qwt
+    PRE_TARGETDEPS += $$OUT_PWD/../core/libcore.dylib
+}
+else{
+    QMAKE_LFLAGS += '-Wl,-rpath,\'$$QWT_ROOT/lib\''
+    LIBS +=-L$$QWT_ROOT/lib -lqwt
+    PRE_TARGETDEPS += $$OUT_PWD/../core/libcore.so
+    QMAKE_RPATHDIR=$$OUT_PWD/../../../../CARTAvis-externals/ThirdParty/casa/trunk/linux/lib
+}

--- a/carta/scripts/copy_dylib_for_Mac_CARTA.sh
+++ b/carta/scripts/copy_dylib_for_Mac_CARTA.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+####################
+# copy dylib files #
+####################
+
+export CARTAWORKHOME=`cd ../../../ && pwd`
+echo $CARTAWORKHOME
+
+cd $CARTAWORKHOME/CARTAvis
+export CARTABUILDHOME=`pwd`
+
+CARTAAPP=build/cpp/desktop/CARTA.app
+echo $CARTAAPP
+
+mkdir -p $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/
+
+cp $CARTABUILDHOME/build/cpp/core/libcore.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/
+#rm $CARTABUILDHOME/build/cpp/core/libcore.1.dylib
+
+cp $CARTABUILDHOME/build/cpp/CartaLib/libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/
+#rm $CARTABUILDHOME/build/cpp/CartaLib/libCartaLib.1.dylib
+
+# need to rm for qt creator 4.2, otherwise when build+run together will result in core/libcore.1.dylib not able find out qwt
+
+install_name_tool -change qwt.framework/Versions/6/qwt  $CARTABUILDHOME/ThirdParty/qwt-6.1.2/lib/qwt.framework/Versions/6/qwt  $CARTABUILDHOME/$CARTAAPP/Contents/MacOS/CARTA
+install_name_tool -change qwt.framework/Versions/6/qwt  $CARTABUILDHOME/ThirdParty/qwt-6.1.2/lib/qwt.framework/Versions/6/qwt  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libcore.1.dylib
+
+# not sure the effect of the below line, try comment
+
+# install_name_tool -change libplugin.dylib    $CARTABUILDHOME/build/cpp/plugins/CasaImageLoader/libplugin.dylib                    $CARTABUILDHOME/build/cpp/plugins/ImageStatistics/libplugin.dylib
+
+install_name_tool -change libcore.1.dylib      $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libcore.1.dylib      $CARTABUILDHOME/build/cpp/plugins/ImageStatistics/libplugin.dylib
+install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libCartaLib.1.dylib  $CARTABUILDHOME/build/cpp/plugins/ImageStatistics/libplugin.dylib
+
+install_name_tool -change libcore.1.dylib      $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libcore.1.dylib      $CARTABUILDHOME/$CARTAAPP/Contents/MacOS/CARTA
+install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/MacOS/CARTA
+
+install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libcore.1.dylib
+
+for f in `find . -name libplugin.dylib`;  do install_name_tool -change libcore.1.dylib      $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libcore.1.dylib      $f; done
+for f in `find . -name libplugin.dylib`;  do install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libCartaLib.1.dylib  $f; done
+for f in `find . -name "*.dylib"`;        do install_name_tool -change libwcs.5.15.dylib    $CARTABUILDHOME/ThirdParty/wcslib/lib/libwcs.5.15.dylib            $f; echo $f; done

--- a/carta/scripts/copy_dylib_for_Mac_testProtoBuf.sh
+++ b/carta/scripts/copy_dylib_for_Mac_testProtoBuf.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+####################
+# copy dylib files #
+####################
+
+export CARTAWORKHOME=`cd ../../../ && pwd`
+echo $CARTAWORKHOME
+
+cd $CARTAWORKHOME/CARTAvis
+export CARTABUILDHOME=`pwd`
+
+APPNAME=testProtoBuf
+echo $APPNAME
+
+CARTAAPP=build/cpp/$APPNAME/$APPNAME.app
+echo $CARTAAPP
+
+mkdir -p $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/
+
+cp $CARTABUILDHOME/build/cpp/core/libcore.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/
+# rm $CARTABUILDHOME/build/cpp/core/libcore.1.dylib
+
+cp $CARTABUILDHOME/build/cpp/CartaLib/libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/
+# rm $CARTABUILDHOME/build/cpp/CartaLib/libCartaLib.1.dylib
+
+# need to rm for qt creator 4.2, otherwise when build+run together will result in core/libcore.1.dylib not able find out qwt
+
+install_name_tool -change qwt.framework/Versions/6/qwt  $CARTABUILDHOME/ThirdParty/qwt-6.1.2/lib/qwt.framework/Versions/6/qwt  $CARTABUILDHOME/$CARTAAPP/Contents/MacOS/$APPNAME
+install_name_tool -change qwt.framework/Versions/6/qwt  $CARTABUILDHOME/ThirdParty/qwt-6.1.2/lib/qwt.framework/Versions/6/qwt  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libcore.1.dylib
+
+# not sure the effect of the below line, try comment
+
+# install_name_tool -change libplugin.dylib    $CARTABUILDHOME/build/cpp/plugins/CasaImageLoader/libplugin.dylib                    $CARTABUILDHOME/build/cpp/plugins/ImageStatistics/libplugin.dylib
+
+install_name_tool -change libcore.1.dylib      $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libcore.1.dylib      $CARTABUILDHOME/build/cpp/plugins/ImageStatistics/libplugin.dylib
+install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libCartaLib.1.dylib  $CARTABUILDHOME/build/cpp/plugins/ImageStatistics/libplugin.dylib
+
+install_name_tool -change libcore.1.dylib      $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libcore.1.dylib      $CARTABUILDHOME/$CARTAAPP/Contents/MacOS/$APPNAME
+install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/MacOS/$APPNAME
+
+install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libcore.1.dylib
+
+for f in `find . -name libplugin.dylib`;  do install_name_tool -change libcore.1.dylib      $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libcore.1.dylib      $f; done
+for f in `find . -name libplugin.dylib`;  do install_name_tool -change libCartaLib.1.dylib  $CARTABUILDHOME/$CARTAAPP/Contents/Frameworks/libCartaLib.1.dylib  $f; done
+for f in `find . -name "*.dylib"`;        do install_name_tool -change libwcs.5.15.dylib    $CARTABUILDHOME/ThirdParty/wcslib/lib/libwcs.5.15.dylib            $f; echo $f; done

--- a/carta/scripts/install_protobuf.sh
+++ b/carta/scripts/install_protobuf.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+export CARTAWORKHOME=`cd ../../../ && pwd`
+
+echo $CARTAWORKHOME
+
+cd $CARTAWORKHOME/CARTAvis-externals/ThirdParty
+
+FILE="protobuf-all-3.5.1.tar.gz"
+if [ ! -f $FILE ]; then
+    curl -O -L https://github.com/google/protobuf/releases/download/v3.5.1/protobuf-all-3.5.1.tar.gz
+fi
+
+DIR1="protobuf-3.5.1"
+if [ -d $DIR1 ]; then
+    rm -rf $DIR1
+fi
+
+DIR2="protobuf"
+if [ -d $DIR2 ]; then
+    rm -rf $DIR2
+fi
+
+tar xvfz protobuf-all-3.5.1.tar.gz > /dev/null
+
+cd protobuf-3.5.1
+
+./configure --prefix=`pwd`/../protobuf/
+
+make 
+
+make check
+
+make install
+
+# sudo ldconfig # refresh shared library cache.
+
+cd ..
+


### PR DESCRIPTION
This is an example of integrating protocol buffer into the current CARTA. It doesn't need to be merged now. Since it might be another better way to do so.

1. To install protocol buffer, go to the directory `$CARTA_HOME/CARTAvis/carta/scripts/` and execute the script `./install_protobuf.sh`. The protocol lib, headers and bin will be installed under the directory `$CARTA_HOME/CARTAvis-externals/ThirdParty/`.

2. For Mac execution files, we need to copy `dylib` files in order to make it executable. Go to the directory `$CARTA_HOME/carta/scripts/` and execute `./copy_dylib_for_Mac_CARTA.sh` for `CARTA` app, or execute `./copy_dylib_for_Mac_testProtoBuf.sh` for `testProtoBuf` app. 

3. The `testProtoBuf` tester exec is under the directory `$CARTA_HOME/CARTAvis/build/cpp/testProtoBuf`. You can check and run `./example.sh` which loads an image file and encodes the image pixel data into the protocol buffer file `DataBook.dat`.
